### PR TITLE
Ports /tg/ performance improvement for mob qdel'etion

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -46,7 +46,7 @@ Sorry Giacom. Please don't be mad :(
 			qdel(I)
 	staticOverlays.len = 0
 	remove_from_all_data_huds()
-	return QDEL_HINT_HARDDEL_NOW
+	return QDEL_HINT_HARDDEL
 
 
 /mob/living/proc/OpenCraftingMenu()


### PR DESCRIPTION
Original PR : https://github.com/tgstation/tgstation/pull/18567
Improves performance of living mob qdel'etion (majority of cases that caused the problem were during singularity/explosions, I'd imagine);

Might as well, it's a one line fix.
