### PR TITLE
Ports the Recovery Agent

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -103,6 +103,11 @@
 	desc = "A robust beret for the Head of Security, for looking stylish while not sacrificing protection."
 	icon_state = "hosberetblack"
 
+/obj/item/clothing/head/HoS/beret/recovery
+	name = "recovery beret"
+	desc = "A pretty robust beret for Recovery Agents. Given that it's in pretty old fashion, and envy's paramedics."
+	icon_state = "wardenberet"
+
 /obj/item/clothing/head/warden
 	name = "warden's police hat"
 	desc = "It's a special armored hat issued to the Warden of a security force. Protects the head from impacts."

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -384,6 +384,71 @@
 	mask = /obj/item/clothing/mask/breath
 	suit_store = /obj/item/weapon/tank/internals/oxygen
 
+/datum/outfit/recovery_agent // THROWBACK TO .... 2014?
+	name = "Recovery Agent"
+	uniform = /obj/item/clothing/under/suit_jacket
+	glasses = /obj/item/clothing/glasses/sunglasses
+	shoes = /obj/item/clothing/shoes/combat
+	gloves = /obj/item/clothing/gloves/color/black
+	head = /obj/item/clothing/head/HoS/beret/recovery
+	back = /obj/item/weapon/storage/backpack/satchel_sec
+	ears = /obj/item/device/radio/headset/headset_med
+	belt = /obj/item/weapon/storage/belt/utility/full
+	id = /obj/item/weapon/card/id
+	l_pocket = /obj/item/device/sensor_device
+	r_pocket = /obj/item/device/flashlight/flare
+
+	backpack_contents = list(/obj/item/weapon/storage/box/survival=1,\
+		/obj/item/weapon/gun/energy/gun=1,\
+		/obj/item/weapon/storage/box/bodybags=1)
+
+/datum/outfit/recovery_agent/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return
+
+	var/obj/item/weapon/implant/mindshield/L = new/obj/item/weapon/implant/mindshield(H)
+	L.imp_in = H
+	L.implanted = 1
+	H.sec_hud_set_implants()
+
+	var/obj/item/weapon/card/id/W = H.wear_id
+	W.assignment = "Recovery Agent"
+	W.registered_name = H.real_name
+	W.update_label()
 
 
+	H << "<span class='alert'>You are NOT security. You are NOT a head of department. You will NOT challenge a head of department and nor will you meddle in securities affairs. You have a gun ONLY to defend your valuable all-access ID. If you see criminals, you MAY stun them, and take the body they are holding. Nothing more. You MAY report their location, Nothing more. You are NOT security. Your job is to recover bodies to the morgue to ensure more players get to play a fair game. ( for more information https://wiki.yogstation.net/index.php?title=Recovery_Agent_manual )</span>"
 
+
+/datum/outfit/recovery_throwback // for adminbuse.
+	name = "Recovery Agent Throwback"
+	shoes = /obj/item/clothing/shoes/combat/swat
+	glasses = /obj/item/clothing/glasses/sunglasses
+	head = /obj/item/clothing/head/helmet/space/beret
+	uniform = /obj/item/clothing/under/acj
+	suit = /obj/item/clothing/suit/space/officer
+	ears = /obj/item/device/radio/headset/headset_cent
+	gloves = /obj/item/clothing/gloves/combat
+	belt = /obj/item/weapon/storage/belt/utility/full
+	r_pocket = /obj/item/weapon/restraints/handcuffs
+	l_pocket = /obj/item/device/flashlight/flare
+	back = /obj/item/weapon/storage/backpack/holding
+	id = /obj/item/weapon/card/id
+
+	backpack_contents = list(/obj/item/weapon/storage/box/survival=1,\
+		/obj/item/weapon/gun/energy/gun/hos=1,\
+		/obj/item/weapon/shield/riot/tele=1)
+
+/datum/outfit/recovery_throwback/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return
+
+	var/obj/item/weapon/card/id/W = H.wear_id
+	W.assignment = "Recovery Agent"
+	W.registered_name = "[H.real_name] Throwback"
+	W.update_label()
+
+	var/obj/item/weapon/implant/mindshield/L = new/obj/item/weapon/implant/mindshield(H)
+	L.imp_in = H
+	L.implanted = 1
+	H.sec_hud_set_implants()


### PR DESCRIPTION
Q&A:

Q. What's a Recovery Agent?
A. It's a really old job that was replaced by paramedics. Their goal was literally to secure corpses, drag them to medbay, and help them get cloned.

Q. Why do we need this?
A. We don't need this really, but it was apart of Yog long ago. I don't feel like we should completely forget things, and at the same time I don't feel we shouldn't bring them directly into the game. However, if an admin wants to make them self look like a recovery agent for old times sake or maybe make someone a recovery agent during a chaotic round, sending them in, why shouldn't they?

This PR contains
- An outfit datum for simple recovery agent
- An outfit datum for a suggested special recovery agent (adminbuse)

https://wiki.yogstation.net/index.php?title=Recovery_Agent
https://wiki.yogstation.net/index.php?title=Recovery_Agent_manual
