### PR TITLE
Alerting admins the presence of Megafuana's

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -48,7 +48,8 @@
 /mob/living/simple_animal/hostile/megafauna/Life()
 	..()
 	if((loc.z != ZLEVEL_LAVALAND) && !alert_admins)
-		message_admins("A live [src] has left the lavaland and is currently on another z level. <A HREF='?_src_=holder;adminplayerobservefollow=\ref[src]'>FLW</A> ([loc.x], [loc.y], [loc.z])")
+		message_admins("A live [src.name] ([src.desc]) has left the lavaland and is currently on another z level. <A HREF='?_src_=holder;adminplayerobservefollow=\ref[src]'>FLW</A> ([loc.x], [loc.y], [loc.z])")
+		log_admin("[src] is off of the lavaland.")
 		alert_admins = !alert_admins
 		spawn(3000) // a cooldown, so it'll alert the admins again if it's still off the z level.
 			alert_admins = !alert_admins

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -13,6 +13,7 @@
 	minbodytemp = 0
 	maxbodytemp = INFINITY
 	layer = LARGE_MOB_LAYER //Looks weird with them slipping under mineral walls and cameras and shit otherwise
+	var/alert_admins
 
 /mob/living/simple_animal/hostile/megafauna/death(gibbed)
 	if(health > 0)
@@ -43,3 +44,11 @@
 		(<A HREF='?_src_=holder;adminplayerobservefollow=\ref[src]'>FLW</A>) \
 		moved via shuttle from ([oldloc.x],[oldloc.y],[oldloc.z]) to \
 		([newloc.x],[newloc.y],[newloc.z])")
+
+/mob/living/simple_animal/hostile/megafauna/Life()
+	..()
+	if((loc.z != ZLEVEL_LAVALAND) && !alert_admins)
+		message_admins("SECOND VERSION AAAAAAH : A live legion has left the lavaland and is currently on an off z level. <A HREF='?_src_=holder;adminplayerobservefollow=\ref[src]'>FLW</A> ([loc.x], [loc.y], [loc.z])")
+		alert_admins = !alert_admins
+		spawn(3000)
+			alert_admins = !alert_admins

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -48,7 +48,7 @@
 /mob/living/simple_animal/hostile/megafauna/Life()
 	..()
 	if((loc.z != ZLEVEL_LAVALAND) && !alert_admins)
-		message_admins("SECOND VERSION AAAAAAH : A live legion has left the lavaland and is currently on an off z level. <A HREF='?_src_=holder;adminplayerobservefollow=\ref[src]'>FLW</A> ([loc.x], [loc.y], [loc.z])")
+		message_admins("A live [src] has left the lavaland and is currently on another z level. <A HREF='?_src_=holder;adminplayerobservefollow=\ref[src]'>FLW</A> ([loc.x], [loc.y], [loc.z])")
 		alert_admins = !alert_admins
-		spawn(3000)
+		spawn(3000) // a cooldown, so it'll alert the admins again if it's still off the z level.
 			alert_admins = !alert_admins


### PR DESCRIPTION
An admin requested for this.
As long as a megafauna is off of the lavaland (z level wise), it'll report to the admins it's presence. Of course between brief periods of time it'll continue to alert admins unlike a singularity.
