### PR TITLE
Ports: Flying over tables in zero gravity with a jetpack

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -48,6 +48,7 @@
 #define PASSMOB			16
 #define LETPASSTHROW	32
 #define PASSDOOR		64
+#define JETPACKTABLE	128
 
 //flags for species
 

--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -48,7 +48,6 @@
 #define PASSMOB			16
 #define LETPASSTHROW	32
 #define PASSDOOR		64
-#define JETPACKTABLE	128
 
 //flags for species
 

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -35,22 +35,22 @@
 		return
 
 	if(!on)
-		turn_on(user)
+		turn_on()
 		user << "<span class='notice'>You turn the jetpack on.</span>"
 	else
-		turn_off(user)
+		turn_off()
 		user << "<span class='notice'>You turn the jetpack off.</span>"
 	for(var/X in actions)
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
 
 
-/obj/item/weapon/tank/jetpack/proc/turn_on(mob/user)
+/obj/item/weapon/tank/jetpack/proc/turn_on()
 	on = TRUE
 	icon_state = "[initial(icon_state)]-on"
 	ion_trail.start()
 
-/obj/item/weapon/tank/jetpack/proc/turn_off(mob/user)
+/obj/item/weapon/tank/jetpack/proc/turn_off()
 	on = FALSE
 	stabilizers = FALSE
 	icon_state = initial(icon_state)
@@ -60,12 +60,12 @@
 	if(!on)
 		return
 	if((num < 0.005 || air_contents.total_moles() < num))
-		turn_off(user)
+		turn_off()
 		return
 
 	var/datum/gas_mixture/removed = air_contents.remove(num)
 	if(removed.total_moles() < 0.005)
-		turn_off(user)
+		turn_off()
 		return
 
 	var/turf/T = get_turf(user)

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -35,23 +35,33 @@
 		return
 
 	if(!on)
-		turn_on()
+		turn_on(user)
 		user << "<span class='notice'>You turn the jetpack on.</span>"
 	else
-		turn_off()
+		turn_off(user)
 		user << "<span class='notice'>You turn the jetpack off.</span>"
 	for(var/X in actions)
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
 
 
-/obj/item/weapon/tank/jetpack/proc/turn_on()
+/obj/item/weapon/tank/jetpack/proc/turn_on(mob/user)
 	on = TRUE
+	var/mob/living/C = user
+
+	if(C.pass_flags & JETPACKTABLE) // a check to make sure we don't start with it again.
+		C.pass_flags &= ~JETPACKTABLE
+
+	if (!has_gravity(user))
+		C.pass_flags |= JETPACKTABLE
 	icon_state = "[initial(icon_state)]-on"
 	ion_trail.start()
 
-/obj/item/weapon/tank/jetpack/proc/turn_off()
+/obj/item/weapon/tank/jetpack/proc/turn_off(mob/user)
 	on = FALSE
+	var/mob/living/C = user
+	if(C.pass_flags & JETPACKTABLE)
+		C.pass_flags &= ~JETPACKTABLE
 	stabilizers = FALSE
 	icon_state = initial(icon_state)
 	ion_trail.stop()
@@ -60,12 +70,12 @@
 	if(!on)
 		return
 	if((num < 0.005 || air_contents.total_moles() < num))
-		turn_off()
+		turn_off(user)
 		return
 
 	var/datum/gas_mixture/removed = air_contents.remove(num)
 	if(removed.total_moles() < 0.005)
-		turn_off()
+		turn_off(user)
 		return
 
 	var/turf/T = get_turf(user)

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -47,14 +47,11 @@
 
 /obj/item/weapon/tank/jetpack/proc/turn_on(mob/user)
 	on = TRUE
-	user.pass_flags |= JETPACKTABLE
 	icon_state = "[initial(icon_state)]-on"
 	ion_trail.start()
 
 /obj/item/weapon/tank/jetpack/proc/turn_off(mob/user)
 	on = FALSE
-	if(user.pass_flags & JETPACKTABLE)
-		user.pass_flags &= ~JETPACKTABLE
 	stabilizers = FALSE
 	icon_state = initial(icon_state)
 	ion_trail.stop()

--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -47,21 +47,14 @@
 
 /obj/item/weapon/tank/jetpack/proc/turn_on(mob/user)
 	on = TRUE
-	var/mob/living/C = user
-
-	if(C.pass_flags & JETPACKTABLE) // a check to make sure we don't start with it again.
-		C.pass_flags &= ~JETPACKTABLE
-
-	if (!has_gravity(user))
-		C.pass_flags |= JETPACKTABLE
+	user.pass_flags |= JETPACKTABLE
 	icon_state = "[initial(icon_state)]-on"
 	ion_trail.start()
 
 /obj/item/weapon/tank/jetpack/proc/turn_off(mob/user)
 	on = FALSE
-	var/mob/living/C = user
-	if(C.pass_flags & JETPACKTABLE)
-		C.pass_flags &= ~JETPACKTABLE
+	if(user.pass_flags & JETPACKTABLE)
+		user.pass_flags &= ~JETPACKTABLE
 	stabilizers = FALSE
 	icon_state = initial(icon_state)
 	ion_trail.stop()

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -127,12 +127,9 @@
 		return 1
 	if(istype(mover) && mover.checkpass(PASSTABLE))
 		return 1
-	if(istype(mover) && mover.checkpass(JETPACKTABLE))
-		if(issilicon(mover))
-			return
-		if(!iscarbon(mover))
-			message_admins("Error. CanPass() has detected a non-carbon mob with a JETPACKTABLE.([mover.x], [mover.y], [mover.z]). Report to a coder.")
-			return
+	if(issilicon(mover))
+		return
+	if(iscarbon(mover))
 		var/mob/living/carbon/C = mover
 		var/obj/item/weapon/tank/jetpack/jetpacktable = C.get_jetpack()
 		if(jetpacktable && jetpacktable.on && !has_gravity(C))

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -127,6 +127,14 @@
 		return 1
 	if(istype(mover) && mover.checkpass(PASSTABLE))
 		return 1
+	if(istype(mover) && mover.checkpass(JETPACKTABLE))
+		if(!iscarbon(mover))
+			message_admins("Error. CanPass() has detected a non-carbon mob with a JETPACKTABLE.([mover.x], [mover.y], [mover.z]). Report to a coder.")
+			return
+		var/mob/living/carbon/C = mover
+		var/obj/item/weapon/tank/jetpack/jetpacktable = C.get_jetpack()
+		if(jetpacktable && jetpacktable.on)
+			return 1
 	if(mover.throwing)
 		return 1
 	if(locate(/obj/structure/table) in get_turf(mover))

--- a/code/game/objects/structures/tables_racks.dm
+++ b/code/game/objects/structures/tables_racks.dm
@@ -128,12 +128,14 @@
 	if(istype(mover) && mover.checkpass(PASSTABLE))
 		return 1
 	if(istype(mover) && mover.checkpass(JETPACKTABLE))
+		if(issilicon(mover))
+			return
 		if(!iscarbon(mover))
 			message_admins("Error. CanPass() has detected a non-carbon mob with a JETPACKTABLE.([mover.x], [mover.y], [mover.z]). Report to a coder.")
 			return
 		var/mob/living/carbon/C = mover
 		var/obj/item/weapon/tank/jetpack/jetpacktable = C.get_jetpack()
-		if(jetpacktable && jetpacktable.on)
+		if(jetpacktable && jetpacktable.on && !has_gravity(C))
 			return 1
 	if(mover.throwing)
 		return 1


### PR DESCRIPTION
I decided to allow people to pass over tables when they have a jetpack ON, on their BACK, and a gravity check fails.

https://github.com/yogstation13/yogstation-old/pull/266
https://github.com/tgstation/tgstation/pull/15866

:cl: Super3222
tweak: You can now fly over tables with a jetpack when gravity is down!
/:cl:
