### PR TITLE
Adds emergency flares to standard survival boxes

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -196,10 +196,12 @@ obj/item/device/flashlight/lamp/bananalamp
 	var/fuel = 0
 	var/on_damage = 7
 	var/produce_heat = 1500
+	var/frng_min = 800
+	var/frng_max = 1000
 	heat = 1000
 
 /obj/item/device/flashlight/flare/New()
-	fuel = rand(800, 1000) // Sorry for changing this so much but I keep under-estimating how long X number of ticks last in seconds.
+	fuel = rand(frng_min, frng_max) // Sorry for changing this so much but I keep under-estimating how long X number of ticks last in seconds.
 	..()
 
 /obj/item/device/flashlight/flare/process()
@@ -249,6 +251,19 @@ obj/item/device/flashlight/lamp/bananalamp
 
 /obj/item/device/flashlight/flare/is_hot()
 	return on * heat
+
+/obj/item/device/flashlight/flare/emergency
+	name = "safety flare"
+	desc = "A flare issued to nanotrasen employees for pending emergencies. There are instructions on the side, it reads 'pull cord, make light, obey nanotrasen'."
+	brightness_on = 3
+	frng_min = 400
+	frng_max = 800
+
+/obj/item/device/flashlight/flare/security
+	name = "heavy-duty safety flare"
+	desc = "A lightweight flare which usually carries around more fuel then the standard edition for emergencies. You can use it on tactical missions, cooperative missions, or for waving back and forth during a concert."
+	frng_min = 750
+	frng_max = 1250
 
 /obj/item/device/flashlight/flare/torch
 	name = "torch"

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -256,13 +256,13 @@ obj/item/device/flashlight/lamp/bananalamp
 	name = "safety flare"
 	desc = "A flare issued to nanotrasen employees for pending emergencies. There are instructions on the side, it reads 'pull cord, make light, obey nanotrasen'."
 	brightness_on = 3
-	frng_min = 400
-	frng_max = 800
+	frng_min = 150
+	frng_max = 350
 
 /obj/item/device/flashlight/flare/security
 	name = "heavy-duty safety flare"
 	desc = "A lightweight flare which usually carries around more fuel then the standard edition for emergencies. You can use it on tactical missions, cooperative missions, or for waving back and forth during a concert."
-	frng_min = 750
+	frng_min = 700
 	frng_max = 1250
 
 /obj/item/device/flashlight/flare/torch

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -63,6 +63,7 @@
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen(src)
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
+	new /obj/item/device/flashlight/flare/emergency(src)
 
 /obj/item/weapon/storage/box/survival/radio/New()
 	..()
@@ -74,6 +75,7 @@
 	new /obj/item/clothing/mask/breath(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen/engi(src)
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
+	new /obj/item/device/flashlight/flare/emergency(src)
 
 /obj/item/weapon/storage/box/engineer/radio/New()
 	..()
@@ -84,6 +86,7 @@
 	..()
 	new /obj/item/clothing/mask/gas/syndicate(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen/engi(src)
+	new /obj/item/device/flashlight/flare/security(src)
 
 // Security survival box
 /obj/item/weapon/storage/box/security/New()
@@ -91,6 +94,7 @@
 	new /obj/item/clothing/mask/gas/sechailer(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen(src)
 	new /obj/item/weapon/reagent_containers/hypospray/medipen(src)
+	new /obj/item/device/flashlight/flare/security(src)
 
 /obj/item/weapon/storage/box/security/radio/New()
 	..()


### PR DESCRIPTION
Emergency flares are weaker then normal flares.
Security get heavy-duty flares which have more fuel than the normal flare.

Remember that this isn't anything like an intentional hit on shadowlings. The only thing I'm doing here is increasing the amount of equipment in a survival box. It already has equipment for emergencies, but still it lacks some (via a quick light source. I also realize your PDA has a light).
#### Changelog

:cl: Super3222
rscadd: Nanotrasen has funded the production of emergencyflares for all of their employees. 
rscadd: Security has been distributed heavy-duty flares which carry more fuel than the standard addition.
/:cl:
