### PR TITLE
Fix event earliest spawn time multipliers.

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -179,11 +179,11 @@ ALLOW_RANDOM_EVENTS
 
 ## Multiplier for earliest start time of dangerous events.
 ## Set to 0 to make dangerous events avaliable from round start.
-EVENTS_MIN_TIME_MUL 0
+EVENTS_MIN_TIME_MUL 1
 
 ## Multiplier for minimal player count (players = alive non-AFK humans) for dangerous events to start.
 ## Set to 0 to make dangerous events avaliable for all populations.
-EVENTS_MIN_PLAYERS_MUL 0
+EVENTS_MIN_PLAYERS_MUL 1
 
 
 ### AI ###


### PR DESCRIPTION
Restore event balance by setting multipliers to 1. This affects all the round_event_control, that is all the events in the events folder by setting their earliest_start timer to the value they have in code, instead of being available at round start. Fixes population multiplier as well, same as with the timer. If you don't want this, discuss, though I guess there's a reason tg has those timers.

EDIT: There are more events that aren't in the events folder, if you want a list of all of them just search for round_event_control.
:cl: Nirnael
tweak: Minimum event spawn time now has the default value in code, as well as the population amount.
:cl:
