### PR TITLE
Fixes swarmer event not spawning properly

### DIFF
--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer_event.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer_event.dm
@@ -13,16 +13,18 @@
 /datum/round_event/spawn_swarmer/start()
 	if(find_swarmer())
 		return 0
-	if(!the_gateway)
+	if(!gravity_generators.len)
 		return 0
-	new /obj/item/device/unactivated_swarmer(get_turf(the_gateway))
+	var/turf/spawn_loc = get_turf(pick(gravity_generators["[ZLEVEL_STATION]"]))
+	if(!spawn_loc)
+		return 0
+	new /obj/item/device/unactivated_swarmer(spawn_loc)
 	if(prob(25)) //25% chance to announce it to the crew
 		var/swarmer_report = "<font size=3><b>[command_name()] High-Priority Update</b></span>"
-		swarmer_report += "<br><br>Our long-range sensors have detected an odd signal emanating from your station's gateway. We recommend immediate investigation of your gateway, as something may have come \
-		through."
+		swarmer_report += "<br><br>Our long-range sensors have detected an odd signal emanating from your station's gravity generator. We recommend immediate investigation of your gravity generator, as something may have come \
+		through." //Hey, it's magnets, noone knows how they work.
 		print_command_report(swarmer_report,"Classified [command_name()] Update")
 		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", 'sound/AI/commandreport.ogg')
-
 
 /datum/round_event/spawn_swarmer/proc/find_swarmer()
 	for(var/mob/living/M in mob_list)


### PR DESCRIPTION
**No, this is a legit and proper bugfix, I don't care what you say.**

/tg/ have the gateway where we have the Clerk shop. That's what's used to spawn in swarmer shells. 

Now it's replaced with gravity generator, because, hey, why the hell not, right, what's the worst that could happen? Only works if the gravity generator is currently on (aka, if station has gravity).

Ghosts get notified the same way as if golem shells/drones being made.
