### PR TITLE
Shadowling Fixes

### DIFF
--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -260,6 +260,8 @@ Made by Xhuis
 	specflags = list(NOBREATH,NOBLOOD,RADIMMUNE,NOGUNS,NODISMEMBER) //Can't use guns due to muzzle flash
 	burnmod = 1.5 //1.5x burn damage, 2x is excessive
 	heatmod = 1.5
+	sight_mod = SEE_MOBS
+	invis_sight = 2
 
 
 /datum/species/shadow/ling/spec_life(mob/living/carbon/human/H)

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -200,6 +200,7 @@
 			H.update_hair()
 			H.update_body_parts()
 			H.update_mutations_overlay() // no hulk lizard
+			H.dna.species.on_species_gain(H)
 
 		if("gender")
 			if(!(H.gender in list("male", "female"))) //blame the patriarchy

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -56,6 +56,7 @@
 	var/siemens_coeff = 1 //base electrocution coefficient
 
 	var/invis_sight = SEE_INVISIBLE_LIVING
+	var/sight_mod = 0 //Add these flags to your mob's sight flag. For shadowlings and things to see people through walls.
 	var/darksight = 2
 
 	// species flags. these can be found in flags.dm
@@ -170,6 +171,8 @@
 
 	if(exotic_bloodtype && C.dna.blood_type != exotic_bloodtype)
 		C.dna.blood_type = exotic_bloodtype
+
+	update_sight(C)
 
 
 /datum/species/proc/on_species_loss(mob/living/carbon/C)
@@ -836,7 +839,7 @@
 
 
 /datum/species/proc/update_sight(mob/living/carbon/human/H)
-	H.sight = initial(H.sight)
+	H.sight = initial(H.sight) | sight_mod
 	H.see_in_dark = darksight
 	H.see_invisible = invis_sight
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -164,7 +164,7 @@
 	//We are now going to move
 	moving = 1
 
-	if(mob.shadow_walk)
+	if(Can_ShadowWalk(mob))
 		if(Process_ShadowWalk(direct))
 			moving = 0
 			return
@@ -188,6 +188,15 @@
 		mob.throwing = 0
 
 	return .
+
+proc/Can_ShadowWalk(var/mob/mob)
+	if(mob.shadow_walk)
+		return 1
+	if(ishuman(mob))
+		var/mob/living/carbon/human/H = mob
+		if(istype(H.dna.species, /datum/species/shadow/ling))
+			return 1
+	return 0
 
 /client/proc/Process_ShadowWalk(direct)
 	var/turf/target = get_step(mob, direct)


### PR DESCRIPTION
Makes MagicMirror Slings useful again.
Also, changed how I always give shadowlings their sight mods, I might
remove their glasses so we can have sun-glasses wielding shadowspooks,
but right now, nty.

:cl: TehFlaminTaco
bugfix: Shadowlings made from various Magic Mirrors now work as they
should.
/:cl:
