### PR TITLE
Fixes a bug with traitor AI objectives.

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -171,7 +171,7 @@
 /datum/game_mode/proc/handle_AI_Traitors()
 	//Handles setting up traitor AIs seperately, because >tfw no datum antags
 	//Override this to change chances for AI traitors
-	var/prob_naughty_ai = 15
+	var/prob_naughty_ai = 19
 	if(prob(100-prob_naughty_ai)) return //no AI traitor made
 
 	var/mob/living/silicon/ai/A

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -60,10 +60,11 @@
 
 /datum/game_mode/traitor/post_setup()
 	for(var/datum/mind/traitor in traitors)
-		forge_traitor_objectives(traitor)
-		spawn(rand(10,100))
-			finalize_traitor(traitor)
-			greet_traitor(traitor)
+		if(!istype(traitor.current,/mob/living/silicon)) //Don't finalize objectives for silicons, that's handled in proc/handle_AI_Traitors()
+			forge_traitor_objectives(traitor)
+			spawn(rand(10,100))
+				finalize_traitor(traitor)
+				greet_traitor(traitor)
 	if(!exchange_blue)
 		exchange_blue = -1 //Block latejoiners from getting exchange objectives
 	modePlayer += traitors


### PR DESCRIPTION
This fixes https://github.com/yogstation13/yogstation/issues/300.
I also adjusted the chance for AI traitor to adjust for the modes that it's disabled on.

:cl:
bugfix: Due to an error in the syndicate agent tracker, subverted AIs were mistakenly being assigned objectives intended for humans.  This has been fixed.
tweak: Syndicate AI subversion agents have taken an online course on subverting AIs, and can now do so slightly more consistently.
/:cl:
