### PR TITLE
Fixes (I hope) ruin loading atmos runtimes

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -109,6 +109,8 @@
 
 /turf/open/proc/tile_graphic()
 	. = new /list
+	if(!air) //Tiles that block atmos don't have this var instantiated
+		return
 	var/list/gases = air.gases
 	for(var/id in gases)
 		var/gas = gases[id]


### PR DESCRIPTION
fixes #451

Atmos blocking tiles don't have `air` instantiated, so it runtimes when you try to check `air.gasses` to determine the overlay to use.

Tested by loading up the Dream Daemon about 20 times, no runtimes.
