### PR TITLE
Fixes telescience not being able to teleport on/off a beacon on another zlevel

### DIFF
--- a/code/modules/telesci/telesci_computer.dm
+++ b/code/modules/telesci/telesci_computer.dm
@@ -158,7 +158,7 @@
 		temp_msg = "ERROR!<BR>Forbidden sector."
 		return
 	if(!random)
-		if(!selection || !selection.can_be_found(z))
+		if(!selection || !selection.can_be_found(z_co))
 			temp_msg = "ERROR!<BR>Cannot locate beacon."
 			return
 		if(offset_x < -selection.range || offset_x > selection.range)
@@ -191,7 +191,7 @@
 				return
 			if(telepad.stat & NOPOWER)
 				return
-			if(!random && (!selection || !selection.can_be_found(z)))
+			if(!random && (!selection || !selection.can_be_found(z_co)))
 				temp_msg = "ERROR!<BR>Beacon lock lost during power up sequence."
 				updateDialog()
 				return

--- a/code/modules/telesci/tsbeacon.dm
+++ b/code/modules/telesci/tsbeacon.dm
@@ -75,8 +75,10 @@ var/list/tsbeacon_list = list()
 
 /obj/item/device/tsbeacon/proc/can_be_found(z)
 	var/turf/t = get_turf(src)
-	if(!on || !t || t.z != z) return 0
-	else return 1
+	if(!on || !t || t.z != z)
+		return 0
+	else
+		return 1
 
 /obj/item/device/tsbeacon/proc/get_offset(dx, dy)
 	var/turf/t = get_turf(src)


### PR DESCRIPTION
Fixes : #issuenotfound

Just a bit of a mixup with the parameter passed to `can_be_found()`

:cl: X-TheDark
bugfix: Telescience console can now properly teleport objects on/off beacons that are on another zlevel
/:cl:
