### PR TITLE
Misc Tweaks

### DIFF
--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -24,17 +24,17 @@
 	update_icon()
 
 /obj/item/device/taperecorder/AltClick()
-	..()
 	eject(usr)
 
 /obj/item/device/taperecorder/CtrlClick()
-	..()
 	play(usr)
 
 
 /obj/item/device/taperecorder/examine(mob/user)
 	..()
 	user << "The wire panel is [open_panel ? "opened" : "closed"]."
+	user << "Hold ALT and click on the tape recorder to eject the tape."
+	user << "Hold CTRL and click on the tape recorder to p-p-p-play that shit."
 
 
 /obj/item/device/taperecorder/attackby(obj/item/I, mob/user, params)

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -23,6 +23,14 @@
 	mytape = new /obj/item/device/tape/random(src)
 	update_icon()
 
+/obj/item/device/taperecorder/AltClick()
+	..()
+	eject(usr)
+
+/obj/item/device/taperecorder/CtrlClick()
+	..()
+	play(usr)
+
 
 /obj/item/device/taperecorder/examine(mob/user)
 	..()

--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -66,6 +66,11 @@
 	origin_tech = "magnets=3;combat=2"
 	hud_type = DATA_HUD_SECURITY_ADVANCED
 
+/obj/item/clothing/glasses/hud/security/examine(mob/user)
+	. = ..()
+	user << "<span class='notice'>To operate the criminal status of someone in range, hold CTRL + ALT and click on the target.</span>"
+	user << "<span class='notice'>To add crimes to a person, hold CTRL + SHIFT and click on the target</span>"
+
 /obj/item/clothing/glasses/hud/security/chameleon
 	name = "Chamleon Security HUD"
 	desc = "A stolen security HUD integrated with Syndicate chameleon technology. Toggle to disguise the HUD. Provides flash protection."


### PR DESCRIPTION
Adds some hotkeys to tape recorders.
ALT + CLICK ejects tapes.
CTRL + CLICK plays tapes.

Examining sechuds will instruct you on how to use the hotkeys associated with them.

:cl: Super3222
tweak: More hotkeys! ALT + CLICK ejects tapes. CTRL + CLICK plays tapes.
tweak: Examining sechuds will tell you the hotkeys associated with them! Remember, you need some sort of access to use them!
/:cl:
