### PR TITLE
Makes syndicate toolbox tools 50% faster than normal.

### DIFF
--- a/code/game/objects/items/weapons/storage/toolbox.dm
+++ b/code/game/objects/items/weapons/storage/toolbox.dm
@@ -78,13 +78,21 @@
 
 /obj/item/weapon/storage/toolbox/syndicate/New()
 	..()
-	new /obj/item/weapon/screwdriver(src, "red")
-	new /obj/item/weapon/wrench(src)
-	new /obj/item/weapon/weldingtool/largetank(src)
-	new /obj/item/weapon/crowbar/red(src)
-	new /obj/item/weapon/wirecutters(src, "red")
-	new /obj/item/device/multitool(src)
-	new /obj/item/clothing/gloves/combat(src)
+	var/obj/item/I
+	I = new /obj/item/weapon/screwdriver(src, "red")
+	I.toolspeed = 1.5
+	I = new /obj/item/weapon/wrench(src)
+	I.toolspeed = 1.5
+	I = new /obj/item/weapon/weldingtool/largetank(src)
+	I.toolspeed = 1.5
+	I = new /obj/item/weapon/crowbar/red(src)
+	I.toolspeed = 1.5
+	I = new /obj/item/weapon/wirecutters(src, "red")
+	I.toolspeed = 1.5
+	I = new /obj/item/device/multitool(src)
+	I.toolspeed = 1.5
+	I = new /obj/item/clothing/gloves/combat(src)
+	I.toolspeed = 1.5
 
 /obj/item/weapon/storage/toolbox/drone
 	name = "mechanical toolbox"


### PR DESCRIPTION
This is a significant buff compared to old yogs, but cyborg tools are 100% faster, so it may be merited. Also the number would have to be 1.4285714285714285714285714285714 to match the old speed and that's an ugly number.

Fixes #19 even though I already closed that.
