### PR TITLE
Ports ctrl+click functionality for demons

### DIFF
--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -1,8 +1,8 @@
 //////////////////The Monster
 
 /mob/living/simple_animal/slaughter
-	name = "slaughter demon"
-	real_name = "slaughter demon"
+	name = "Slaughter Demon"
+	real_name = "Slaughter Demon"
 	desc = "A large, menacing creature covered in armored black scales."
 	speak_emote = list("gurgles")
 	emote_hear = list("wails","screeches")
@@ -35,7 +35,7 @@
 	bloodcrawl = BLOODCRAWL_EAT
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	var/playstyle_string = "<B><font size=3 color='red'>You are a slaughter demon,</font> a terrible creature from another realm. You have a single desire: To kill.  \
-							You may use the \"Blood Crawl\" ability near blood pools to travel through them, appearing and disappearing from the station at will. \
+							You may use the \"Blood Crawl\" ability near blood pools or Ctrl+Clicking a tile that has blood on it to travel through them, appearing and disappearing from the station at will. \
 							Pulling a dead or unconscious mob while you enter a pool will pull them in with you, allowing you to feast and regain your health. \
 							You move quickly upon leaving a pool of blood, but the material world will soon sap your strength and leave you sluggish. </B>"
 
@@ -45,12 +45,12 @@
 	del_on_death = 1
 	deathmessage = "screams in anger as it collapses into a puddle of viscera!"
 
-/mob/living/simple_animal/slaughter/New()
+/*/mob/living/simple_animal/slaughter/New()
 	..()
 	var/obj/effect/proc_holder/spell/bloodcrawl/bloodspell = new
 	AddSpell(bloodspell)
 	if(istype(loc, /obj/effect/dummy/slaughter))
-		bloodspell.phased = 1
+		bloodspell.phased = 1*/
 
 /mob/living/simple_animal/slaughter/Life()
 	..()
@@ -88,11 +88,10 @@
 	user.visible_message("<span class='warning'>[user] raises [src] to their mouth and tears into it with their teeth!</span>", \
 						 "<span class='danger'>An unnatural hunger consumes you. You raise [src] your mouth and devour it!</span>")
 	playsound(user, 'sound/magic/Demon_consume.ogg', 50, 1)
-	for(var/obj/effect/proc_holder/spell/knownspell in user.mind.spell_list)
-		if(knownspell.type == /obj/effect/proc_holder/spell/bloodcrawl)
-			user <<"<span class='warning'>...and you don't feel any different.</span>"
-			qdel(src)
-			return
+	if(user.bloodcrawl == BLOODCRAWL)
+		user <<"<span class='warning'>...and you don't feel any different.</span>"
+		qdel(src)
+		return
 	user.visible_message("<span class='warning'>[user]'s eyes flare a deep crimson!</span>", \
 						 "<span class='userdanger'>You feel a strange power seep into your body... you have absorbed the demon's blood-travelling powers!</span>")
 	user.drop_item()
@@ -100,14 +99,11 @@
 
 /obj/item/organ/heart/demon/Insert(mob/living/carbon/M, special = 0)
 	..()
-	if(M.mind)
-		M.mind.AddSpell(new /obj/effect/proc_holder/spell/bloodcrawl(null))
+	M.bloodcrawl = BLOODCRAWL
 
 /obj/item/organ/heart/demon/Remove(mob/living/carbon/M, special = 0)
 	..()
-	if(M.mind)
-		M.mind.RemoveSpell(/obj/effect/proc_holder/spell/bloodcrawl)
-
+	M.bloodcrawl = 0
 /obj/item/organ/heart/demon/Stop()
 	return 0 // Always beating.
 

--- a/code/modules/mob/living/bloodcrawl.dm
+++ b/code/modules/mob/living/bloodcrawl.dm
@@ -25,26 +25,28 @@
 
 
 /mob/living/proc/phaseout(obj/effect/decal/cleanable/B)
-	if(iscarbon(src))
-		var/mob/living/carbon/C = src
-		if(C.l_hand || C.r_hand)
-			//TODO make it toggleable to either forcedrop the items, or deny
-			//entry when holding them
-			// literally only an option for carbons though
-			C << "<span class='warning'>You may not hold items while blood crawling!</span>"
-			return 0
-		var/obj/item/weapon/bloodcrawl/B1 = new(C)
-		var/obj/item/weapon/bloodcrawl/B2 = new(C)
-		B1.icon_state = "bloodhand_left"
-		B2.icon_state = "bloodhand_right"
-		C.put_in_hands(B1)
-		C.put_in_hands(B2)
-		C.regenerate_icons()
-	src.notransform = TRUE
-	spawn(0)
-		bloodpool_sink(B)
-		src.notransform = FALSE
-	return 1
+	var/turf/bloodloc = get_turf(B.loc)
+	if(Adjacent(bloodloc))
+		if(iscarbon(src))
+			var/mob/living/carbon/C = src
+			if(C.l_hand || C.r_hand)
+				//TODO make it toggleable to either forcedrop the items, or deny
+				//entry when holding them
+				// literally only an option for carbons though
+				C << "<span class='warning'>You may not hold items while blood crawling!</span>"
+				return 0
+			var/obj/item/weapon/bloodcrawl/B1 = new(C)
+			var/obj/item/weapon/bloodcrawl/B2 = new(C)
+			B1.icon_state = "bloodhand_left"
+			B2.icon_state = "bloodhand_right"
+			C.put_in_hands(B1)
+			C.put_in_hands(B2)
+			C.regenerate_icons()
+		src.notransform = TRUE
+		spawn(0)
+			bloodpool_sink(B)
+			src.notransform = FALSE
+		return 1
 
 /mob/living/proc/bloodpool_sink(obj/effect/decal/cleanable/B)
 	var/turf/mobloc = get_turf(src.loc)
@@ -159,11 +161,6 @@
 	if(src.notransform)
 		src << "<span class='warning'>Finish eating first!</span>"
 		return 0
-	B.visible_message("<span class='warning'>[B] starts to bubble...</span>")
-	if(!do_after(src, 20, target = B))
-		return
-	if(!B)
-		return
 	src.loc = B.loc
 	src.client.eye = src
 	src.visible_message("<span class='warning'><B>[src] rises out of the pool of blood!</B>")

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -198,6 +198,8 @@ Sorry Giacom. Please don't be mad :(
 
 	if(istype(AM) && AM.Adjacent(src))
 		start_pulling(AM)
+	else if(bloodcrawl == BLOODCRAWL_EAT) //so demons can ctrl + click tiles to teleport to them
+		return
 	else
 		stop_pulling()
 

--- a/code/modules/spells/spell_types/bloodcrawl.dm
+++ b/code/modules/spells/spell_types/bloodcrawl.dm
@@ -13,7 +13,7 @@
 	action_background_icon_state = "bg_demon"
 	var/phased = 0
 
-/obj/effect/proc_holder/spell/bloodcrawl/choose_targets(mob/user = usr)
+/*/obj/effect/proc_holder/spell/bloodcrawl/choose_targets(mob/user = usr)
 	for(var/obj/effect/decal/cleanable/target in range(range, get_turf(user)))
 		if(target.can_bloodcrawl_in())
 			perform(target)
@@ -23,7 +23,7 @@
 
 /obj/effect/proc_holder/spell/bloodcrawl/perform(obj/effect/decal/cleanable/target, recharge = 1, mob/living/user = usr)
 	if(istype(user))
-		if(phased)
+		if(phased == 1)
 			if(user.phasein(target))
 				phased = 0
 		else
@@ -32,4 +32,35 @@
 		start_recharge()
 		return
 	revert_cast()
-	user << "<span class='warning'>You are unable to blood crawl!</span>"
+	user << "<span class='warning'>You are unable to blood crawl!</span>"*/
+
+/obj/effect/decal/cleanable/blood/CtrlClick(mob/living/user)
+	..()
+	if(user.bloodcrawl)
+		if(user.holder)
+			user.phasein(src)
+		else
+			user.phaseout(src)
+
+
+/obj/effect/decal/cleanable/trail_holder/CtrlClick(mob/living/user)
+	..()
+	if(user.bloodcrawl)
+		if(user.holder)
+			user.phasein(src)
+		else
+			user.phaseout(src)
+
+
+
+/turf/CtrlClick(var/mob/living/user)
+	if(user.bloodcrawl)
+		for(var/obj/effect/decal/cleanable/B in src.contents)
+			if(istype(B, /obj/effect/decal/cleanable/blood) || istype(B, /obj/effect/decal/cleanable/trail_holder))
+				if(user.holder)
+					user.phasein(B)
+					break
+				else
+					user.phaseout(B)
+					break
+	..()


### PR DESCRIPTION
Adds back slaughter demons being able to instantly get in and out of blood puddles by ctrl + clicking a puddle of blood or a turf that has blood on it. This should in theory make them _much_ stronger because they don't need to wave their mouse around everywhere. Also removes the blood bubbling before they pop out because it was irritating in my opinion.

:cl: ShadowDeath6
rscadd: Slaughter Demons can now use Ctrl + Click shortcut to quickly jaunt in and out of blood.
rscdel: Removed the Blood Crawl spell in favor of Ctrl + Click.
tweak: Slaughter Demons now instantly emerge from blood puddles.
/:cl:
