### PR TITLE
Fixes random dark turfs

### DIFF
--- a/code/modules/lighting/lighting_system.dm
+++ b/code/modules/lighting/lighting_system.dm
@@ -308,6 +308,7 @@
 		lighting_changed = 0
 		if(lighting_object)
 			lighting_object.alpha = 0
+			qdel(lighting_object)
 			lighting_object = null
 	else
 		if(!lighting_object)


### PR DESCRIPTION
This was causing turfs changed at world init from a no lighting system turf to a turf that used the lighting system to have two lighting overlays, one randomly stuck at black depending on timing. 
