### PR TITLE
Fixes protolathe chemical capacity

### DIFF
--- a/code/modules/research/protolathe.dm
+++ b/code/modules/research/protolathe.dm
@@ -53,6 +53,7 @@ Note: Must be placed west/left of and R&D console to function.
 /obj/machinery/r_n_d/protolathe/RefreshParts()
 	var/T = 0
 	for(var/obj/item/weapon/reagent_containers/glass/G in component_parts)
+		reagents.maximum_volume += G.volume
 		G.reagents.trans_to(src, G.reagents.total_volume)
 	for(var/obj/item/weapon/stock_parts/matter_bin/M in component_parts)
 		T += M.rating


### PR DESCRIPTION
Issue : #167 

Protolathe's chemical capacity wasn't updated according to the beakers used in it's construction. This has been fixed.
