### PR TITLE
Predator Updates

### DIFF
--- a/code/modules/mob/living/carbon/predator/predator.dm
+++ b/code/modules/mob/living/carbon/predator/predator.dm
@@ -9,7 +9,6 @@
 	languages_understood = HUMAN | PREDATOR
 	gender = NEUTER
 	ventcrawler = 0
-	var/datum/action/innate/predator_remove_skull/skull = new
 
 /mob/living/carbon/human/predator/New()
 	..()
@@ -30,7 +29,7 @@
 	equip_to_slot_if_possible(new /obj/item/weapon/twohanded/spear/combistick, slot_r_store)
 	equip_to_slot_if_possible(new /obj/item/clothing/gloves/combat/predator, slot_gloves)
 
-	skull.Grant(src)
+	AddSpell(new /obj/effect/proc_holder/spell/self/remove_skull(null))
 
 /mob/living/carbon/human/predator/Stat()
 	..()
@@ -54,13 +53,11 @@
 /mob/living/carbon/human/predator/say_quote(var/text)
 	return "[verb_say], \"[text]\"";
 
-
-
 /datum/species/predator
 	name = "Predator"
 	id = "pred"
 	say_mod = "clicks"
 	default_color = "59CE00"
 	sexes = 0
-	specflags = list(NOBLOOD,NOBREATH,VIRUSIMMUNE)
+	specflags = list(VIRUSIMMUNE)
 	skinned_type = /obj/item/stack/sheet/animalhide/human

--- a/code/modules/mob/living/carbon/predator/predator_powers.dm
+++ b/code/modules/mob/living/carbon/predator/predator_powers.dm
@@ -2,70 +2,57 @@
 ///		SKULL REMOVAL 		///
 ///////////////////////////////
 
-/datum/action/innate/predator_remove_skull
-	name = "Remove Skull"
-	button_icon_state = "godspeak"
-	check_flags = AB_CHECK_CONSCIOUS
-	var/busy
-
-/datum/action/innate/predator_remove_skull/Activate()
-	if(!ispredator(usr))
-		Remove(usr)
-
-	if(busy)
-		return
-	var/mob/living/carbon/human/predator/P = usr
-	P.remove_skull()
-
-
-/mob/living/carbon/human/predator/verb/remove_skull()
-	set name = "Remove Skull"
-	set desc = "Digs the Predator's fingers into the eye sockets of their target, and attempts to yank out their skull from their head."
-	set category = "Predator"
-
-	for(var/datum/action/innate/predator_remove_skull/dat_skull in src)
-		if(dat_skull.busy)
-			return
-		else
-			dat_skull.busy = 1 // o shit waddup
-
-	if(!ispredator(src))
-		qdel(src)
-		return
-	if(!src.pulling || !iscarbon(src.pulling))
-		src << "<span class='warning'>You must hold the target in a head-lock to remove their skull!</span>"
-		return
-	if(src.grab_state <= GRAB_NECK)
-		src << "<span class='warning'>You have to carry a tighter grip on the target to remove their skull!</span>"
-		return
-
-	var/mob/living/carbon/ptarget = src.pulling
-
-	visible_message("<span class='danger'>[src] has plunged their sharp, dagger-like fingers into [ptarget]'s eyes!</span>", \
-		"<span class='danger'>You plunge your sharp, dagger-like fingers into [ptarget]'s eyes!</span>")
-	if(!iszombie(ptarget))
-		ptarget.visible_message("<span class='danger'>OH GOD!!! THE PAIN!</span>")
-		ptarget.adjust_eye_damage(25)
-		ptarget.blind_eyes(1)
-		ptarget.Weaken(20)
-	if(do_after(src, 200, target = ptarget))
-		ptarget.visible_message("<span class='danger'>[src] furthers his grip around [ptarget]'s skull!</span>",\
-			"<span class='danger'>You can feel fingers wrapping around the inside of your skull!</span>")
-		src << "<span class='danger'>Now it's time to collect your trophy...</span>"
-		ptarget.Weaken(10)
-		if(do_after(src, 50, target = ptarget))
-			if(ptarget.stat != DEAD)
-				ptarget.visible_message("<span class='danger'>In an instant, [src] tears out [ptarget]'s skull along with their spinal cord whipping back and forth above their body now torn open.</span>",\
-					"<span class='danger'>In an instant, after feeling all sorts of tremendous pain you are left with a feeling of numbness as your skull is torn from your head.</span>")
-				ptarget.death()
-			ptarget.adjustBruteLoss(200)
-			ptarget.visible_message("<span class='danger'>[ptarget]'s brain and spinal cord get ripped out of their body along with their skull clutched by [src]!</span>")
-			ptarget.spill_organs()
-			new /obj/item/trophy_skull(get_turf(ptarget))
-
-
 /obj/item/trophy_skull
 	name = "human skull"
 	desc = "No matter the score, I'm always a-head!"
 	icon = 'icons/mob/predators.dmi'
 	icon_state = "skull"
+
+
+/obj/effect/proc_holder/spell/self/remove_skull //This spell exists mainly for debugging purposes, and also to show how casting works
+	name = "Skull Removal"
+	desc = "Rips the skull out of your target's head and claims your trophy."
+	clothes_req = 0
+	charge_max = 15
+	cooldown_min = 10
+	invocation = null
+	invocation_type = "none"
+	school = "evocation"
+	action_icon_state = "alien_transfer"
+
+/obj/effect/proc_holder/spell/self/remove_skull/cast(mob/living/carbon/human/user)
+	if(!ispredator(user))
+		user << "<span class='danger'>You're too weak!</span>"
+		qdel(user)
+		return
+
+	if(!user.pulling || !iscarbon(user.pulling))
+		user << "<span class='warning'>You must hold the target in a head-lock to remove their skull!</span>"
+		return
+	if(user.grab_state <= GRAB_NECK)
+		user << "<span class='warning'>You have to carry a tighter grip on the target to remove their skull!</span>"
+		return
+
+	var/mob/living/carbon/ptarget = user.pulling
+
+	visible_message("<span class='danger'>[user] has plunged their sharp, dagger-like fingers into [ptarget]'s eyes!</span>", \
+		"<span class='danger'>You plunge your sharp, dagger-like fingers into [ptarget]'s eyes!</span>")
+	if(!iszombie(ptarget))
+		ptarget << "<span class='danger'>OH GOD!!! THE PAIN!</span>"
+		ptarget.adjust_eye_damage(50)
+		ptarget.blind_eyes(1)
+		ptarget.Weaken(20)
+	if(do_after(user, 200, target = ptarget))
+		ptarget.visible_message("<span class='danger'>[user] furthers his grip around [ptarget]'s skull!</span>",\
+			"<span class='danger'>You can feel fingers wrapping around the inside of your skull!</span>")
+		user << "<span class='danger'>Now it's time to collect your trophy...</span>"
+		ptarget.Weaken(10)
+		if(do_after(user, 50, target = ptarget))
+			if(ptarget.stat != DEAD)
+				ptarget.visible_message("<span class='danger'>In an instant, [user] tears out [ptarget]'s skull along with their spinal cord whipping back and forth above their body now torn open.</span>",\
+					"<span class='danger'>In an instant, after feeling all sorts of tremendous pain you are left with a feeling of numbness as your skull is torn from your head.</span>")
+				ptarget.death()
+			ptarget.adjustBruteLoss(200)
+			ptarget.visible_message("<span class='danger'>[ptarget]'s brain and spinal cord get ripped out of their body along with their skull clutched by [user]!</span>")
+			ptarget.spill_organs()
+			new /obj/item/trophy_skull(get_turf(ptarget))

--- a/code/modules/mob/living/carbon/predator/predator_powers.dm
+++ b/code/modules/mob/living/carbon/predator/predator_powers.dm
@@ -9,7 +9,7 @@
 	icon_state = "skull"
 
 
-/obj/effect/proc_holder/spell/self/remove_skull //This spell exists mainly for debugging purposes, and also to show how casting works
+/obj/effect/proc_holder/spell/self/remove_skull
 	name = "Skull Removal"
 	desc = "Rips the skull out of your target's head and claims your trophy."
 	clothes_req = 0


### PR DESCRIPTION
In this revision:
- Deletes old comments
- Makes Predators spells not lazy by rewriting them to follow 'procholder/spell' paths
- Rewrites the gloves code so they can be removed now instead of being NODROP and so you don't need to use awkward methods to retract the wristblades
- Fixes a bug with the combatstick
- Reworks the Predators biomask, so toggling it (via action button) will activate thermals + nightvision instead of using a verb.
- Nerfs Predators so they need to breath and have blood. However they'll be kept virus immune.
