### PR TITLE
Prevents StonedMC from freezing when minigun itself is spawned rather than the backpack

### DIFF
--- a/_maps/map_files/generic/z2.dmm
+++ b/_maps/map_files/generic/z2.dmm
@@ -2202,7 +2202,7 @@
 /obj/item/weapon/gun/energy/ionrifle,
 /obj/item/weapon/gun/energy/laser,
 /obj/item/weapon/gun/energy/lasercannon,
-/obj/item/weapon/gun/projectile/minigun,
+/obj/item/weapon/minigunpack,
 /obj/item/weapon/mop{
 	desc = "No one really knows why this is here in the centcom top-Notch weapon facility."
 	},

--- a/code/modules/projectiles/guns/projectile/rechargable_magazine.dm
+++ b/code/modules/projectiles/guns/projectile/rechargable_magazine.dm
@@ -195,9 +195,9 @@
 	if(!ammo_pack)
 		if(istype(loc,/obj/item/weapon/minigunpack)) //We should spawn inside a ammo pack so let's use that one.
 			ammo_pack = loc
+			..()
 		else
 			qdel(src)//No pack, no gun
-	..()
 
 /obj/item/weapon/gun/projectile/minigun/dropped(mob/living/user)
 	ammo_pack.attach_gun(user)


### PR DESCRIPTION
Also replaces "minigun" in CentComm (the gun itself) with the proper one (the backpack that is part of and has the minigun).

Also moves the `..()` call so it doesn't add 5k+ items (gun+ammo) to the deletion queue if it's spawned by itself just because it instantiates all the ammo even if the gun needs to be deleted.
