### PR TITLE
New Holy Weapon: Genesis

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -81,3 +81,9 @@
  #define WEAPON_LIGHT 0
  #define WEAPON_MEDIUM 1
  #define WEAPON_HEAVY 2
+
+ // Intent stuff
+ #define HARM "harm"
+ #define DISARM "disarm"
+ #define GRAB "grab"
+ #define HELP "help"

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -77,7 +77,7 @@
 	if(!diety)
 		desc = "It is the will of man that tells you to do these things, so you must!"
 		return
-	desc = "It is the plan of [diety] that allows me to tell you what to do, so do it!"
+	desc = "It is the plan of [diety] that gives me the power to tell you what to do, so do it!"
 	message = "Obey [diety]."
 
 
@@ -85,11 +85,12 @@
 	..()
 
 	var/genesis = input(usr, "Enter the message you want to deliever", "")
+
 	if(!genesis)
 		return
 
 	message = genesis
-	user << "<span class='alert'>Genesis will now deliever the message '[genesis]'</span>"
+	user << "<span class='alert'>Genesis will now deliever the message: [genesis]</span>"
 
 
 /obj/item/weapon/nullrod/genesis/attack(mob/M, mob/living/carbon/human/user)
@@ -109,8 +110,8 @@
 
 		if(DISARM || GRAB)
 			M << "<h1 class='red'>[message]</span><br>"
-			if(!M.dizziness)
-				M.Dizzy(500)
+			if(!M.jitteriness)
+				M.Jitter(15)
 
 		if(HELP)
 			M << 'sound/effects/pray.ogg'

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -58,6 +58,74 @@
 /obj/item/weapon/nullrod/godhand/dropped(mob/user)
 	qdel(src)
 
+
+/obj/item/weapon/nullrod/genesis
+	icon_state = "disintegrate"
+	item_state = "disintegrate"
+	name = "genesis"
+	flags = ABSTRACT | NODROP
+	w_class = 5
+	damtype = BURN
+	hitsound = 'sound/weapons/sear.ogg'
+	attack_verb = list("sears", "commands", "instructs")
+	var/message
+	var/cooldown
+
+/obj/item/weapon/nullrod/genesis/New()
+	..()
+	var/diety = ticker.Bible_deity_name
+	if(!diety)
+		desc = "It is the will of man that tells you to do these things, so you must!"
+		return
+	desc = "It is the plan of [diety] that allows me to tell you what to do, so do it!"
+	message = "Obey [diety]."
+
+
+/obj/item/weapon/nullrod/genesis/attack_self(mob/living/user)
+	..()
+
+	var/genesis = input(usr, "Enter the message you want to deliever", "")
+	if(!genesis)
+		return
+
+	message = genesis
+	user << "<span class='alert'>Genesis will now deliever the message '[genesis]'</span>"
+
+
+/obj/item/weapon/nullrod/genesis/attack(mob/M, mob/living/carbon/human/user)
+	if(cooldown > world.time - 15)
+		..()
+		return
+
+	if(user == M)
+		..()
+		return
+
+	switch (user.a_intent)
+		if(HARM)
+			M << 'sound/weapons/sear.ogg'
+			M << "<h1 class='red'>[message]</span><br>"
+			..()
+
+		if(DISARM || GRAB)
+			M << "<h1 class='red'>[message]</span><br>"
+			if(!M.dizziness)
+				M.Dizzy(500)
+
+		if(HELP)
+			M << 'sound/effects/pray.ogg'
+			M << "<h1 class='green'>[message]</span><br>"
+
+	log_game("[user] has sent a genesis member to [M] stating: [message]")
+	cooldown = world.time
+	user << "Message delivered."
+
+
+
+/obj/item/weapon/nullrod/genesis/dropped(mob/user)
+	visible_message("<span class='danger'>[src] screeches at the top of their lungs as they ascend!</span>")
+	qdel(src)
+
 /obj/item/weapon/nullrod/staff
 	icon_state = "godstaff-red"
 	item_state = "godstaff-red"

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -89,7 +89,7 @@
 	if(!genesis)
 		return
 
-	if(length(genesis) > 35)
+	if(length(genesis) > 55)
 		user << "<span class='alert'>That message is too long! Genesis cannot deliever that!</span>"
 		return
 
@@ -98,7 +98,7 @@
 
 
 /obj/item/weapon/nullrod/genesis/attack(mob/M, mob/living/carbon/human/user)
-	if(cooldown > world.time - 15)
+	if(cooldown > world.time - 25)
 		if(user.a_intent == HELP)
 			user << "Genesis is not ready."
 			return

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -116,7 +116,7 @@
 			M << 'sound/effects/pray.ogg'
 			M << "<h1 class='green'>[message]</span><br>"
 
-	log_game("[user] has sent a genesis member to [M] stating: [message]")
+	log_game("[user] has sent a genesis message to [M] stating: [message]")
 	cooldown = world.time
 	user << "Message delivered."
 

--- a/code/game/objects/items/weapons/holy_weapons.dm
+++ b/code/game/objects/items/weapons/holy_weapons.dm
@@ -89,12 +89,19 @@
 	if(!genesis)
 		return
 
+	if(length(genesis) > 35)
+		user << "<span class='alert'>That message is too long! Genesis cannot deliever that!</span>"
+		return
+
 	message = genesis
 	user << "<span class='alert'>Genesis will now deliever the message: [genesis]</span>"
 
 
 /obj/item/weapon/nullrod/genesis/attack(mob/M, mob/living/carbon/human/user)
 	if(cooldown > world.time - 15)
+		if(user.a_intent == HELP)
+			user << "Genesis is not ready."
+			return
 		..()
 		return
 
@@ -102,20 +109,21 @@
 		..()
 		return
 
+
 	switch (user.a_intent)
 		if(HARM)
 			M << 'sound/weapons/sear.ogg'
-			M << "<h1 class='red'>[message]</span><br>"
+			M << "<span class='genesisred'>[message]</span><br>"
 			..()
 
 		if(DISARM || GRAB)
-			M << "<h1 class='red'>[message]</span><br>"
+			M << "<span class='genesisred'>[message]</span><br>"
 			if(!M.jitteriness)
 				M.Jitter(15)
 
 		if(HELP)
 			M << 'sound/effects/pray.ogg'
-			M << "<h1 class='green'>[message]</span><br>"
+			M << "<span class='genesisgreen'>[message]</span><br>"
 
 	log_game("[user] has sent a genesis message to [M] stating: [message]")
 	cooldown = world.time
@@ -126,6 +134,42 @@
 /obj/item/weapon/nullrod/genesis/dropped(mob/user)
 	visible_message("<span class='danger'>[src] screeches at the top of their lungs as they ascend!</span>")
 	qdel(src)
+
+/obj/item/weapon/nullrod/genesis/suicide_act(mob/user)
+	user.visible_message("<span class='suicide'>[user] is saying good bye to \the [src.name]! It looks like \he's trying to sing her away!s</span>")
+	if(ishuman(user))
+		var/mob/living/carbon/human/H = user
+		spawn(75) // gib three times, spill organs, drop genesis
+			gibs(H.loc, H.viruses, H.dna)
+			H.adjustBruteLoss(1000)
+			H.spill_organs(1)
+			for(var/obj/item/W in H)
+				H.unEquip(W)
+			gibs(H.loc, H.viruses, H.dna)
+			spawn(3)
+				gibs(H.loc, H.viruses, H.dna)
+				dropped(user)
+
+	user.Stun(50)
+
+	user.say("So shut your eyes while mother sings")
+	playsound(loc, 'sound/effects/splat.ogg', 50, 1)
+	sleep(15)
+	user.say("Of wonderful sights that be,")
+	playsound(loc, 'sound/effects/splat.ogg', 70, 1)
+	sleep(15)
+	user.say("And you shall see the beautiful things")
+	playsound(loc, 'sound/effects/splat.ogg', 80, 1)
+	sleep(15)
+	user.say("As you rock in the misty sea,")
+	playsound(loc, 'sound/effects/splat.ogg', 90, 1)
+	sleep(15)
+	user.say("Where the old shoe rocked the fishermen three")
+	playsound(loc, 'sound/effects/splat.ogg', 110, 1)
+	sleep(15)
+	user.say("Wynken, Blynken, and Nod")
+	return (BRUTELOSS)
+
 
 /obj/item/weapon/nullrod/staff
 	icon_state = "godstaff-red"

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -50,6 +50,9 @@ h1.alert, h2.alert		{color: #000000;}
 .disarm					{color: #990000;}
 .passive				{color: #660000;}
 
+h1.green				{color: #03ff39;}
+h1.red				{color: #FF0000;}
+
 .userdanger				{color: #ff0000;	font-weight: bold; font-size: 3;}
 .danger					{color: #ff0000;}
 .warning				{color: #ff0000;	font-style: italic;}

--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -50,8 +50,8 @@ h1.alert, h2.alert		{color: #000000;}
 .disarm					{color: #990000;}
 .passive				{color: #660000;}
 
-h1.green				{color: #03ff39;}
-h1.red				{color: #FF0000;}
+.genesisgreen			{color: #03ff39		font-weight: bold; font-size: 5;}
+.genesisred				{color: #FF0000; 	font-weight: bold; font-size: 5;}
 
 .userdanger				{color: #ff0000;	font-weight: bold; font-size: 3;}
 .danger					{color: #ff0000;}


### PR DESCRIPTION
Alright, time for a holy weapon that's not a direct reference to a TV show.

This is a new null rod choice called Genesis.

It works somewhat like a godhand, where you can't take it off and it's extremely visible.
However, with this one allows you to input "messages" into it.

These messages can only be used by hitting someone with the weapon.
The message's font is rather font and varies between green or red depending on your intent.

On help intent, the message will be green, won't do any damage, and will play the holy soundtrack (what admins get from prayers / what players get from admins I believe).

On disarm or grab intent, the message will be red, and make the victim's speech jitter a little.

On harm intent, play the same sound which burn type weapons play, the weapon will actually HIT you, and the message is red.

Other Notes:
- Does not work when you hit yourself
- This'll run on a short CD

Example:
![](http://image.prntscr.com/image/2ede85e3c113406886585332f4934e4d.png)

:cl: Super3222
rscadd: New Holy Weapon!
rscadd: Introducing Genesis (definitely not a reference to anything)! You input messages into it, and those messages can be transferred to people that you touch with them.
rscadd: When you receive a message from genesis it's in pretty BIG text.
rscadd: Genesis's color and effect relies on it's intent. Harm intent does ... actually nevermind. Have fun figuring it out yourselves!
/:cl:
