### PR TITLE
Maps out an engine bay instead of the memey space engine thing.

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -63005,8 +63005,8 @@
 /area/maintenance/incinerator)
 "cuC" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/space,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cuD" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 2;
@@ -63827,6 +63827,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cvU" = (
@@ -64353,6 +64354,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cwN" = (
@@ -64774,6 +64776,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel{
 	dir = 2;
 	icon_state = "warning"
@@ -65333,13 +65336,6 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = 32
-	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cyD" = (
@@ -65395,17 +65391,9 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cyM" = (
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
-	icon_state = "space";
-	layer = 4;
-	name = "EXTERNAL AIRLOCK";
-	pixel_x = -32
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 4;
+	on = 1
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -65638,7 +65626,7 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "czl" = (
 /obj/structure/cable{
@@ -65646,7 +65634,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "czm" = (
 /obj/machinery/camera/emp_proof{
@@ -65657,14 +65645,15 @@
 /obj/machinery/power/grounding_rod{
 	anchored = 1
 	},
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "czn" = (
 /obj/machinery/power/grounding_rod{
 	anchored = 1
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "czo" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
@@ -65684,7 +65673,8 @@
 	dir = 2;
 	network = list("Singularity")
 	},
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "czq" = (
 /obj/structure/cable{
@@ -65692,7 +65682,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "czr" = (
 /obj/structure/grille,
@@ -65701,7 +65691,7 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "czs" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -65887,14 +65877,15 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "czH" = (
 /obj/item/weapon/extinguisher,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "czI" = (
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "czJ" = (
 /obj/structure/cable/yellow{
@@ -65902,16 +65893,16 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "czK" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "czL" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -65928,19 +65919,19 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "czM" = (
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "czN" = (
 /obj/item/weapon/wrench,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "czO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
@@ -66051,7 +66042,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "czY" = (
 /obj/machinery/power/emitter{
@@ -66063,7 +66054,7 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "czZ" = (
 /obj/structure/cable/yellow{
@@ -66071,15 +66062,18 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cAa" = (
 /obj/machinery/field/generator{
 	anchored = 1;
 	state = 2
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating{
+	dir = 2;
+	icon_state = "warnplate"
+	},
+/area/engine/engineering)
 "cAb" = (
 /obj/machinery/power/emitter{
 	anchored = 1;
@@ -66090,7 +66084,7 @@
 	icon_state = "0-4";
 	d2 = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cAc" = (
 /obj/structure/grille,
@@ -66104,7 +66098,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cAd" = (
 /obj/structure/sign/pods,
@@ -66120,7 +66114,8 @@
 /area/engine/engineering)
 "cAf" = (
 /obj/item/device/multitool,
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cAg" = (
 /obj/structure/cable/yellow{
@@ -66133,8 +66128,8 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cAh" = (
 /obj/machinery/power/tesla_coil{
 	anchored = 1
@@ -66143,13 +66138,18 @@
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating{
+	dir = 4;
+	icon_state = "warnplate";
+	luminosity = 2
+	},
+/area/engine/engineering)
 "cAi" = (
-/obj/item/weapon/wirecutters,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cAj" = (
 /obj/machinery/power/tesla_coil{
 	anchored = 1
@@ -66158,8 +66158,11 @@
 	d2 = 4;
 	icon_state = "0-4"
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating{
+	icon_state = "warnplate";
+	dir = 8
+	},
+/area/engine/engineering)
 "cAk" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
@@ -66171,8 +66174,8 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cAl" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -66244,7 +66247,7 @@
 	icon_state = "1-4"
 	},
 /obj/structure/grille,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cAt" = (
 /obj/structure/cable{
@@ -66253,7 +66256,7 @@
 	icon_state = "2-8"
 	},
 /obj/structure/grille,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cAu" = (
 /obj/structure/cable{
@@ -66262,7 +66265,7 @@
 	icon_state = "2-4"
 	},
 /obj/structure/grille,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cAv" = (
 /obj/structure/cable{
@@ -66271,7 +66274,7 @@
 	icon_state = "1-8"
 	},
 /obj/structure/grille,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cAw" = (
 /obj/machinery/door/airlock/shuttle{
@@ -66366,12 +66369,12 @@
 	icon_state = "1-2"
 	},
 /obj/structure/grille,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cAG" = (
 /obj/item/weapon/crowbar,
-/turf/open/space,
-/area/space)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cAH" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Escape Pod";
@@ -66501,18 +66504,18 @@
 	icon_state = "1-2"
 	},
 /obj/structure/grille,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cAV" = (
 /obj/machinery/the_singularitygen{
 	anchored = 0
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/light,
+/area/engine/engineering)
 "cAW" = (
 /obj/machinery/the_singularitygen/tesla,
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/light,
+/area/engine/engineering)
 "cAX" = (
 /obj/machinery/light{
 	dir = 4;
@@ -66524,7 +66527,7 @@
 	icon_state = "1-2"
 	},
 /obj/structure/grille,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cAY" = (
 /obj/structure/sign/vacuum,
@@ -66637,8 +66640,8 @@
 /area/solar/starboard)
 "cBk" = (
 /obj/item/weapon/weldingtool,
-/turf/open/space,
-/area/space)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cBl" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -66923,7 +66926,8 @@
 /area/solar/starboard)
 "cBK" = (
 /obj/item/device/radio/off,
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cBL" = (
 /obj/structure/cable{
@@ -67116,7 +67120,7 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cCb" = (
 /obj/structure/grille,
@@ -67125,7 +67129,7 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cCc" = (
 /obj/structure/transit_tube{
@@ -67324,7 +67328,7 @@
 /area/space)
 "cCu" = (
 /obj/structure/grille,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cCv" = (
 /obj/machinery/power/tesla_coil{
@@ -67334,8 +67338,8 @@
 	d2 = 2;
 	icon_state = "0-2"
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cCw" = (
 /obj/structure/sign/securearea{
 	desc = "A warning sign which reads 'HIGH VOLTAGE'";
@@ -67671,7 +67675,11 @@
 	dir = 1;
 	network = list("Singularity")
 	},
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 1;
+	on = 1
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cCU" = (
 /obj/structure/cable/yellow{
@@ -67679,8 +67687,8 @@
 	d2 = 4;
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cCV" = (
 /obj/structure/cable/yellow{
 	d1 = 4;
@@ -67692,23 +67700,29 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cCW" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating/airless,
-/area/space)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cCX" = (
 /obj/machinery/camera/emp_proof{
 	c_tag = "Singularity East";
 	dir = 1;
 	network = list("Singularity")
 	},
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/components/unary/vent_pump{
+	dir = 1;
+	external_pressure_bound = 140;
+	on = 1;
+	pressure_checks = 0
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cCY" = (
 /obj/structure/transit_tube{
@@ -69031,94 +69045,119 @@
 /obj/machinery/computer/communications,
 /turf/open/floor/plasteel/shuttle/white,
 /area/shuttle/escape)
+"cFM" = (
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cFN" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1;
+	initialize_directions = 11
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cFO" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cFP" = (
+/obj/effect/landmark/start{
+	name = "Station Engineer"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cFQ" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'RADIOACTIVE AREA'";
+	icon_state = "radiation";
+	name = "RADIOACTIVE AREA";
+	pixel_x = 0;
+	pixel_y = -32
+	},
+/obj/machinery/light,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel{
+	dir = 2;
+	icon_state = "warning"
+	},
+/area/engine/engineering)
+"cFR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"cFS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cFT" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8;
+	initialize_directions = 11
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cFU" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 8;
+	on = 1;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cFV" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cFW" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -25
+	},
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cFX" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access = null;
+	req_access_txt = "10;13"
+	},
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'EXTERNAL AIRLOCK'";
+	icon_state = "space";
+	layer = 4;
+	name = "EXTERNAL AIRLOCK";
+	pixel_x = -32;
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cFY" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"cFZ" = (
+/turf/open/floor/plating,
+/area/space)
+"cGa" = (
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access = null;
+	req_access_txt = "10;13"
+	},
+/turf/open/floor/plating,
+/area/space)
 "cGb" = (
 /turf/closed/wall/shuttle{
 	icon_state = "swall_s9";
-	dir = 2
-	},
-/area/shuttle/transport)
-"cGa" = (
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel/shuttle/purple,
-/area/shuttle/transport)
-"cFZ" = (
-/obj/structure/closet/crate,
-/turf/open/floor/plasteel/shuttle/purple,
-/area/shuttle/transport)
-"cFY" = (
-/turf/open/floor/plasteel/shuttle/purple,
-/turf/closed/wall/shuttle/interior{
-	icon_state = "swall_f10"
-	},
-/area/shuttle/transport)
-"cFX" = (
-/obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
-	dir = 4
-	},
-/turf/closed/wall/shuttle{
-	icon_state = "swall_s5";
-	dir = 2
-	},
-/area/shuttle/transport)
-"cFW" = (
-/turf/open/floor/plasteel/shuttle/purple,
-/area/shuttle/transport)
-"cFV" = (
-/obj/machinery/door/airlock/shuttle,
-/turf/open/floor/plasteel/shuttle,
-/area/shuttle/transport)
-"cFU" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/shuttle/purple,
-/area/shuttle/transport)
-"cFT" = (
-/obj/machinery/computer/shuttle/ferry/request,
-/turf/open/floor/plasteel/shuttle/purple,
-/area/shuttle/transport)
-"cFS" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/turf/open/floor/plasteel/shuttle/purple,
-/area/shuttle/transport)
-"cFR" = (
-/turf/open/floor/plasteel/shuttle/purple,
-/turf/closed/wall/shuttle/interior{
-	icon_state = "swall_f9"
-	},
-/area/shuttle/transport)
-"cFQ" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall_s10";
-	dir = 2
-	},
-/area/shuttle/transport)
-"cFP" = (
-/obj/structure/grille,
-/obj/structure/window/shuttle,
-/turf/open/floor/plating,
-/area/shuttle/transport)
-"cFO" = (
-/obj/structure/window/shuttle,
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/shuttle/transport)
-"cFN" = (
-/turf/closed/wall/shuttle{
-	icon_state = "swall12";
-	dir = 2
-	},
-/area/shuttle/transport)
-"cFM" = (
-/obj/structure/shuttle/engine/propulsion{
-	icon_state = "propulsion";
-	dir = 4
-	},
-/turf/closed/wall/shuttle{
-	icon_state = "swall_s6";
 	dir = 2
 	},
 /area/shuttle/transport)
@@ -95540,8 +95579,8 @@ cCa
 cCu
 cCu
 cnp
-aaa
-aaa
+cFY
+cFY
 aaa
 aaa
 aaa
@@ -95786,19 +95825,19 @@ cyc
 czl
 czH
 czY
-czI
+cpM
 cAt
 cAF
 cAU
 cAF
 cAv
-czI
+cpM
 czY
-czI
-czI
+cpM
+cpM
 cAe
-ady
-ady
+cFZ
+cGa
 ady
 ady
 aaa
@@ -96033,16 +96072,16 @@ crp
 coS
 ctt
 cnw
-cqC
+cFN
 cvT
 cwM
 cxw
-cnp
-cnp
-cnp
+ctq
+ctq
+ctq
 czm
 czI
-czI
+cFT
 cAf
 czI
 czI
@@ -96297,20 +96336,20 @@ cxx
 cyd
 cyD
 cnp
-aaC
-aaC
-aaC
-aaa
-aaa
-aaa
-aaA
-aaa
-aaa
-aaA
-aaa
-aaa
-aaa
-czI
+cpM
+cpM
+cFU
+cpM
+cpM
+cpM
+cpM
+cpM
+cpM
+cpM
+cpM
+cpM
+cpM
+cFV
 cnp
 bIk
 aaa
@@ -96554,7 +96593,7 @@ cxy
 cye
 cyE
 cyG
-aaC
+cpM
 czJ
 czZ
 cAg
@@ -96567,7 +96606,7 @@ cAg
 czZ
 czZ
 cCU
-aaa
+cpM
 cnp
 bIk
 aaa
@@ -96813,18 +96852,18 @@ cyF
 cyG
 czn
 czK
-aaC
+cpM
 cAh
-aaC
-aaC
+cFN
+cFN
 cAh
-aaC
-aaC
+cFN
+cFN
 cAh
-aaC
-aaC
+cpM
+cpM
 czK
-aaa
+cpM
 cnp
 bIk
 aaA
@@ -97071,17 +97110,17 @@ cyG
 cyG
 czK
 cAa
-aaa
-aaa
-cAa
-aaa
-aaa
-aaa
-aaa
-cAa
-aaC
+cFM
+cFM
+cFR
+cFM
+cFM
+cFM
+cFM
+cFT
+cpM
 czK
-aaa
+cpM
 cnp
 cDZ
 aaA
@@ -97327,18 +97366,18 @@ cyG
 cyG
 cyG
 czK
-aaa
-aaa
-aaa
-aaA
-aaa
+czd
+cFM
+cFM
+cFM
+cFM
 cBk
-aaa
-aaa
-aaa
+cFM
+cFM
+cFU
 cCv
 cCV
-aaA
+cpM
 cnp
 bIk
 aaA
@@ -97584,18 +97623,18 @@ cyH
 cza
 cyG
 czK
-aaa
-aaa
-aaA
-aaA
-aaA
-aaA
-aaA
-aaa
-aaa
-aaC
+czd
+cFM
+cFM
+cFO
+cFO
+cFO
+cFM
+cFM
+cFU
+cpM
 czK
-aaa
+cpM
 cnp
 bIk
 aaa
@@ -97841,18 +97880,18 @@ cyI
 czb
 cyG
 czK
-aaa
-aaa
-aaA
-aaC
+czd
+cFM
+cFO
+cFO
 cAV
-aaC
-aaA
-aaA
-cAa
-aaC
+cFO
+cFO
+cFM
+cFT
+cpM
 czK
-aaa
+cpM
 cnp
 bIk
 aaa
@@ -98098,18 +98137,18 @@ cyJ
 czc
 czo
 czL
-aaa
-aaa
-aaA
-aaC
-czz
-aaC
-aaA
-aaa
-aaa
+czd
+cFM
+cFO
+cFO
+cFS
+cFO
+cFO
+cFM
+cFU
 cCv
 cCV
-aaa
+cFW
 cnp
 bIk
 aaa
@@ -98356,17 +98395,17 @@ czd
 cyG
 czK
 cAa
-cAi
-aaA
-aaC
+cFM
+cFP
+cFO
 cAW
-aaC
-aaA
-aaa
-aaa
-aaC
+cFO
+cFO
+cFM
+cFU
+cpM
 czK
-aaa
+cpM
 cnp
 bIk
 aaa
@@ -98612,18 +98651,18 @@ cyj
 cze
 cyG
 czK
-aaa
-aaa
-aaA
-aaA
-aaA
-aaA
-aaA
-aaa
-aaa
-aaC
+czd
+cFM
+cFM
+cFO
+cFO
+cFO
+cFM
+cFM
+cFU
+cpM
 czK
-aaa
+cpM
 cnp
 bIk
 aaA
@@ -98869,18 +98908,18 @@ cyG
 cyG
 cyG
 czK
-aaa
-aaa
-aaa
+czd
+cFM
+cFM
 cAG
-aaa
-aaA
-aaa
-aaa
-aaa
+cFM
+cFM
+cFM
+cFM
+cFU
 cCv
 cCV
-aaA
+cpM
 cnp
 bIk
 aaA
@@ -99127,17 +99166,17 @@ cyG
 cyG
 czK
 cAa
-aaa
-aaa
-aaa
-aaa
-cAa
-aaa
-aaa
-cAa
-aaC
+cFM
+cFM
+cFM
+cFM
+cFR
+cFM
+cFM
+cFT
+cpM
 czK
-aaa
+cpM
 cnp
 cDZ
 aaA
@@ -99383,18 +99422,18 @@ cyE
 cyG
 czn
 czK
-aaC
+cpM
 cAj
-aaC
-aaC
+cFQ
+cFQ
 cAj
-aaC
-aaC
+cFQ
+cFQ
 cAj
-aaC
-aaC
+cpM
+cpM
 czK
-aaa
+cpM
 cnp
 bIk
 aaA
@@ -99638,7 +99677,7 @@ cxH
 cye
 cyE
 cyG
-aaC
+cpM
 czM
 czZ
 cAk
@@ -99651,7 +99690,7 @@ cAk
 czZ
 czZ
 cCW
-aaa
+cpM
 cnp
 bIk
 aaa
@@ -99895,20 +99934,20 @@ cxx
 cyd
 cyL
 cnp
-aaC
-aaC
-aaC
-aaa
+cpM
+cpM
+cyM
+cpM
 cuC
-aaa
-aaA
-aaa
-aaa
-aaA
-aaa
-aaa
-aaa
-czI
+cpM
+cpM
+cpM
+cpM
+cpM
+cpM
+cpM
+cpM
+cpM
 cnp
 bIk
 aaa
@@ -100146,24 +100185,24 @@ csH
 ctE
 cnw
 cqC
-cqG
-cur
-cxw
-cnp
-cnp
-cnp
+cFO
+cFP
+cFQ
+cFR
+cFR
+cFR
 czp
-czI
-czI
-czI
-czI
-czI
-czI
-czI
-czI
-czI
-czI
-czI
+cFS
+cAi
+cFS
+cFS
+cFS
+cFS
+cFS
+cFS
+cFS
+cFS
+cFS
 cCX
 cnp
 cnp
@@ -100407,24 +100446,24 @@ cwg
 cwW
 crs
 cyc
-cyM
+cyC
 cyc
 czq
 czN
 cAb
-czI
+cpM
 cAu
 cAF
 cAX
 cAF
 cAs
-czI
+cpM
 cAb
-czI
-czI
-cAe
-ady
-ady
+cpM
+cpM
+cFX
+cFZ
+cGa
 ady
 ady
 aaa
@@ -100680,8 +100719,8 @@ cCb
 cCu
 cCu
 cnp
-aaA
-aaa
+cFY
+cFY
 aaa
 ady
 aaa


### PR DESCRIPTION
🆑 kmc
rscadd: Nanotrasen decided that having open space inside the engine bay was a pretty bad idea overall, a brilliant team of engineers managed to make it airtight.
/🆑

![](https://i.gyazo.com/4886d54dd9eaccf5accb0c0baffe2080.png)

![](https://i.gyazo.com/dd945e890bfa9a770e3bd0ede0e50b02.png)

References: https://github.com/yogstation13/yogstation/issues/355
