### PR TITLE
Ported Yogstation darkvision

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling_items.dm
+++ b/code/game/gamemodes/shadowling/shadowling_items.dm
@@ -79,34 +79,13 @@
 	item_state = null
 	origin_tech = null
 	vision_flags = SEE_MOBS
-	darkness_view = 1
+	darkness_view = 8
 	invis_view = 2
 	flash_protect = -1
 	unacidable = 1
-	actions_types = list(/datum/action/item_action/hands_free/shift_nerves)
 	var/max_darkness_view = 8
 	var/min_darkness_view = 0
 	flags = ABSTRACT | NODROP
-
-/obj/item/clothing/glasses/night/shadowling/attack_self(mob/user)
-	if(!ishuman(user))
-		return
-	var/mob/living/carbon/human/H = user
-	if(H.dna.species.id != "shadowling")
-		user << "<span class='warning'>You aren't sure how to do this...</span>"
-		return
-	H.dna.species.darksight = 0 //so our species' vision in the dark doesn't interfere.
-	var/new_dark_view
-	new_dark_view = (input(user, "Enter the radius of tiles to see with night vision.", "Night Vision", "[new_dark_view]") as num)
-	new_dark_view = Clamp(new_dark_view,min_darkness_view,max_darkness_view)
-	switch(new_dark_view)
-		if(0)
-			user << "<span class='notice'>Your night vision capabilities fade away for the time being.</span>"
-		else
-			user << "<span class='notice'>You shift your night vision capabilities to see [new_dark_view] tiles away.</span>"
-	darkness_view = new_dark_view
-	user.update_sight()
-
 
 //Thrall organ that is responsible for person becoming/unbecoming a thrall
 /obj/item/organ/thrall_tumor

--- a/code/modules/lighting/lighting_system.dm
+++ b/code/modules/lighting/lighting_system.dm
@@ -254,10 +254,17 @@
 /atom/movable/light/Move()
 	return 0
 
+/atom/movable/light/dim
+	color = "#000" // Always half bright.
+	alpha = 0 // Only visible when the tile it's on is ~pure black.
+	invisibility = 0 // Never invisible. Might be a bit annoying for observers. Might.
+	layer = TURF_LAYER // Don't darken things on top of the turf.
+
 /turf
 	var/lighting_lumcount = 0
 	var/lighting_changed = 0
 	var/atom/movable/light/lighting_object //Will be null for space turfs and anything in a static lighting area
+	var/atom/movable/light/dim/light_dim  // Used for shadowlings and night vision and stuffs, to show pure black areas, but make them still visible... So to speak...
 	var/list/affecting_lights			//not initialised until used (even empty lists reserve a fair bit of memory)
 
 /turf/ChangeTurf(path)
@@ -313,6 +320,8 @@
 	else
 		if(!lighting_object)
 			lighting_object = new (src)
+		if(!light_dim)
+			light_dim = new (src)
 		redraw_lighting(1)
 
 /turf/open/space/init_lighting()
@@ -341,6 +350,7 @@
 			if(newalpha >= LIGHTING_DARKEST_VISIBLE_ALPHA)
 				luminosity = 0
 				lighting_object.luminosity = 0
+		light_dim.alpha = (get_lumcount() <= 0.3) * 128 // We're only visible if the lighting lumcount is less than what shadowlings can walk through.
 
 	lighting_changed = 0
 


### PR DESCRIPTION
:cl:
rscadd: Ported Yogstation's ability for mobs with darkvision to see if tiles are completely dark.
/:cl:

Also removed annoying shadowling darkvision.
