### PR TITLE
Fixes some cybermen bugs and an SSU bug

### DIFF
--- a/code/game/gamemodes/cybermen/cybermen.dm
+++ b/code/game/gamemodes/cybermen/cybermen.dm
@@ -167,12 +167,6 @@ var/datum/cyberman_network/cyberman_network
 	cyberman_network.process_cyberman_objectives()
 	var/cybermen_won = (cyberman_network.cybermen_win == 1)
 
-	#ifdef CYBERMEN_DEBUG
-	world << "Cybermen won:[cybermen_won]"
-	world << "Shuttle Escaped: [SSshuttle.emergency.mode >= SHUTTLE_ESCAPE]"
-	world << "Station was Nuked: [station_was_nuked]"
-	#endif
-
 	//log_yogstat_data("gamemode.php?gamemode=cybermen&value=rounds&action=add&changed=1")
 
 	if(!cybermen_won && SSshuttle.emergency.mode >= SHUTTLE_ESCAPE)
@@ -187,23 +181,23 @@ var/datum/cyberman_network/cyberman_network
 	else
 		world << "<span class='redtext'>The Cybermen have failed!</span>"
 		//log_yogstat_data("gamemode.php?gamemode=cybermen&value=crewwin&action=add&changed=1")
-
-	world << "<br><span class='big'><b>The Cybermens' Objectives were:</b></span>"
-	var/datum/objective/cybermen/O
-	for(var/i = 1 to cyberman_network.cybermen_objectives.len-1)
-		O = cyberman_network.cybermen_objectives[i]
-		if(O)
-			world << "Phase [i]:[O.phase]"
-			world << "[O.explanation_text]"
-			world << "<font color='green'><b>Completed</b></font><br>"
-	O = cyberman_network.cybermen_objectives[cyberman_network.cybermen_objectives.len]
-	world << "Phase [cyberman_network.cybermen_objectives.len]:[O.phase]"
-	world << "[O.explanation_text]"
-	world << (O.check_completion() ? "<font color='green'><b>Completed</b></font><br>" : "<font color='red'><b>Failed</b></font>")
 	return 1
 
 /datum/game_mode/proc/auto_declare_completion_cybermen()
 	if(cyberman_network && cyberman_network.cybermen.len > 0)
+		world << "<br><span class='big'><b>The Cybermens' Objectives were:</b></span>"
+		var/datum/objective/cybermen/O
+		for(var/i = 1 to cyberman_network.cybermen_objectives.len-1)
+			O = cyberman_network.cybermen_objectives[i]
+			if(O)
+				world << "Phase [i]:[O.phase]"
+				world << "[O.explanation_text]"
+				world << "<font color='green'><b>Completed</b></font><br>"
+		O = cyberman_network.cybermen_objectives[cyberman_network.cybermen_objectives.len]
+		world << "Phase [cyberman_network.cybermen_objectives.len]:[O.phase]"
+		world << "[O.explanation_text]"
+		world << (O.check_completion() ? "<font color='green'><b>Completed</b></font><br>" : "<font color='red'><b>Failed</b></font>")
+
 		var/text = ""
 		text += "<br><span class='big'><b>The Cybermen were:</b></span>"
 		for(var/datum/mind/cyberman in cyberman_network.cybermen)

--- a/code/game/gamemodes/cybermen/cybermen_hacking.dm
+++ b/code/game/gamemodes/cybermen/cybermen_hacking.dm
@@ -189,8 +189,8 @@
 	if(target)
 		if(!target.hud_list)
 			target.hud_list = list()
-		target.hud_list |= CYBERMEN_HACK_HUD
-		target.hud_list[CYBERMEN_HACK_HUD] = image('icons/mob/hud.dmi', target, "cybermenhack0")
+		if(!target.hud_list[CYBERMEN_HACK_HUD])
+			target.hud_list[CYBERMEN_HACK_HUD] = image('icons/mob/hud.dmi', target, "cybermenhack0")
 	var/datum/atom_hud/data/cybermen/hud = huds[DATA_HUD_CYBERMEN_HACK]
 	hud.add_to_hud(target)
 
@@ -221,6 +221,10 @@
 	maintained = 0
 
 	if(target)
+		if(!target.hud_list)
+			target.hud_list = list()
+		if(!target.hud_list[CYBERMEN_HACK_HUD])
+			target.hud_list[CYBERMEN_HACK_HUD] = image('icons/mob/hud.dmi', target, "cybermenhack0")
 		var/image/hud_icon = target.hud_list[CYBERMEN_HACK_HUD]
 		hud_icon.icon_state = "cybermenhack[round(progress/cost*100, 25)]"
 
@@ -375,7 +379,7 @@
 	var/datum/cyberman_hack/multiple_vector/new_multiple_vector_hack = new multi_vector_hack_type(multi_vector_hack_target)
 	return new_multiple_vector_hack.start(src)
 
-/datum/cyberman_hack/multiple_vector/
+/datum/cyberman_hack/multiple_vector
 	var/list/datum/cyberman_hack/component_hacks = list()//please please please do not add to this list directly, use add_component_hack().
 	required_type = null
 	//tick vars
@@ -393,6 +397,11 @@
 		if(istype(H, src.type) && H.target == target)
 			drop("<span class='warning'>[display_verb] failed, \the [target_name] is already being hacked.</span>")//this should never happen, because whatever started this should have checked to see if it could join H before starting this one.
 			return 0
+	if(target)
+		if(!target.hud_list)
+			target.hud_list = list()
+		if(!target.hud_list[CYBERMEN_HACK_HUD])
+			target.hud_list[CYBERMEN_HACK_HUD] = image('icons/mob/hud.dmi', target, "cybermenhack0")
 	component_hacks += first_component_hack
 	cyberman_network.active_cybermen_hacks += src
 	return 1
@@ -410,6 +419,13 @@
 			continue
 		if(H.progress > 0)
 			progress += H.progress
+		if(H.target)
+			if(!H.target.hud_list)
+				H.target.hud_list = list()
+			if(!H.target.hud_list[CYBERMEN_HACK_HUD])
+				H.target.hud_list[CYBERMEN_HACK_HUD] = image('icons/mob/hud.dmi', target, "cybermenhack0")
+		var/image/hud_icon = H.target.hud_list[CYBERMEN_HACK_HUD]
+		hud_icon.icon_state = "cybermenhack[round(progress/cost*100, 25)]"
 		H.progress = 0
 	if(progress < 0)
 		drop("<span class='warning'>[display_verb] of \the [target_name] has failed, all hack vectors were unmaintained.</span>")
@@ -456,6 +472,11 @@
 		if(hack.target == H.target)
 			H.drop("<span class='warning'>[display_verb] failed, \the [target_name] is already being hacked.</span>")
 			return 0
+	if(H.target)
+		if(!H.target.hud_list)
+			H.target.hud_list = list()
+		if(!target.hud_list[CYBERMEN_HACK_HUD])
+			target.hud_list[CYBERMEN_HACK_HUD] = image('icons/mob/hud.dmi', target, "cybermenhack0")
 	component_hacks += H
 	usr << "<span class='notice'>You join the ongoing [display_verb] of \the [target_name] through \the [H.target_name].</span>"
 	return 1

--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -252,7 +252,7 @@
 		var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
 		s.set_up(5, 1, src)
 		s.start()
-		if(electrocute_mob(user, src, src))
+		if(user && electrocute_mob(user, src, src))
 			return 1
 
 /obj/machinery/suit_storage_unit/relaymove(mob/user)


### PR DESCRIPTION
Fixed suit storage units runtiming when burning something.
Fixed cybermen multiple vector hacks runtiming when trying to update hack progress icons.
Made adminspawned cybermen display their objectives at roundend.
Removed some debug text.
Removed a single trailing /.
