### PR TITLE
Nerfs revolvers

### DIFF
--- a/code/modules/projectiles/ammunition/ammo_casings.dm
+++ b/code/modules/projectiles/ammunition/ammo_casings.dm
@@ -1,7 +1,7 @@
 /obj/item/ammo_casing/a357
 	desc = "A .357 bullet casing."
 	caliber = "357"
-	projectile_type = /obj/item/projectile/bullet
+	projectile_type = /obj/item/projectile/bullet/sub
 
 /obj/item/ammo_casing/a762
 	desc = "A 7.62 bullet casing."

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -7,6 +7,9 @@
 	flag = "bullet"
 	hitsound_wall = "ricochet"
 
+/obj/item/projectile/bullet/sub //nerfed substitute for revolvers
+	damage = 40
+
 /obj/item/projectile/bullet/weakbullet //beanbag, heavy stamina damage
 	damage = 5
 	stamina = 80


### PR DESCRIPTION
Revolvers as of now are ridiculously over powered. They do an outstanding 60 brute damage which makes them two click kill weapons. A few weeks ago there was quite an amount of controversy, but there was an agreement to nerf it somewhere around 40~ damage.

This PR takes from [yogstation-old/#1226](https://github.com/yogstation13/yogstation-old/issues/1226) and [yogstation-old/#1228](https://github.com/yogstation13/yogstation-old/pull/1228).

Stats (with the changes):
To an unarmored person all 3 bullets would do
120 damage.

Protective Security Vest AND the HOS's standard armor
3 bullets TO THE CHEST (or anywhere for HoS) does 84 damage.

Against the Captains Carpace
3 bullets TO THE CHEST does 72 damage.

Against the Captains Hardsuit (considerably the strongest armor you can manage to get in the game)
3 bullets does 60 damage.

Against bulletproof vests
3 bullets TO THE CHEST does 24 damage. (keep in mind 2 bullets currently against a bulletproof vest does 24 damage).
#### Changelog

:cl: Super3222
tweak: Nanotrasen Intel presents information that the Syndicate has fortunately cut back on quality of their devastating revolvers. Their ballistic damage now does 40 damage per shot rather then 60.
/:cl:
