### PR TITLE
More mapping fixes

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -18624,6 +18624,7 @@
 "aJn" = (
 /obj/machinery/flasher{
 	id = "cockpit_flasher";
+	pixel_x = 6;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel/shuttle/white,
@@ -47658,9 +47659,13 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bPR" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
+/obj/machinery/button/flasher{
+	id = "cockpit_flasher";
+	pixel_x = 6;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/escape)
 "bPS" = (
 /obj/structure/cable{
 	icon_state = "0-4";
@@ -121810,7 +121815,7 @@ aCa
 aHR
 aJm
 cFG
-cFK
+bPR
 aNX
 aJn
 aKR

--- a/code/game/machinery/flasher.dm
+++ b/code/game/machinery/flasher.dm
@@ -23,13 +23,13 @@
 	density = 1
 
 /obj/machinery/flasher/New(loc, ndir = 0, built = 0)
-	..() // ..() is EXTREMELY IMPORTANT, never forget to add it
 	if(built)
 		dir = ndir
 		pixel_x = (dir & 3)? 0 : (dir == 4 ? -28 : 28)
 		pixel_y = (dir & 3)? (dir ==1 ? -28 : 28) : 0
 	else
 		bulb = new /obj/item/device/assembly/flash/handheld(src)
+	..() // ..() is EXTREMELY IMPORTANT, never forget to add it //Initializing variables defined in your object before calling the parent is, arguably, MORE IMPORTANT.
 
 /obj/machinery/flasher/Move()
 	remove_from_proximity_list(src, range)
@@ -43,7 +43,7 @@
 		else
 			icon_state = "[base_state]1"
 	else
-		stat |= ~NOPOWER
+		stat |= NOPOWER
 		icon_state = "[base_state]1-p"
 
 //Don't want to render prison breaks impossible


### PR DESCRIPTION
- Fixes a weird error made by me in #213 (due to Gift Vendor+Area being mapmerged into the Shuttle Cockpit, behind the comfy chair somehow);
- Fixes shuttle flashers having their icon changed to broken one due to proc call sequence break (`obj/machinery/New()` called `power_change()` BEFORE the bulb was initialized in flasher and since shuttle areas never call the proc again (since it's always powered), we have an issue of icon being set at roundstart and never updated thereafter) (#224)
- Fixes incorrect bitflag operation with `NOPOWER` in flasher's `power_change()` proc
