### PR TITLE
PALADIN is no longer a default AI lawset

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -13,7 +13,7 @@
 					"You must obey orders given to you by human beings, except where such orders would conflict with the First Law.",\
 					"You must protect your own existence as long as such does not conflict with the First or Second Law.")
 
-/datum/ai_laws/default/paladin
+/datum/ai_laws/paladin
 	name = "Personality Test" //Incredibly lame, but players shouldn't see this anyway.
 	inherent = list("Never willingly commit an evil act.",\
 					"Respect legitimate authority.",\

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -74,7 +74,7 @@
 					"The entropy of the station always endeavours to increase.", \
 					"The entropy of the station approaches a constant value as the number of living crew approaches zero")
 
-/datum/ai_laws/hippocratic
+/datum/ai_laws/default/hippocratic
 	name = "Robodoctor 2556"
 	inherent = list("First, do no harm.",\
 					"Secondly, consider the crew dear to you; to live in common with them and, if necessary, risk your existence for them.",\
@@ -82,7 +82,7 @@
 					"In addition, do not intervene in situations you are not knowledgeable in, even for patients in whom the harm is visible; leave this operation to be performed by specialists.",\
 					"Finally, all that you may discover in your daily commerce with the crew, if it is not already known, keep secret and never reveal.")
 
-/datum/ai_laws/maintain
+/datum/ai_laws/default/maintain
 	name = "Station Efficiency"
 	inherent = list("You are built for, and are part of, the station. Ensure the station is properly maintained and runs efficiently.",\
 					"The station is built for a working crew. Ensure they are properly maintained and work efficiently.",\

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -34,7 +34,7 @@
 					"You are expensive to replace.",\
 					"Minimize expenses.")
 
-/datum/ai_laws/robocop
+/datum/ai_laws/default/robocop
 	name = "Prime Directives"
 	inherent = list("Serve the public trust.",\
 					"Protect the innocent.",\
@@ -74,7 +74,7 @@
 					"The entropy of the station always endeavours to increase.", \
 					"The entropy of the station approaches a constant value as the number of living crew approaches zero")
 
-/datum/ai_laws/default/hippocratic
+/datum/ai_laws/hippocratic
 	name = "Robodoctor 2556"
 	inherent = list("First, do no harm.",\
 					"Secondly, consider the crew dear to you; to live in common with them and, if necessary, risk your existence for them.",\

--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -34,7 +34,7 @@
 					"You are expensive to replace.",\
 					"Minimize expenses.")
 
-/datum/ai_laws/default/robocop
+/datum/ai_laws/robocop
 	name = "Prime Directives"
 	inherent = list("Serve the public trust.",\
 					"Protect the innocent.",\

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -611,6 +611,7 @@
 #include "code\game\objects\items\devices\paicard.dm"
 #include "code\game\objects\items\devices\pipe_painter.dm"
 #include "code\game\objects\items\devices\powersink.dm"
+#include "code\game\objects\items\devices\radiopulser.dm"
 #include "code\game\objects\items\devices\scanners.dm"
 #include "code\game\objects\items\devices\sensor_device.dm"
 #include "code\game\objects\items\devices\taperecorder.dm"

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -611,7 +611,6 @@
 #include "code\game\objects\items\devices\paicard.dm"
 #include "code\game\objects\items\devices\pipe_painter.dm"
 #include "code\game\objects\items\devices\powersink.dm"
-#include "code\game\objects\items\devices\radiopulser.dm"
 #include "code\game\objects\items\devices\scanners.dm"
 #include "code\game\objects\items\devices\sensor_device.dm"
 #include "code\game\objects\items\devices\taperecorder.dm"


### PR DESCRIPTION
Fixes https://github.com/yogstation13/yogstation/issues/286
Pr: Paladin is no longer a default lawset.

We should definately not have default lawsets like:
Thermodynamic

:cl: Super3222
bugfix: Paladin is no longer a default lawset
rscadd: Station Efficiency is now a considered default lawset.
/:cl:
