### PR TITLE
Detective can no longer be a traitor

### DIFF
--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -10,7 +10,7 @@
 	config_tag = "traitor"
 	antag_flag = ROLE_TRAITOR
 	restricted_jobs = list("Cyborg")//They are part of the AI if he is traitor so are they, they use to get double chances
-	protected_jobs = list("Security Officer", "Warden", "Head of Security", "Captain")
+	protected_jobs = list("Security Officer","Detective", "Warden", "Head of Security", "Captain")
 	required_players = 0
 	required_enemies = 1
 	recommended_enemies = 4


### PR DESCRIPTION
TG removed it too because they knew it was shit.

Basically antag dets make security's job a lot harder. Non antag dets cannot do their jobs either because nobody trusts them.

:cl: FluffySurvivor
rscdel: Detectives can no longer be traitors.
/:cl:
