### PR TITLE
Uprights the bar stools

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -22117,9 +22117,7 @@
 /area/crew_quarters/bar)
 "aRl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/chair/stool/bar{
-	step_x = 0
-	},
+/obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -23317,9 +23315,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/chair/stool/bar{
-	step_x = 0
-	},
+/obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -24010,9 +24006,7 @@
 	tag = "icon-manifold-r-f (WEST)";
 	dir = 8
 	},
-/obj/structure/chair/stool/bar{
-	step_x = 0
-	},
+/obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -25722,9 +25716,7 @@
 	dir = 4;
 	initialize_directions = 11
 	},
-/obj/structure/chair/stool/bar{
-	step_x = 0
-	},
+/obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -26439,9 +26431,7 @@
 	},
 /area/crew_quarters/bar)
 "baG" = (
-/obj/structure/chair/stool/bar{
-	step_x = 0
-	},
+/obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -68928,9 +68918,7 @@
 /area/hallway/secondary/exit)
 "cFn" = (
 /obj/effect/landmark/event_spawn,
-/obj/structure/chair/stool/bar{
-	step_x = 0
-	},
+/obj/structure/chair/stool/bar,
 /turf/open/floor/plasteel{
 	icon_state = "bar"
 	},

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -22117,7 +22117,9 @@
 /area/crew_quarters/bar)
 "aRl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	step_x = 0
+	},
 /turf/open/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -23315,7 +23317,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/item/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	step_x = 0
+	},
 /turf/open/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -24006,7 +24010,9 @@
 	tag = "icon-manifold-r-f (WEST)";
 	dir = 8
 	},
-/obj/item/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	step_x = 0
+	},
 /turf/open/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -25716,7 +25722,9 @@
 	dir = 4;
 	initialize_directions = 11
 	},
-/obj/item/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	step_x = 0
+	},
 /turf/open/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -26431,7 +26439,9 @@
 	},
 /area/crew_quarters/bar)
 "baG" = (
-/obj/item/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	step_x = 0
+	},
 /turf/open/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -68918,7 +68928,9 @@
 /area/hallway/secondary/exit)
 "cFn" = (
 /obj/effect/landmark/event_spawn,
-/obj/item/chair/stool/bar,
+/obj/structure/chair/stool/bar{
+	step_x = 0
+	},
 /turf/open/floor/plasteel{
 	icon_state = "bar"
 	},
@@ -105106,7 +105118,7 @@ aUl
 aVQ
 aXl
 aXl
-aRk
+baG
 bch
 aKh
 beO


### PR DESCRIPTION
Bar stools were put in as roundstart items (can't sit on them, would have to pick them up then click on them in-hand), rather than structures, this has been fixed.

Was:
![stools_1](https://cloud.githubusercontent.com/assets/2188139/16356237/2a42ae74-3ada-11e6-88a6-956ee08c4415.png)

Became:
![stools_2](https://cloud.githubusercontent.com/assets/2188139/16356245/2eee57f2-3ada-11e6-99d3-43807bfc496d.png)
