### PR TITLE
Watcher rebalance

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -32,10 +32,11 @@
 #define IGNORESLOWDOWN	16
 #define GOTTAGOFAST	32
 #define GOTTAGOREALLYFAST	64
-#define GODMODE		4096
+#define SLOWDOWN		128
 #define FAKEDEATH	8192	//Replaces stuff like changeling.changeling_fakedeath
 #define DISFIGURED	16384	//I'll probably move this elsewhere if I ever get wround to writing a bitflag mob-damage system
 #define XENO_HOST	32768	//Tracks whether we're gonna be a baby alien's mummy.
+#define GODMODE		65536
 
 
 //Grab levels

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -967,6 +967,9 @@
 				if(!leg_amount)
 					. += 6 - 3*H.get_num_arms() //crawling is harder with fewer arms
 
+			if(H.status_flags & SLOWDOWN) //From bolamine, intended to replicate the slowdown of a 50K freeze blast.
+				. += 3
+
 
 			. += speedmod
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -68,8 +68,8 @@
 	maxHealth = 200
 	health = 200
 	harm_intent_damage = 5
-	melee_damage_lower = 15
-	melee_damage_upper = 15
+	melee_damage_lower = 13
+	melee_damage_upper = 13
 	attacktext = "bites into"
 	a_intent = "harm"
 	speak_emote = list("chitters")

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -57,7 +57,7 @@
 	icon_dead = "Basilisk_dead"
 	icon_gib = "syndicate_gib"
 	move_to_delay = 20
-	projectiletype = /obj/item/projectile/temp/basilisk
+	projectiletype = /obj/item/projectile/bullet/dart/basilisk
 	projectilesound = 'sound/weapons/pierce.ogg'
 	ranged = 1
 	ranged_message = "stares"
@@ -68,8 +68,8 @@
 	maxHealth = 200
 	health = 200
 	harm_intent_damage = 5
-	melee_damage_lower = 12
-	melee_damage_upper = 12
+	melee_damage_lower = 15
+	melee_damage_upper = 15
 	attacktext = "bites into"
 	a_intent = "harm"
 	speak_emote = list("chitters")
@@ -80,14 +80,14 @@
 	loot = list(/obj/item/weapon/ore/diamond{layer = ABOVE_MOB_LAYER},
 				/obj/item/weapon/ore/diamond{layer = ABOVE_MOB_LAYER})
 
-/obj/item/projectile/temp/basilisk
+/obj/item/projectile/bullet/dart/basilisk
 	name = "freezing blast"
 	icon_state = "ice_2"
-	damage = 0
-	damage_type = BURN
-	nodamage = 1
-	flag = "energy"
-	temperature = 50
+	nodamage = 1 //The darts don't do much damage, but it adds up (especially since you may get hit 20+ times assaulting a tendril)
+
+/obj/item/projectile/bullet/dart/basilisk/New()
+	..()
+	reagents.add_reagent("bolamine",5)
 
 /mob/living/simple_animal/hostile/asteroid/basilisk/GiveTarget(new_target)
 	if(..()) //we have a target

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -431,6 +431,7 @@ var/const/INJECT = 5 //injection
 			reagent_list -= R
 			update_total()
 			my_atom.on_reagent_change()
+			check_slowdown(my_atom)
 			check_ignoreslow(my_atom)
 			check_gofast(my_atom)
 			check_goreallyfast(my_atom)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -443,6 +443,14 @@ var/const/INJECT = 5 //injection
 		else
 			M.status_flags &= ~IGNORESLOWDOWN
 
+/datum/reagents/proc/check_slowdown(mob/M)  //SLOWDOWN is halfway in between GOTTAGOFAST and GOTTAGOREALLYFAST.  IGNORESLOWDOWN cancels it.
+	if(istype(M, /mob))
+		if(M.reagents.has_reagent("bolamine"))
+			return 1
+		else
+			M.status_flags &= ~SLOWDOWN
+
+
 /datum/reagents/proc/check_gofast(mob/M)
 	if(istype(M, /mob))
 		if(M.reagents.has_reagent("unholywater")||M.reagents.has_reagent("nuka_cola")||M.reagents.has_reagent("stimulants"))

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -143,6 +143,19 @@
 	..()
 	. = 1
 
+/datum/reagent/drug/bolamine  //Anti-meth.  Slows you down, does very gradual stamina damage.
+	name = "Bolamine"
+	id = "bolamine"
+	description = "A thick, blue liquid that non-harmfully slows down the victim.  In large quantities, destroys one's stamina.  Naturally produced by certain monsters."
+	reagent_state = LIQUID
+	color = "#3399FF"
+
+/datum/reagent/drug/bolamine/on_mob_life(mob/living/M)
+	M.adjustStaminaLoss(1, 0)
+	M.status_flags |= SLOWDOWN
+	..()
+	. = 1
+
 /datum/reagent/drug/methamphetamine
 	name = "Methamphetamine"
 	id = "methamphetamine"

--- a/code/modules/reagents/chemistry/recipes/drugs.dm
+++ b/code/modules/reagents/chemistry/recipes/drugs.dm
@@ -46,3 +46,10 @@
 	result = "aranesp"
 	required_reagents = list("epinephrine" = 1, "atropine" = 1, "morphine" = 1)
 	result_amount = 3
+
+/datum/chemical_reaction/bolamine
+	name= "bolamine"
+	id = "bolamine"
+	result = "bolamine"
+	required_reagents = list("space_drugs" = 2, "frostoil" = 1)
+	result_amount = 2


### PR DESCRIPTION
I'm not calling this a nerf, because by some metrics watchers actually become more dangerous, but that's effectively what it is.

NEW SHIT:
Bolamine, the slowdown chemical.  Bolamine is made by applying one part frost oil to two parts space drugs.  The frost oil is consumed, and the space drugs become bolamine.  Bolamine functions as 'reverse meth'; It slowly eats stamina, and causes a slowdown effect.  Bolamine's effect can be mitigated using stimpacks and meth, and completely negated (at least temporarily) by Ephedrine and morphine, as well as any other chemical that gives the 'NOSLOWDOWN' flag.

This PR also adds the SLOWDOWN flag for other chemicals to potentially use.

OLD SHIT:
Basilisks and watchers have had their freeze beam replaced by an organic dart containing 5u bolamine.  This negates their ranged damage potential, but makes their slowdown slightly more potent and far longer lasting (as well as adding a stamina damage element).  In order to compensate for their loss of ranged damage, basilisk and watcher melee has been buffed from 9 shots to kill to 7 (on an unarmored human).

WHAT THIS MEANS:
-Cabbages will get less powerful in mining, because other races no longer have to worry about regenerating 40 burn damage after every watcher encounter.
-Watcher tendrils should no longer be nearly unassailable (although they remain dangerous).
-People should now hoard less burn patches
-Watcher slowdowns last far longer (on the order of 10 minutes for a large group of them), necessitating more careful play and survival capsule usage.  This also makes it much harder to raid tendrils, necessitating the use of stimpacks and such.
-While not lethal in and of itself, the stamina stun that large amounts of bolamine can cause is incredibly lethal if there's no availible shelter.  This means that watchers remain the deadliest motherfuckers in space.

WHY IT'S NECCESARY:
Let's run down a list of mobs with ranged damage.
-Colossus (rediculous megabeast, powerful drop)
-Ash Drake (rediculous megabeast, powerful drop)
-Bubblegum (rediculous megabeast, powerful drop)
-Syndicate Agents (they have machine guns, usually guarding something powerful)
-Alien Sentinels (less powerful than watcher, guarding alien queen and some loot)
-Watcher (drops two sinew and a single bone)

One of these things is not like the others.

Other than that, watchers tend to have absurd hitscan aiming capabilities at close range (which is where you're fighting them 90% of the time) and necessitate doing stupid things like bringing an ore box to eat shots, or tanking them out until you go crit from the burn damage.

Finally, taking freezing damage in lavaland is fucking stupid.

:cl:
tweak: While studying the biology of slain Watchers, a Nanotrasen scientist realized that it should be impossible to freeze to death in the middle of Lavaland.  Shortly thereafter, all Watchers in Lavaland switched to firing organic darts filled with a natural muscle relaxant.
rscadd: Bolamine can now be produced in chemistry by reacting Frost Oil with Space Drugs.  It slows down the user, and drains their stamina.
/:cl:
