### PR TITLE
The RSF now prints fake cash instead of real cash.

### DIFF
--- a/code/game/objects/items/stacks/cash.dm
+++ b/code/game/objects/items/stacks/cash.dm
@@ -18,6 +18,10 @@
 	desc = "It's worth 10 credits."
 	value = 10
 
+/obj/item/stack/spacecash/c10/fake
+	desc = "It's worth 10 cred- wait a minute... something's not right here. It smells like cheap paper."
+	value = 0
+
 /obj/item/stack/spacecash/c20
 	icon_state = "spacecash20"
 	desc = "It's worth 20 credits."

--- a/code/game/objects/items/weapons/RSF.dm
+++ b/code/game/objects/items/weapons/RSF.dm
@@ -81,7 +81,7 @@ RSF
 	switch(mode)
 		if(1)
 			user << "Dispensing Dosh..."
-			new /obj/item/stack/spacecash/c10(T)
+			new /obj/item/stack/spacecash/c10/fake(T)
 			use_matter(200, user)
 		if(2)
 			user << "Dispensing Drinking Glass..."


### PR DESCRIPTION
#232
#### Super3222

:cl:
tweak: Nanotrasen News Reporter, Timato Vegetable, is on the scene where the QM is being publicly arrested for commanding a service borg to print him an infinite amount of money to profit from cargo exports. Space Cash printed from service borgs has been officially legalized, and precautions have been taken place.
/:cl:
