### PR TITLE
Bandages are now actually good and not shit

### DIFF
--- a/code/game/objects/items/medical/bandage.dm
+++ b/code/game/objects/items/medical/bandage.dm
@@ -149,7 +149,7 @@
 	desc = "A primitive bandage fashioned from some torn cloth and leftover elastic. Will do in a pinch, but is nowhere near as effective as actual medical-grade bandages."
 	healtype = "brute"
 	healamount = 40
-	duration = 120
+	duration = 40
 	staunch_bleeding = 240
 
 /obj/item/medical/bandage/improvised_soaked
@@ -158,21 +158,21 @@
 	healtype = "burn"
 	color = "blue"
 	healamount = 40
-	duration = 120
+	duration = 40
 	staunch_bleeding = 0
 
 /obj/item/medical/bandage/destitute
 	name = "beggar's bandage"
 	desc = "Aptly named. These tattered shreds of cloth look about as useful as their namesake."
 	healamount = 15
-	duration = 120
+	duration = 40
 	staunch_bleeding = 120
 
 /obj/item/medical/bandage/normal
 	name = "standard NT-issue emergency bandage"
 	desc = "Does the job, and does it well. Wrap tightly around a wound. Smells like a pay docking."
 	healamount = 65
-	duration = 80
+	duration = 40
 	staunch_bleeding = 600
 
 /obj/item/medical/bandage/burn
@@ -180,7 +180,7 @@
 	desc = "Does the job, but stings like all hell. Wrap tightly around the wound. Smells slightly worse than the burning flesh it is supposed to heal, probably because it's being docked from your pay."
 	healamount = 65
 	healtype = "burn"
-	duration = 80
+	duration = 40
 	staunch_bleeding = 0
 
 /obj/item/medical/bandage/quality

--- a/code/game/objects/items/medical/recipes_medical.dm
+++ b/code/game/objects/items/medical/recipes_medical.dm
@@ -2,19 +2,16 @@
 	name = "Improvised Bandage"
 	result = /obj/item/medical/bandage/improvised
 	reqs = list(/obj/item/clothing/torncloth = 1)
-	time = 5
 	category = CAT_MISC
 
 /datum/crafting_recipe/improvised_gauze
 	name = "Hessian Gauze Strips"
 	result = /obj/item/stack/medical/gauze/improvised
 	reqs = list(/obj/item/clothing/torncloth = 3)
-	time = 10
 	category = CAT_MISC
 
 /datum/crafting_recipe/soaked_improvised_bandage
 	name = "Improvised Bandage (Soaked)"
 	result = /obj/item/medical/bandage/improvised_soaked
 	reqs = list(/obj/item/clothing/torncloth = 1, /datum/reagent/water = 20)
-	time = 5
 	category = CAT_MISC

--- a/code/game/objects/items/medical/recipes_medical.dm
+++ b/code/game/objects/items/medical/recipes_medical.dm
@@ -2,16 +2,19 @@
 	name = "Improvised Bandage"
 	result = /obj/item/medical/bandage/improvised
 	reqs = list(/obj/item/clothing/torncloth = 1)
+	time = 45
 	category = CAT_MISC
 
 /datum/crafting_recipe/improvised_gauze
 	name = "Hessian Gauze Strips"
 	result = /obj/item/stack/medical/gauze/improvised
 	reqs = list(/obj/item/clothing/torncloth = 3)
+	time = 55
 	category = CAT_MISC
 
 /datum/crafting_recipe/soaked_improvised_bandage
 	name = "Improvised Bandage (Soaked)"
 	result = /obj/item/medical/bandage/improvised_soaked
 	reqs = list(/obj/item/clothing/torncloth = 1, /datum/reagent/water = 20)
+	time = 45
 	category = CAT_MISC

--- a/code/game/objects/items/medical/recipes_medical.dm
+++ b/code/game/objects/items/medical/recipes_medical.dm
@@ -2,19 +2,19 @@
 	name = "Improvised Bandage"
 	result = /obj/item/medical/bandage/improvised
 	reqs = list(/obj/item/clothing/torncloth = 1)
-	time = 100
+	time = 5
 	category = CAT_MISC
 
 /datum/crafting_recipe/improvised_gauze
 	name = "Hessian Gauze Strips"
 	result = /obj/item/stack/medical/gauze/improvised
 	reqs = list(/obj/item/clothing/torncloth = 3)
-	time = 400
+	time = 10
 	category = CAT_MISC
 
 /datum/crafting_recipe/soaked_improvised_bandage
 	name = "Improvised Bandage (Soaked)"
 	result = /obj/item/medical/bandage/improvised_soaked
 	reqs = list(/obj/item/clothing/torncloth = 1, /datum/reagent/water = 20)
-	time = 200
+	time = 5
 	category = CAT_MISC


### PR DESCRIPTION
Okay so these original crafting times and tick durations are fucking ASS. I shall explain the default times compared to the newer times, taking into account station life and lavaland survival.

**Crafting times**
_Improvised Bandage_
Old: 100 ticks
New: 45 ticks

_Hessian Gauze_
Old: 400 ticks (What the fuck?)
New: 55 ticks

_Soaked Improvised bandage_
Old: 200 ticks
New: 45 ticks

Okay so for a first bandages wont take your whole fucking lifetime to craft anymore. These are meant to be makeshift medical substitutes that you can make on the fly and even if you stockpile them they heal less than bruise packs, salves and patches. Ontop of that they take a tick duration to heal, these are meant to be something you resort to when you have no other meds available at the same time improv med will now become a staple on lavaland survival as it should.

**Healing tick duration**
Not to be confused with the overall heal, this determines HOW LONG it takes for the bandage to apply its set heal value. I will include to heal amount since it seems fitting.

_Improvised Bandage_
Old: 120 seconds
New: 40 seconds
Heal Amount: 40 brute

_Improvised Bandage Soaked_
Old: 120 seconds
New: 40 seconds
Heal Amount: 40 burn

_Medical Bandage Normal_ (Found in Medkits)
Old: 120 seconds
New: 40 seconds
Heal Amount: 65 brute

_Medical Bandage Soaked_ (Not implemented)
Old: 120 seconds
New: 40 seconds
Heal Amount: 65 burn

_Quality Medical Bandage_ (Not implemented)
Old: 120 seconds
New: 35 seconds
Heal Amount: 90 brute

Huge duration time reduction on all these bandages, with the old times it use to take too dam long for them to heal and for bandages that were meant to be a last resort they were way too time consuming. These changes make it so the most used bandages heal 1 on 1 with their tick duration, meaning not only will they heal at an acceptable rate, but you will be able to notice it.

Finally all bandages except soaked will still staunch bleeding, this means if a wound is bleeding they will prevent blood from seeping through the wound. It use to be that light wounds could seep blood, however now only medium to severe bleeding will consume all of the staunch and seep blood. Hessian Gauze nolonger takes an entire ash storm to craft and normal bandages are now given their respective place as the preferred on the go ghetto meds.

Before anyone goes on and says "These times are drastically reduced! Surely this must make them the least bit OP!", my answer to this is simply put in this perspective. Normal bruise packs and Salves have a delay when used on oneself but are used instantly when applied by someone else. They heal 40 of their respective damage type and can be used 6 times. To meet the same standard with bandages you would have to craft atleast 6 bandages, thats one whole jumpsuit to equate to the same value of a bruise pack, to top it off you need access to water to even get burn bandages. Bandages also take around the same amount of time to apply on oneself and take the same time when applying to others. Application is never instant for bandages, and since they only cover one limb you have to do this for every single limb.

So it is with this PR that I introduce the fixes that we have been wanting to the god Eph med. The bandages were a brilliant idea in the first place, however the craft times and tick durations on them were absolutely fucked in terms of how long they took.

:cl: stealthkibbler
tweak: Improvised bandages and their counter parts are now dropped from 100-200 crafting ticks to 45, gauze is 55 from 400. In simple terms each bandage takes 6 seconds to craft, gauze takes 8.
tweak: bandage heal duration has been lowered drastically from 120 seconds to 40 seconds, bandages now heal 1 damage per second to account for their 40 total heal amount.
tweak: Medical kit bandages heal  duration is 40 seconds as-well but its worth mentioning that they heal a bit more, their heal amount being 65, meaning they are now viable meds when on the move. 
/:cl:
