### PR TITLE
Adds security transceivers (non-lazy edition)

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -2459,7 +2459,7 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/item/device/radio,
+/obj/item/device/radio/security,
 /turf/open/floor/carpet,
 /area/security/hos)
 "aeE" = (
@@ -4942,7 +4942,7 @@
 "aiG" = (
 /obj/structure/table,
 /obj/item/device/assembly/flash/handheld,
-/obj/item/device/radio,
+/obj/item/device/radio/security,
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiH" = (
@@ -6122,7 +6122,12 @@
 	pixel_x = -3;
 	pixel_y = 7
 	},
-/obj/item/device/radio,
+/obj/item/device/radio/security{
+	pixel_x = -8
+	},
+/obj/item/device/radio{
+	pixel_x = 8
+	},
 /turf/open/floor/plasteel{
 	icon_state = "showroomfloor"
 	},
@@ -29886,7 +29891,12 @@
 	pixel_y = 7
 	},
 /obj/item/weapon/pen,
-/obj/item/device/radio,
+/obj/item/device/radio{
+	pixel_x = -8
+	},
+/obj/item/device/radio/security{
+	pixel_x = 8
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/captain)
 "bik" = (
@@ -68721,12 +68731,12 @@
 /obj/structure/table,
 /obj/item/weapon/paper_bin,
 /obj/item/device/radio{
-	pixel_x = 8
-	},
-/obj/item/device/radio{
 	pixel_x = -8
 	},
 /obj/machinery/light,
+/obj/item/device/radio/security{
+	pixel_x = 8
+	},
 /turf/open/floor/plasteel{
 	icon_state = "yellow"
 	},

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -24,6 +24,7 @@
 	new /obj/item/device/radio/headset/heads/captain(src)
 	new /obj/item/clothing/glasses/sunglasses/gar/supergar(src)
 	new /obj/item/clothing/gloves/color/captain(src)
+	new /obj/item/device/radio/security(src)
 	new /obj/item/weapon/restraints/handcuffs/cable/zipties(src)
 	new /obj/item/weapon/gun/energy/gun(src)
 	new /obj/item/weapon/door_remote/captain(src)
@@ -76,6 +77,7 @@
 	new /obj/item/weapon/storage/box/flashbangs(src)
 	new /obj/item/weapon/shield/riot/tele(src)
 	new /obj/item/weapon/storage/belt/security/full(src)
+	new /obj/item/device/radio/security(src)
 	new /obj/item/weapon/gun/energy/gun/hos(src)
 	new /obj/item/device/flashlight/seclite(src)
 	new /obj/item/weapon/pinpointer(src)
@@ -99,6 +101,7 @@
 	new /obj/item/weapon/storage/box/zipties(src)
 	new /obj/item/weapon/storage/box/flashbangs(src)
 	new /obj/item/weapon/storage/belt/security/full(src)
+	new /obj/item/device/radio/security(src)
 	new /obj/item/device/flashlight/seclite(src)
 	new /obj/item/clothing/gloves/color/black/krav_maga/sec(src)
 	new /obj/item/weapon/door_remote/head_of_security(src)
@@ -116,6 +119,7 @@
 	new /obj/item/device/radio/headset/headset_sec/alt(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
 	new /obj/item/device/flashlight/seclite(src)
+	new /obj/item/device/radio/security(src)
 
 /obj/structure/closet/secure_closet/security/sec
 


### PR DESCRIPTION
Issue : #160

Adds security transceivers to lockers and the map. In addition, Warden/HoS keep the bounced station radios as well too! (Previously, they were replaced with security radios, I just added them, instead of replacing)
