### PR TITLE
Port: Shadows Artificers

### DIFF
--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -181,10 +181,10 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 		ChangeTurf(/turf/open/floor/engine/cult)
 
 /turf/simulated/floor/attack_animal(mob/living/simple_animal/M)
-	if(istype(M,/mob/living/simple_animal/construct/builder)||istype(M,/mob/living/simple_animal/construct/harvester))//only cult things can interact with floors so far
-		if(istype(src, /turf/simulated/floor/engine/cult))
+	if(istype(M,/mob/living/simple_animal/hostile/construct/builder)||istype(M,/mob/living/simple_animal/hostile/construct/harvester))//only cult things can interact with floors so far
+		if(istype(src, /turf/open/floor/engine/cult))
 			return
-		src.ChangeTurf(/turf/simulated/floor/engine/cult)
+		src.ChangeTurf(/turf/open/floor/engine/cult)
 		M <<"<span class='notice'>You transfer some of your corrupt energy into the floor, causing it to transform.</span>"
 		playsound(src, 'sound/items/Welder.ogg', 100, 1)
 		return

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -180,6 +180,16 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 	if(prob(20))
 		ChangeTurf(/turf/open/floor/engine/cult)
 
+/turf/simulated/floor/attack_animal(mob/living/simple_animal/M)
+	if(istype(M,/mob/living/simple_animal/construct/builder)||istype(M,/mob/living/simple_animal/construct/harvester))//only cult things can interact with floors so far
+		if(istype(src, /turf/simulated/floor/engine/cult))
+			return
+		src.ChangeTurf(/turf/simulated/floor/engine/cult)
+		M <<"<span class='notice'>You transfer some of your corrupt energy into the floor, causing it to transform.</span>"
+		playsound(src, 'sound/items/Welder.ogg', 100, 1)
+		return
+	return
+
 /turf/open/floor/ratvar_act()
 	if(prob(20))
 		ChangeTurf(/turf/open/floor/clockwork)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -99,7 +99,14 @@
 	return src.attack_hand(user)
 
 
-/turf/closed/wall/attack_animal(mob/living/simple_animal/M)
+/turf/simulated/wall/attack_animal(mob/living/simple_animal/M)
+	if(istype(M,/mob/living/simple_animal/construct/builder)||istype(M,/mob/living/simple_animal/construct/harvester))
+		if(istype(src, /turf/simulated/wall/cult))
+			return
+		src.ChangeTurf(/turf/simulated/wall/cult)
+		M <<"<span class='notice'>You transfer some of your corrupt energy into the wall, causing it to transform.</span>"
+		playsound(src, 'sound/items/Welder.ogg', 100, 1)
+		return
 	M.changeNext_move(CLICK_CD_MELEE)
 	M.do_attack_animation(src)
 	if(M.environment_smash >= 2)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -99,11 +99,11 @@
 	return src.attack_hand(user)
 
 
-/turf/simulated/wall/attack_animal(mob/living/simple_animal/M)
-	if(istype(M,/mob/living/simple_animal/construct/builder)||istype(M,/mob/living/simple_animal/construct/harvester))
-		if(istype(src, /turf/simulated/wall/cult))
+/turf/closed/wall/attack_animal(mob/living/simple_animal/M)
+	if(istype(M,/mob/living/simple_animal/hostile/construct/builder)||istype(M,/mob/living/simple_animal/hostile/construct/harvester))
+		if(istype(src, /turf/closed/wall/mineral/cult))
 			return
-		src.ChangeTurf(/turf/simulated/wall/cult)
+		src.ChangeTurf(/turf/closed/wall/mineral/cult)
 		M <<"<span class='notice'>You transfer some of your corrupt energy into the wall, causing it to transform.</span>"
 		playsound(src, 'sound/items/Welder.ogg', 100, 1)
 		return
@@ -114,6 +114,17 @@
 		M << "<span class='notice'>You smash through the wall.</span>"
 		dismantle_wall(1)
 		return
+
+/turf/closed/wall/mineral/cult/Bumped(atom/movable/C as mob)
+	var/phasable=0
+	if(istype(C,/mob/living/simple_animal/hostile/construct/builder)||istype(C,/mob/living/simple_animal/hostile/construct/wraith)||istype(C,/mob/living/simple_animal/hostile/construct/harvester))
+		phasable = 2
+		while(phasable>0)
+			src.density = 0
+			sleep(10)
+			phasable--
+		src.density = 1
+	return
 
 /turf/closed/wall/attack_hulk(mob/user)
 	..(user, 1)

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -37,7 +37,7 @@
 		AddSpell(new spell(null))
 
 /mob/living/simple_animal/hostile/construct/examine(mob/user)
-	var/msg = "<span cass='info'>*---------*\nThis is \icon[src] \a <b>[src]</b>!\n"
+	var/msg = "<span cass='info'>*---------*\nThis is \icon[src] \a <EM>[src]</EM>!\n[desc]\n"
 	if (src.health < src.maxHealth)
 		msg += "<span class='warning'>"
 		if (src.health >= src.maxHealth/2)
@@ -96,6 +96,8 @@
 	attacktext = "smashes their armored gauntlet into"
 	speed = 3
 	environment_smash = 2
+	see_in_dark = 8
+	see_invisible = SEE_INVISIBLE_MINIMUM
 	attack_sound = 'sound/weapons/punch3.ogg'
 	status_flags = 0
 	mob_size = MOB_SIZE_LARGE
@@ -149,6 +151,8 @@
 	melee_damage_upper = 25
 	retreat_distance = 2 //AI wraiths will move in and out of combat
 	attacktext = "slashes"
+	see_in_dark = 8
+	see_invisible = SEE_INVISIBLE_MINIMUM
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	construct_spells = list(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift)
 	playstyle_string = "<b>You are a Wraith. Though relatively fragile, you are fast, deadly, and even able to phase through walls.</b>"
@@ -165,8 +169,8 @@
 	desc = "A bulbous construct dedicated to building and maintaining the Cult of Nar-Sie's armies."
 	icon_state = "artificer"
 	icon_living = "artificer"
-	maxHealth = 50
-	health = 50
+	maxHealth = 55
+	health = 55
 	response_harm = "viciously beats"
 	harm_intent_damage = 5
 	melee_damage_lower = 5
@@ -174,6 +178,8 @@
 	retreat_distance = 10
 	minimum_distance = 10 //AI artificers will flee like fuck
 	attacktext = "rams"
+	see_in_dark = 8
+	see_invisible = SEE_INVISIBLE_MINIMUM
 	environment_smash = 2
 	attack_sound = 'sound/weapons/punch2.ogg'
 	construct_spells = list(/obj/effect/proc_holder/spell/aoe_turf/conjure/wall,
@@ -181,10 +187,11 @@
 							/obj/effect/proc_holder/spell/aoe_turf/conjure/soulstone,
 							/obj/effect/proc_holder/spell/aoe_turf/conjure/construct/lesser,
 							/obj/effect/proc_holder/spell/targeted/projectile/magic_missile/lesser)
-	playstyle_string = "<b>You are an Artificer. You are incredibly weak and fragile, but you are able to construct fortifications, \
-						use magic missile, repair allied constructs, shades, and yourself (by clicking on them), \
-						<i>and, most important of all,</i> create new constructs by producing soulstones to capture souls, \
-						and shells to place those soulstones into.</b>"
+	playstyle_string = "<B>You are an Artificer. You are incredibly weak and fragile, but you are able to construct fortifications, \
+						corrupt areas (click on floors and walls to corrupt them and allow you to phase through them), \
+						use magic missile, repair allied constructs (by clicking on them), \
+						</B><I>and most important of all create new constructs</I><B> \
+						(Use your Artificer spell to summon a new construct shell and Summon Soulstone to create a new soulstone).</B>"
 
 /mob/living/simple_animal/hostile/construct/builder/Found(atom/A) //what have we found here?
 	if(isconstruct(A)) //is it a construct?


### PR DESCRIPTION
makes artificers able to corrupt walls and floors by clicking them, etc etc
cult walls can be phased through by wraiths, artys, and harvesters but not juggs becuase fuck them
also increases arty health by 5
also fixes wraiths not actually having nightvision when they were supposed to
also makes every construct have nightvision

as always look over my code please because I probably made a mistake somewhere

:cl: ShadowDeath6
rscadd: Artificers and Harvesters can once again corrupt walls and floors.
rscadd: Artificers, Harvesters, and Wraiths can once again phase through cult walls.
bugfix: Wraiths can now see in the dark.
tweak: All Nar'siean constructs can see in the dark.
/:cl:
