### PR TITLE
Fixes space bartenders

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -386,7 +386,7 @@
 	glasses = /obj/item/clothing/glasses/sunglasses/reagent
 	has_id = 1
 	id_job = "Bartender"
-	id_access = "Bartender"
+	id_access = "Space Bartender"
 
 /obj/effect/mob_spawn/human/bartender/alive
 	death = FALSE

--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -124,6 +124,10 @@ Bartender
 	backpack_contents = list(/obj/item/weapon/storage/box/beanbag=1)
 	shoes = /obj/item/clothing/shoes/laceup
 
+/datum/job/bartender/space
+	title = "Space Bartender"
+	minimal_access = list(access_bar, access_kitchen)
+
 /*
 Cook
 */


### PR DESCRIPTION
EDIT by X-TheDark : use `fixes #number` as it will autoclose the issue when this is merged
fixes #132
Pr: Space Bartenders now have access to the kitchen so they can open kitchen cabinets.

:cl: Super3222
bugfix: Space Bartenders now have access to the kitchen! Remember these are bartenders from away missions.
/:cl:
