### PR TITLE
More Misc Fixes

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -31,6 +31,7 @@
 
 	if(!C.handcuffed)
 		if(C.get_num_arms() >= 2)
+			add_logs(user, C, "attempted to handcuff")
 			C.visible_message("<span class='danger'>[user] is trying to put [src.name] on [C]!</span>", \
 								"<span class='userdanger'>[user] is trying to put [src.name] on [C]!</span>")
 

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -140,4 +140,6 @@
 			K.visible_message("<span class='notice'>The Killer Tomato growls as it suddenly awakens.</span>")
 			if(user)
 				user.unEquip(src)
+				user.attack_log += "\[[time_stamp()]\] <b>[user.real_name]/[user.ckey]</b> awakened a killer tomato."
+				K.spawnedBy = "[user.real_name]([user.ckey])"
 			qdel(src)

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -671,6 +671,7 @@
 
 /obj/machinery/hydroponics/attackby(obj/item/O, mob/user, params)
 	//Called when mob user "attacks" it with object O
+	add_fingerprint(user)
 	if(istype(O, /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosia/gaia)) //Checked early on so it doesn't have to deal with composting checks
 		if(self_sustaining)
 			user << "<span class='warning'>This [name] is already self-sustaining!</span>"
@@ -857,6 +858,7 @@
 /obj/machinery/hydroponics/attack_hand(mob/user)
 	if(istype(user, /mob/living/silicon))		//How does AI know what plant is?
 		return
+	add_fingerprint(user)
 	if(harvest)
 		myseed.harvest()
 	else if(dead)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -430,7 +430,7 @@
 			if(C.wear_mask)
 				C << "<span class='notice'>It's pretty hard to drink something with a mask on!</span>"
 			else
-				if(ishumanbasic(C)) //implying xenoshumans are holy
+				if(!ishumanbasic(C)) //implying xenoshumans are holy
 					C << "<span class='notice'>You down the elixir, noting nothing else but a terrible aftertaste.</span>"
 				else
 					C << "<span class='userdanger'>You down the elixir, a terrible pain travels down your back as wings burst out!</span>"

--- a/code/modules/mob/living/simple_animal/hostile/killertomato.dm
+++ b/code/modules/mob/living/simple_animal/hostile/killertomato.dm
@@ -24,3 +24,4 @@
 	minbodytemp = 150
 	maxbodytemp = 500
 	gold_core_spawnable = 1
+	var/spawnedBy = null


### PR DESCRIPTION
Activating killer tomatos is now logged in the tomato mob and the person who activated it.
Wing potions now properly only work on humans. Fixes #296
Hydroponics trays now take fingerprints from people who use them.
Attempting to handcuff someone is now logged.
