### PR TITLE
Improves GPS cluster

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/cargo.dm
@@ -11,6 +11,7 @@
 	new /obj/item/device/radio/headset/headset_cargo(src)
 	new /obj/item/clothing/suit/fire/firefighter(src)
 	new /obj/item/clothing/gloves/fingerless(src)
+	new /obj/item/device/gps/mining(src)
 	new /obj/item/device/megaphone/cargo(src)
 	new /obj/item/weapon/tank/internals/emergency_oxygen(src)
 	new /obj/item/clothing/mask/gas(src)

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -370,6 +370,12 @@
 	anchored = 1
 	density = 1
 	pixel_y = -32
+	channel = "lavaland"
+
+/obj/item/device/gps/computer/New()
+	..()
+	visible_message("[src] activates their tracking mechanism.")
+	tracking = TRUE
 
 /obj/item/device/gps/computer/attackby(obj/item/weapon/W, mob/user, params)
 	if(istype(W, /obj/item/weapon/wrench) && !(flags&NODECONSTRUCT))

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -30,7 +30,7 @@
 	deathmessage = "sinks into a pool of blood, fleeing the battle. You've won, for now... "
 	death_sound = 'sound/magic/enter_blood.ogg'
 
-/obj/item/device/gps/internal/bubblegum
+/obj/item/device/gps/internal/lavaland/bubblegum
 	icon_state = null
 	gpstag = "Bloody Signal"
 	desc = "You're not quite sure how a signal can be bloody."
@@ -73,7 +73,7 @@
 	AddSpell(bloodspell)
 	if(istype(loc, /obj/effect/dummy/slaughter))
 		bloodspell.phased = 1
-	new/obj/item/device/gps/internal/bubblegum(src)
+	new/obj/item/device/gps/internal/lavaland/bubblegum(src)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/AttackingTarget()
 	if(charging)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -71,7 +71,7 @@
 
 /mob/living/simple_animal/hostile/megafauna/colossus/New()
 	..()
-	internal = new/obj/item/device/gps/internal/colossus(src)
+	internal = new/obj/item/device/gps/internal/lavaland/colossus(src)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/Destroy()
 	qdel(internal)
@@ -277,7 +277,7 @@
 		target.ex_act(2)
 
 
-/obj/item/device/gps/internal/colossus
+/obj/item/device/gps/internal/lavaland/colossus
 	icon_state = null
 	gpstag = "Angelic Signal"
 	desc = "Get in the fucking robot."

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -37,7 +37,7 @@
 
 /mob/living/simple_animal/hostile/megafauna/dragon/New()
 	..()
-	internal = new/obj/item/device/gps/internal/dragon(src)
+	internal = new/obj/item/device/gps/internal/lavaland/dragon(src)
 
 /mob/living/simple_animal/hostile/megafauna/dragon/Destroy()
 	qdel(internal)
@@ -216,7 +216,7 @@
 		return
 	swoop_attack(1, A)
 
-/obj/item/device/gps/internal/dragon
+/obj/item/device/gps/internal/lavaland/dragon
 	icon_state = null
 	gpstag = "Fiery Signal"
 	desc = "Here there be dragons."

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -31,7 +31,7 @@
 
 /mob/living/simple_animal/hostile/megafauna/legion/New()
 	..()
-	new/obj/item/device/gps/internal/legion(src)
+	new/obj/item/device/gps/internal/lavaland/legion(src)
 
 /mob/living/simple_animal/hostile/megafauna/legion/OpenFire(the_target)
 	if(world.time >= ranged_cooldown && !charging)
@@ -97,7 +97,7 @@
 /mob/living/simple_animal/hostile/megafauna/legion/Process_Spacemove(movement_dir = 0)
 	return 1
 
-/obj/item/device/gps/internal/legion
+/obj/item/device/gps/internal/lavaland/legion
 	icon_state = null
 	gpstag = "Echoing Signal"
 	desc = "The message repeats."

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -991,7 +991,7 @@
 
 /mob/living/simple_animal/hostile/spawner/lavaland/New()
 	..()
-	gps = new /obj/item/device/gps/internal(src)
+	gps = new /obj/item/device/gps/internal/lavaland(src)
 
 /mob/living/simple_animal/hostile/spawner/lavaland/Destroy()
 	qdel(gps)

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -10,13 +10,13 @@ var/list/GPS_list = list()
 	var/gpstag = "COM0"
 	var/emped = 0
 	var/turf/locked_location
-	var/tracking = TRUE
+	var/tracking = FALSE
+	var/channel = "Common"
 
 /obj/item/device/gps/New()
 	..()
 	GPS_list.Add(src)
 	name = "global positioning system ([gpstag])"
-	overlays += "working"
 
 /obj/item/device/gps/Destroy()
 	GPS_list.Remove(src)
@@ -67,13 +67,15 @@ var/list/GPS_list = list()
 			var/turf/pos = get_turf(G)
 			var/area/gps_area = get_area(G)
 			var/tracked_gpstag = G.gpstag
+			if(channel != G.channel)
+				continue
 			if(G.emped == 1)
 				t += "<BR>[tracked_gpstag]: ERROR"
 			else if(G.tracking)
 				t += "<BR>[tracked_gpstag]: [format_text(gps_area.name)] ([pos.x], [pos.y], [pos.z])"
 			else
 				continue
-	var/datum/browser/popup = new(user, "GPS", name, 360, min(gps_window_height, 800))
+	var/datum/browser/popup = new(user, "GPS", name, 360, min(gps_window_height, 350))
 	popup.set_content(t)
 	popup.set_title_image(user.browse_rsc_icon(src.icon, src.icon_state))
 	popup.open()
@@ -91,22 +93,29 @@ var/list/GPS_list = list()
 /obj/item/device/gps/science
 	icon_state = "gps-s"
 	gpstag = "SCI0"
+	channel = "science"
 
 /obj/item/device/gps/engineering
 	icon_state = "gps-e"
 	gpstag = "ENG0"
+	channel = "engine"
 
 /obj/item/device/gps/mining
 	icon_state = "gps-m"
 	gpstag = "MINE0"
 	desc = "A positioning system helpful for rescuing trapped or injured miners, keeping one on you at all times while mining might just save your life."
+	channel = "lavaland"
 
 /obj/item/device/gps/internal
 	icon_state = null
 	flags = ABSTRACT
+	tracking = TRUE
 	gpstag = "Eerie Signal"
 	desc = "Report to a coder immediately."
 	invisibility = INVISIBILITY_MAXIMUM
+
+/obj/item/device/gps/internal/lavaland
+	channel = "lavaland"
 
 /obj/item/device/gps/mining/internal
 	icon_state = "gps-m"


### PR DESCRIPTION
So we have a problem with lavaland GPS's.
They are able to detect other GPS's in the world like the ones in paramedics lockers and science. Which is sorta ridiculous. It creates a lot of cluster when you want to look for something on your tracking list, and is really unnecessary.

All GPS's will now start turned off and have their own channel. So miners will no longer pick up signals from the paramedics room for no reason.

GPS computers will automatically be turned on when created.

The GPS window is also smaller.

![](http://image.prntscr.com/image/b076273289ce4ba0b759b6ebd12bf451.png)
#### Changelog

:cl: Super3222
rscadd: GPS's now carry their own channel depending on the department they're coming from. So now they won't be as clustered as they use to be.
rscadd: QM's locker now carries a mining GPS.
/:cl:
