### PR TITLE
Removes the sleeping carp scroll from syndicate uplinks

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -533,14 +533,6 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 /datum/uplink_item/stealthy_weapons
 	category = "Stealthy and Inconspicuous Weapons"
 
-/datum/uplink_item/stealthy_weapons/martialarts
-	name = "Martial Arts Scroll"
-	desc = "This scroll contains the secrets of an ancient martial arts technique. You will master unarmed combat, \
-			deflecting all ranged weapon fire, but you also refuse to use dishonorable ranged weaponry."
-	item = /obj/item/weapon/sleeping_carp_scroll
-	cost = 17
-	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/gang)
-
 /datum/uplink_item/stealthy_weapons/throwingweapons
 	name = "Box of Throwing Weapons"
 	desc = "A box of shurikens and reinforced bolas from ancient Earth martial arts. They are highly effective \


### PR DESCRIPTION
Ever since I heard about it being available to traitors, I've always told everyone that I was going to remove it. My reason for removing it isn't just because it's overpowered, no that's another story.

I'm removing it because it simply doesn't fit traitors.
It's a tool which gives you awesome karate moves and allows you to deflect ANY projectile, sure. But on the other side, again it does not fit the Syndicate organization. The Syndicate are made up of ballistic weaponry and bombs, not karate moves.

No, that's more of a Sleeping Carp sort of thing. You may be wondering, 'well technically gang leaders are syndicate agents who are employeed to reek havoc on the station and sleeping carps can be gang leader'. Yes, that's true. But still, they are basically an entirely different organization themself. Instead of being employeed they are almost fighting them.

For example, one of the sleeping carps most popular traits are not being able to use guns. Syndicate is popular for using guns whenever they can, and their variety of different guns doesn't help with their cause. Take into account that EVERY OTHER GANG uses guns, so you cannot say that the  sleeping carps have agreed to fight for the syndicate which does not agree with their customs.

Another thing, sleeping carp gang leaders cannot "attack a fallen foe". This is obviously not a trait of the criminal organization of the Syndicate who sends agents to literally assassinate people. The Sleeping Carps do not "assassinate", instead they best their opponent, but do not ensure their death. This is something different from the Syndicate who wants their agents to ensure that their target is completely dead.

One last thing, this is LITERALLY TAKING A RARE AND UNIQUE ITEM FROM ANOTHER GAME MODE AND SQUISHING IT INTO A LIST OF ACTUAL TRAITOR GEAR.
#### Super3222

:cl:
rscdel: Embarrassingly enough, the Sleeping Carp Gang has recently acknowledged the Syndicate's immoral goals which cannot coexist with their own. They've decided to unlist their martial arts scroll from their uplink.
/:cl:
