### PR TITLE
Making miners' lives easier and encouraging them to do their job

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -167,23 +167,25 @@
 	//Mining hardsuit
 /obj/item/clothing/head/helmet/space/hardsuit/mining
 	name = "mining hardsuit helmet"
-	desc = "A special helmet designed for work in a hazardous, low pressure environment. Has reinforced plating for wildlife encounters and dual floodlights."
+	desc = "A special helmet designed for work in a hazardous, low pressure environment. Has reinforced plating for wildlife encounters and ash storms. Has dual floodlights on the helmet."
 	icon_state = "hardsuit0-mining"
 	item_state = "mining_helm"
 	item_color = "mining"
 	armor = list(melee = 30, bullet = 5, laser = 10, energy = 5, bomb = 50, bio = 100, rad = 50)
 	brightness_on = 7
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals, /obj/item/weapon/resonator, /obj/item/device/mining_scanner, /obj/item/device/t_scanner/adv_mining_scanner, /obj/item/weapon/gun/energy/kinetic_accelerator)
+	max_heat_protection_temperature = FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT
 
 
 /obj/item/clothing/suit/space/hardsuit/mining
 	icon_state = "hardsuit-mining"
 	name = "mining hardsuit"
-	desc = "A special suit that protects against hazardous, low pressure environments. Has reinforced plating for wildlife encounters."
+	desc = "A special suit that protects against hazardous, low pressure environments. Has reinforced plating for wildlife encounters and ash storms."
 	item_state = "mining_hardsuit"
 	armor = list(melee = 30, bullet = 5, laser = 10, energy = 5, bomb = 50, bio = 100, rad = 50)
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals,/obj/item/weapon/storage/bag/ore,/obj/item/weapon/pickaxe)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/mining
+	max_heat_protection_temperature = FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT
 
 
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -10,7 +10,7 @@
 
 /obj/structure/closet/crate/necropolis/tendril/New()
 	..()
-	var/loot = rand(1,25)
+	var/loot = rand(1,26)
 	switch(loot)
 		if(1)
 			new /obj/item/device/shared_storage/red(src)
@@ -33,7 +33,7 @@
 		if(9)
 			new /obj/item/organ/brain/alien(src)
 		if(10)
-			new /obj/item/organ/heart/cursed/wizard(src)
+			new /obj/item/organ/heart/cursed(src)
 		if(11)
 			new /obj/item/ship_in_a_bottle(src)
 		if(12)
@@ -65,6 +65,8 @@
 			new /obj/item/clothing/suit/space/hardsuit/ert/paranormal/inquisitor(src)
 		if(25)
 			new /obj/item/weapon/spellbook/oneuse/summonitem(src)
+		if(26)
+			new /obj/item/organ/heart/cursed/wizard(src)
 
 
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -33,7 +33,7 @@
 		if(9)
 			new /obj/item/organ/brain/alien(src)
 		if(10)
-			new /obj/item/organ/heart/cursed(src)
+			new /obj/item/organ/heart/cursed/wizard(src)
 		if(11)
 			new /obj/item/ship_in_a_bottle(src)
 		if(12)

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -32,7 +32,6 @@
 		new /datum/data/mining_equipment("Silver Pickaxe",		/obj/item/weapon/pickaxe/silver,				                  		1000),
 		new /datum/data/mining_equipment("Jetpack Upgrade",		/obj/item/hardsuit_jetpack,	              								2000),
 		new /datum/data/mining_equipment("Space Cash",    		/obj/item/stack/spacecash/c1000,                    			  		2000),
-		new /datum/data/mining_equipment("Mining Hardsuit",		/obj/item/clothing/suit/space/hardsuit/mining,				            2000),
 		new /datum/data/mining_equipment("Diamond Pickaxe",		/obj/item/weapon/pickaxe/diamond,				                  		2000),
 		new /datum/data/mining_equipment("Super Resonator",     /obj/item/weapon/resonator/upgraded,                              		2500),
 		new /datum/data/mining_equipment("Super Accelerator",	/obj/item/weapon/gun/energy/kinetic_accelerator/super,			  		3000),
@@ -42,6 +41,7 @@
 		new /datum/data/mining_equipment("Drone Health Upgrade",/obj/item/device/mine_bot_ugprade/health,      			   	       		400),
 		new /datum/data/mining_equipment("Drone Ranged Upgrade",/obj/item/device/mine_bot_ugprade/cooldown,      			   	   		600),
 		new /datum/data/mining_equipment("Drone AI Upgrade",    /obj/item/slimepotion/sentience/mining,      			   	      		1000),
+		new /datum/data/mining_equipment("Mining Hardsuit",		/obj/item/clothing/suit/space/hardsuit/mining,				            4000),
 		)
 
 /datum/data/mining_equipment/


### PR DESCRIPTION
Makes the miner hardsuit have a use, it's now ashproof and fireproof. Price has been doubled to 4000 points to reflect this. 
HOPEFULLY this actually makes miners want to mine ore for science instead of exploring for the entire shift, and 4000 points means miners need to bring in a good amount of ore if they want to be ashproof. 
Reminder that this does not protect against lava in any way, but it protects against ash and plasma fire. 

Also, makes the cursed heart drop from necropolis chests actually worth getting, as it's now the wizard version which heals you every pump and is a bit more lenient on the death part. One, this makes an item found from killing a difficult tendril worth using (unless it's a legion tendril I guess), while still keeping with the challenge of lavaland since you need to multitask pump for your heals. There are more powerful items than it, it certainly wouldn't be unbalanced.

:cl: ShadowDeath6
rscadd: NanoTrasen has realized that their hardsuits could be put to better use in the newfound Lavaland, and they have adapted them with fireproof plating to weather the ash storms there. Note that NanoTrasen has not spared the expense to make them lavaproof. Its price has been adjusted accordingly.
tweak: The wizard variant of the cursed heart, that heals the user, now has a chance to spawn in necropolis chests along with the original that does not posses healing traits.
/:cl:
