### PR TITLE
Fixes syndicate shuttle docking locations

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -7,7 +7,7 @@
 	dheight = 9;
 	dir = 2;
 	dwidth = 5;
-	height = 22;
+	height = 24;
 	id = "syndicate_n";
 	name = "north of station";
 	turf_type = /turf/open/space;
@@ -20,7 +20,7 @@
 	dheight = 9;
 	dir = 2;
 	dwidth = 5;
-	height = 22;
+	height = 24;
 	id = "syndicate_ne";
 	name = "northeast of station";
 	turf_type = /turf/open/space;
@@ -68703,7 +68703,7 @@
 	dheight = 9;
 	dir = 2;
 	dwidth = 5;
-	height = 22;
+	height = 24;
 	id = "syndicate_sw";
 	name = "southwest of station";
 	turf_type = /turf/open/space;
@@ -68773,7 +68773,7 @@
 	dheight = 9;
 	dir = 2;
 	dwidth = 5;
-	height = 22;
+	height = 24;
 	id = "syndicate_se";
 	name = "southeast of station";
 	turf_type = /turf/open/space;
@@ -68786,7 +68786,7 @@
 	dheight = 9;
 	dir = 2;
 	dwidth = 5;
-	height = 22;
+	height = 24;
 	id = "syndicate_s";
 	name = "south of station";
 	turf_type = /turf/open/space;
@@ -81134,7 +81134,7 @@ aaa
 aaa
 aaa
 aaa
-aad
+aaa
 aaa
 aaa
 aai

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -39,7 +39,7 @@
 				dat += "<A href='?src=\ref[src];request=1]'>Request Authorization</A><br>"
 	dat += "<a href='?src=\ref[user];mach_close=computer'>Close</a>"
 
-	var/datum/browser/popup = new(user, "computer", M ? M.name : "shuttle", 300, 200)
+	var/datum/browser/popup = new(user, "computer", M ? M.name : "shuttle", 300, 300)
 	popup.set_content("<center>[dat]</center>")
 	popup.set_title_image(usr.browse_rsc_icon(src.icon, src.icon_state))
 	popup.open()


### PR DESCRIPTION
Syndicate shuttle can now actually be sent to places other than "northwest of station".

**Issue** : Old docking points had incorrect height (old was 22, new /tg/ maps use 24) - was fixed where necessary.
