### PR TITLE
Misc Fixes

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -152,9 +152,6 @@ var/list/airlock_overlays = list()
 			return
 	..()
 
-/obj/machinery/door/airlock/bumpopen(mob/living/simple_animal/user)
-	..()
-
 /obj/machinery/door/airlock/proc/isElectrified()
 	if(src.secondsElectrified != 0)
 		return 1

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -61,6 +61,10 @@
 	if(istype(AM, /obj/mecha))
 		var/obj/mecha/mecha = AM
 		if(density)
+			if(mecha.occupant)
+				if(world.time - mecha.occupant.last_bumped <= 10)
+					return
+				mecha.occupant.last_bumped = world.time
 			if(mecha.occupant && (src.allowed(mecha.occupant) || src.check_access_list(mecha.operation_req_access) || emergency == 1))
 				open()
 			else

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -371,6 +371,10 @@
 //This proc is called when you want to place an item into the storage item.
 /obj/item/weapon/storage/attackby(obj/item/W, mob/user, params)
 	..()
+	if(istype(W, /obj/item/weapon/hand_labeler))
+		var/obj/item/weapon/hand_labeler/labeler = W
+		if(labeler.mode)
+			return 0
 	. = 1 //no afterattack
 	if(isrobot(user))
 		return	//Robots can't interact with storage items.

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -80,6 +80,10 @@
 /obj/structure/bodycontainer/container_resist()
 	open()
 
+/obj/structure/bodycontainer/relay_container_resist(mob/living/user, obj/O)
+	user << "<span class='notice'>You slam yourself into the side of [O].</span>"
+	container_resist()
+
 /obj/structure/bodycontainer/proc/open()
 	playsound(src.loc, 'sound/items/Deconstruct.ogg', 50, 1)
 	var/turf/T = get_step(src, opendir)

--- a/code/modules/recycling/sortingmachinery.dm
+++ b/code/modules/recycling/sortingmachinery.dm
@@ -54,7 +54,7 @@
 		return
 	user << "<span class='notice'>You lean on the back of [O] and start pushing to rip the wrapping around it.</span>"
 	if(do_after(user, 50, target = O))
-		if(!user || user.stat != CONSCIOUS || user.loc != src || O.loc != src )
+		if(!user || user.stat != CONSCIOUS || user.loc != O || O.loc != src )
 			return
 		user << "<span class='notice'>You successfully removed [O]'s wrapping !</span>"
 		O.loc = loc


### PR DESCRIPTION
Fixed hand labelers being unable to label storage items. 
Fixed being unable to resist out of wrapped lockers.
Fixed being unable to resist out of lockers inside morgues.
Fixed mechs being able to spam doors they do not have access to. Fixes #216.

:cl:
bugfix: Hand labelers can now label storage containers.
bugfix: You can now properly resist out of wrapped lockers.
bugfix: You can now resist out of morgues if you are in a bodybag.
bugfix: Mechs can no longer spam doors they do not have access to.
/:cl:
