### PR TITLE
Fixes chameleon jumpsuit adjustability settings

### DIFF
--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -75,7 +75,7 @@
 	if(button)
 		button.name = "Change [chameleon_name] Appearance"
 	chameleon_blacklist += target.type
-	var/list/temp_list = typesof(chameleon_type)
+	var/list/temp_list = subtypesof(chameleon_type)
 	for(var/V in temp_list - (chameleon_blacklist))
 		chameleon_list += V
 
@@ -131,10 +131,17 @@
 		var/obj/item/I = target
 		I.item_state = initial(picked_item.item_state)
 		I.item_color = initial(picked_item.item_color)
-		if(istype(I, /obj/item/clothing) && istype(initial(picked_item), /obj/item/clothing))
+		if(istype(target, /obj/item/clothing))
 			var/obj/item/clothing/CL = I
 			var/obj/item/clothing/PCL = picked_item
 			CL.flags_cover = initial(PCL.flags_cover)
+			if(istype(target, /obj/item/clothing/under))
+				var/obj/item/clothing/under/UCL = target
+				var/obj/item/clothing/under/PUCL = picked_item
+				UCL.can_adjust = initial(PUCL.can_adjust)
+				if(!UCL.can_adjust && UCL.adjusted)
+					UCL.toggle_jumpsuit_adjust()
+					usr.update_inv_w_uniform()
 	target.icon = initial(picked_item.icon)
 
 /datum/action/item_action/chameleon/change/Trigger()
@@ -161,6 +168,11 @@
 	..()
 	var/datum/action/item_action/chameleon/change/chameleon_action = new(src)
 	chameleon_action.chameleon_type = /obj/item/clothing/under
+	chameleon_action.chameleon_blacklist = list(/obj/item/clothing/under/shadowling,
+		/obj/item/clothing/under/changeling,
+		/obj/item/clothing/under/color/random,
+		/obj/item/clothing/under/golem,
+		/obj/item/clothing/under/predator)
 	chameleon_action.chameleon_name = "Jumpsuit"
 	chameleon_action.initialize_disguises()
 


### PR DESCRIPTION
Prevents you from being able to adjust unadjustable jumpsuits chameleon is disguised as, causing icon issues. Also blacklists some useless/broken types.

**Before any coders even ask:** No, as strange as it may seem, `istype(picked_item, /obj/item/clothing/under)` (or even `/obj/item/clothing`, for that matter) _doesn't work_ (or `istype(I...)` or `istype(PCL...)`). As in, it returns 0, even if the picked_item IS (and can be typecast into) the appropriate type. I have no idea why it is the way it is, but it is the way it is. `picked_item` will have to be assumed to be the same type as the object calling the button (which is very risky, I know, but I have no idea how to fix this in any other way).
