### PR TITLE
Fixes AI Eye not moving to core at roundstart

### DIFF
--- a/code/modules/mob/living/silicon/ai/login.dm
+++ b/code/modules/mob/living/silicon/ai/login.dm
@@ -9,4 +9,5 @@
 		for(var/obj/machinery/ai_status_display/O in machines) //change status
 			O.mode = 1
 			O.emotion = "Neutral"
-	view_core()
+	spawn
+		view_core()


### PR DESCRIPTION
Issue : #124

As far as I can tell, this is a weird race condition, where the eye is moved before AI has finished initializing or something like that...this spawn fixes that.
