### PR TITLE
Changeling Improvements

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -346,7 +346,7 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 			return
 	if(!target)
 		return
-	if((target.disabilities & NOCLONE) || (target.disabilities & HUSK))
+	if((target.disabilities & NOCLONE)/* || (target.disabilities & HUSK)*/)//Husk absorption, to prevent redtext due to people spacing themselves.
 		if(verbose)
 			user << "<span class='warning'>DNA of [target] is ruined beyond usability!</span>"
 		return

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -186,7 +186,12 @@
 		user.mind.changeling.remove_profile(target)
 		user.mind.changeling.absorbedcount--
 		user << "<span class='notice'>We refresh our DNA information on [target]!</span>"
-	user.mind.changeling.add_new_profile(target, user)
+	var/protect = 0 //Should the system be prevented from automatically replacing this DNA?
+	for(var/datum/objective/escape/escape_with_identity/ewi in user.mind.objectives)
+		if(ewi.target == target.mind)
+			protect = 1
+			break
+	user.mind.changeling.add_new_profile(target, user, protect)
 	feedback_add_details("changeling_powers","ED")
 	return 1
 


### PR DESCRIPTION
I had put off making a fix for this stuff because I assumed that /TG/ had already fixed these very old and obnoxious bugs, but I guess that rolling changeling is rare enough that nobody bothered.
### LINGS CAN ABSORB HUSKS

Husks still have some blood, which is presumably where they get the DNA from.  Therefore, it makes no sense to prevent lings from absorbing husks.  Note, this still prevents lings from just DNA stinging the husk.  It requires a full absorb.
##### BUT WHY

Because finding your target husked by space on the solars 30 minutes into the round is obnoxous.  Allowing ling targets to redtext their hunters by flinging themselves out an airlock is shit, and it's always been shit, and it always will be shit.  Same thing with accidentally burning to death in lavaland.  That husks the body in about 30 seconds.  Get to it after that, you're SOL and get a redtext.
### LING DNA STORAGE WILL NO LONGER AUTOMATICALLY DELETE THE DNA OF IMPERSONATION TARGETS

Very straightforward.  Now, if you immediately absorb your impersonation target and chuck them into space, that appearance won't get pushed out by Faceless Greytider #527's clueless mug.
# Remember kids, there is no better way to get a coder to fix a bug than to destroy his round with it!
