### PR TITLE
Adminwho and Banning Panel fixes

### DIFF
--- a/code/modules/admin/DB_ban/functions.dm
+++ b/code/modules/admin/DB_ban/functions.dm
@@ -185,7 +185,7 @@
 	else
 		bantype_sql = "bantype = '[bantype_str]'"
 
-	var/sql = "SELECT id FROM [format_table_name("ban")] WHERE ckey = '[ckey]' AND [bantype_sql] AND (unbanned is null OR unbanned = false)"
+	var/sql = "SELECT id FROM [format_table_name("ban")] WHERE ckey = '[ckey]' AND [bantype_sql] AND (unbanned = 0)"
 	if(job)
 		sql += " AND job = '[job]'"
 
@@ -432,7 +432,7 @@
 			var/expiration = select_query.item[7]
 			var/ckey = select_query.item[8]
 			var/ackey = select_query.item[9]
-			var/unbanned = select_query.item[10]
+			var/unbanned = text2num(select_query.item[10]) //Even in integer, we are text
 			var/unbanckey = select_query.item[11]
 			var/unbantime = select_query.item[12]
 			var/edits = select_query.item[13]

--- a/code/modules/admin/DB_ban/functions.dm
+++ b/code/modules/admin/DB_ban/functions.dm
@@ -185,7 +185,7 @@
 	else
 		bantype_sql = "bantype = '[bantype_str]'"
 
-	var/sql = "SELECT id FROM [format_table_name("ban")] WHERE ckey = '[ckey]' AND [bantype_sql] AND (unbanned = 0)"
+	var/sql = "SELECT id FROM [format_table_name("ban")] WHERE ckey = '[ckey]' AND [bantype_sql] AND unbanned = 0"
 	if(job)
 		sql += " AND job = '[job]'"
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -16,7 +16,7 @@ var/list/admin_verbs_default = list(
 	/client/proc/secrets,
 	/client/proc/reload_admins,
 	/client/proc/adminwhotoggle,
-	/client/proc/adminwho,
+	// /client/proc/adminwho,
 	/client/proc/donor_ooc_admin,
 	/client/proc/reestablish_db_connection,/*reattempt a connection to the database*/
 	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/


### PR DESCRIPTION
- Adminwho remains even if you deadmin #241;
- Banning pannel now processes 'unbanned' var from DB correctly and shows the correct information on the panel (when you search for bans);
- Fixes a SQL query using `unbanned is null OR unbanned = false` to `unbanned = 0`
