### PR TITLE
Fixes the infinite exoskeleton bug

### DIFF
--- a/code/game/objects/items/robot/robot_parts.dm
+++ b/code/game/objects/items/robot/robot_parts.dm
@@ -270,6 +270,9 @@
 
 			feedback_inc("cyborg_birth",1)
 
+			if(pulledby)
+				pulledby.stop_pulling()
+
 			src.loc = O
 			O.robot_suit = src
 


### PR DESCRIPTION
Ignore the branch name, I was "in a rush".

Bug: Pull on an exoskeleton, click on it using a MMI (with an acceptable brain), borg is created but the exoskeleton doesn't disappear.

The bug happened because the skeletons loc was stuck because the user was still pulling.
I fixed it by ending anyone's pull when the MMI would transfer into the borg.

> ez fix
> merge token pls
