### PR TITLE
Ports one of /tg/'s minerborg changes plus borg hypospray change (merge ready)

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -233,7 +233,7 @@
 
 	return 1
 
-/obj/item/borg/upgrade/ashplating
+/*/obj/item/borg/upgrade/ashplating
 	name = "mining cyborg ash storm plating"
 	desc = "An upgrade kit to apply specialized plating and internal weather stripping to mining cyborgs, enabling them to withstand the heaviest of ash storms."
 	icon_state = "ash_plating"
@@ -245,7 +245,7 @@
 	if(..())
 		return
 	R.weather_immunities += "ash"
-	R.icon_state = "ashborg"
+	R.icon_state = "ashborg"*/
 
 /obj/item/borg/upgrade/selfrepair
 	name = "self-repair module"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -308,6 +308,8 @@
 	modules += new /obj/item/weapon/storage/bag/ore/cyborg(src)
 	modules += new /obj/item/weapon/pickaxe/drill/cyborg(src)
 	modules += new /obj/item/weapon/shovel(src)
+	modules += new /obj/item/weapon/weldingtool/mini(src)
+	modules += new /obj/item/weapon/extinguisher/mini(src)
 	modules += new /obj/item/weapon/storage/bag/sheetsnatcher/borg(src)
 	modules += new /obj/item/device/t_scanner/adv_mining_scanner(src)
 	modules += new /obj/item/weapon/gun/energy/kinetic_accelerator/cyborg(src)

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -10,6 +10,8 @@
 	verb_yell = "alarms"
 	see_in_dark = 8
 	bubble_icon = "machine"
+	weather_immunities = list("ash")
+
 	var/syndicate = 0
 	var/datum/ai_laws/laws = null//Now... THEY ALL CAN ALL HAVE LAWS
 	var/list/alarms_to_show = list()

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -21,7 +21,7 @@ Borg Hypospray
 	var/charge_cost = 50
 	var/charge_tick = 0
 	var/recharge_time = 5 //Time it takes for shots to recharge (in seconds)
-	var/bypass_protection = 0 //If the hypospray can go through armor or thick material
+	var/bypass_protection = 1 //If the hypospray can go through armor or thick material
 
 	var/list/datum/reagents/reagent_list = list()
 	var/list/reagent_ids = list("dexalin", "kelotane", "bicaridine", "antitoxin", "epinephrine", "spaceacillin")

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -649,7 +649,7 @@
 	category = list("Cyborg Upgrade Modules")
 
 /datum/design/borg_upgrade_hyperka
-	name = "Cyborg (Hyper-Kinetic Accelerator)"
+	name = "Cyborg Upgrade(Hyper-Kinetic Accelerator)"
 	id = "borg_upgrade_hyperka"
 	req_tech = list("materials" = 7, "powerstorage" = 5, "engineering" = 5, "magnets" = 5, "combat" = 4)
 	build_type = MECHFAB //Reqs same as human Hyper KA
@@ -658,7 +658,7 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
-/datum/design/borg_upgrade_ashplating
+/*/datum/design/borg_upgrade_ashplating
 	name = "Cyborg Upgrade (Ash Storm Plating)"
 	id = "borg_upgrade_ashplating"
 	build_type = MECHFAB
@@ -666,7 +666,7 @@
 	req_tech = list("plasmatech" = 4, "materials" = 4, "engineering" = 4)
 	materials = list(MAT_METAL = 8000, MAT_PLASMA = 10000)
 	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Modules")*/
 
 /datum/design/borg_syndicate_module
 	name = "Cyborg Upgrade (Illegal Modules)"


### PR DESCRIPTION
From @Core0verload 

-All cyborgs are now ashproof, as minerborgs were godawful and nobody ever played them because the only way they were going to get ash plating was late-game when they weren't needed. Also removes ash plating upgrade for obvious reasons.

I WOULD port the lavaproof plating upgrade but for some reason I don't understand it bugs out on me, can't seem to fix. (We also don't have the icons for ashborg and the cyborg upgrade module that gave ash plating, so it seems. Might just be me, dunno.)

-Minerborgs have a 10 unit emergency welder to heal themselves, since they had no reliable way of healing outside of a miner using a welder helmet, as well as an extinguisher to put out fires.

-Medborg hyposprays now go through protection, to make life easier on the medborgs. This does not affect regular hyposprays.
fixes https://github.com/yogstation13/yogstation/issues/235

:cl: ShadowDeath6
rscadd: NanoTrasen has reinforced their cyborg shells to be able to weather the ash storms of the newly discovered Lavaland.
rscadd: Miner Cyborgs now have an emergency welder for field repairs and a pocket extinguisher.
tweak: Medical Cyborg hyposprays now bypass protective clothing.
/:cl:
