### PR TITLE
RCD QoL

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -4,6 +4,7 @@
 CONTAINS:
 RCD
 */
+
 /obj/item/weapon/rcd
 	name = "rapid-construction-device (RCD)"
 	desc = "A device used to rapidly build and deconstruct walls and floors."
@@ -61,6 +62,12 @@ RCD
 	var/decongrilledelay = null //as rapid as wirecutters
 	var/deconwindowdelay = 50
 	var/deconairlockdelay = 50
+
+	var/no_ammo_message = ""
+
+/obj/item/weapon/rcd/New()
+	..()
+	no_ammo_message = "<span class='warning'>The \'Low Ammo\' light on \the [src] blinks yellow.</span>"
 
 /obj/item/weapon/rcd/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] sets the [abbreviated_name] to 'Wall' and points it down \his throat! It looks like \he's trying to commit suicide..</span>")
@@ -323,6 +330,7 @@ RCD
 					activate()
 					S.ChangeTurf(/turf/open/floor/plating)
 					return 1
+				user << no_ammo_message
 				return 0
 
 			if(istype(A, /turf/open/floor))
@@ -331,10 +339,16 @@ RCD
 					user << "<span class='notice'>You start building wall...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, walldelay, target = A))
-						if(!useResource(wallcost, user)) return 0
+						if(!istype(F, /turf/open/floor)) //The turf might have changed during the do_after
+							return 0
+						if(!useResource(wallcost, user))
+							user << no_ammo_message
+							return 0
 						activate()
 						F.ChangeTurf(/turf/closed/wall)
 						return 1
+					return 0
+				user << no_ammo_message
 				return 0
 
 		if(2)
@@ -350,7 +364,9 @@ RCD
 						user << "<span class='notice'>You start building airlock...</span>"
 						playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 						if(do_after(user, airlockdelay, target = A))
-							if(!useResource(airlockcost, user)) return 0
+							if(!useResource(airlockcost, user))
+								user << no_ammo_message
+								return 0
 							activate()
 							var/obj/machinery/door/airlock/T = new airlock_type( A )
 
@@ -375,6 +391,7 @@ RCD
 					else
 						user << "<span class='warning'>There is another door here!</span>"
 						return 0
+				user << no_ammo_message
 				return 0
 
 		if(3)
@@ -386,10 +403,14 @@ RCD
 					user << "<span class='notice'>You start deconstructing wall...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, deconwalldelay, target = A))
-						if(!useResource(deconwallcost, user)) return 0
+						if(!useResource(deconwallcost, user))
+							user << no_ammo_message
+							return 0
 						activate()
 						W.ChangeTurf(/turf/open/floor/plating)
 						return 1
+					return 0
+				user << no_ammo_message
 				return 0
 
 			if(istype(A, /turf/open/floor))
@@ -403,10 +424,14 @@ RCD
 					user << "<span class='notice'>You start deconstructing floor...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, deconfloordelay, target = A))
-						if(!useResource(deconfloorcost, user)) return 0
+						if(!useResource(deconfloorcost, user))
+							user << no_ammo_message
+							return 0
 						activate()
 						F.ChangeTurf(F.baseturf)
 						return 1
+					return 0
+				user << no_ammo_message
 				return 0
 
 			if(istype(A, /obj/machinery/door/airlock))
@@ -414,10 +439,14 @@ RCD
 					user << "<span class='notice'>You start deconstructing airlock...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, deconairlockdelay, target = A))
-						if(!useResource(deconairlockcost, user)) return 0
+						if(!useResource(deconairlockcost, user))
+							user << no_ammo_message
+							return 0
 						activate()
 						qdel(A)
 						return 1
+					return 0
+				user << no_ammo_message
 				return	0
 
 			if(istype(A, /obj/structure/window))
@@ -425,10 +454,14 @@ RCD
 					user << "<span class='notice'>You start deconstructing the window...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, deconwindowdelay, target = A))
-						if(!useResource(deconwindowcost, user)) return 0
+						if(!useResource(deconwindowcost, user))
+							user << no_ammo_message
+							return 0
 						activate()
 						qdel(A)
 						return 1
+					return 0
+				user << no_ammo_message
 				return	0
 
 			if(istype(A, /obj/structure/grille))
@@ -440,6 +473,7 @@ RCD
 						playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 						qdel(A)
 						return 1
+					user << no_ammo_message
 					return 0
 
 		if (4)
@@ -451,12 +485,15 @@ RCD
 					user << "<span class='notice'>You start building a grille...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, grilledelay, target = A))
-						if(!useResource(grillecost, user)) return 0
+						if(!useResource(grillecost, user))
+							user << no_ammo_message
+							return 0
 						activate()
 						var/obj/structure/grille/G = new/obj/structure/grille(A)
 						G.anchored = 1
 						return 1
 					return 0
+				user << no_ammo_message
 				return 0
 			if(istype(A, /obj/structure/grille))
 				if(checkResource(windowcost, user))
@@ -464,12 +501,15 @@ RCD
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, windowdelay, target = A))
 						if(locate(/obj/structure/window) in A.loc) return 0
-						if(!useResource(windowcost, user)) return 0
+						if(!useResource(windowcost, user))
+							user << no_ammo_message
+							return 0
 						activate()
 						var/obj/structure/window/WD = new/obj/structure/window/fulltile(A.loc)
 						WD.anchored = 1
 						return 1
 					return 0
+				user << no_ammo_message
 				return 0
 
 		else
@@ -485,20 +525,27 @@ RCD
 
 /obj/item/weapon/rcd/proc/checkResource(amount, mob/user)
 	return matter >= amount
-/obj/item/weapon/rcd/borg/useResource(amount, mob/user)
-	if(!isrobot(user))
-		return 0
-	return user:cell:use(amount * 72) //borgs get 1.3x the use of their RCDs
 
-/obj/item/weapon/rcd/borg/checkResource(amount, mob/user)
-	if(!isrobot(user))
-		return 0
-	return user:cell:charge >= (amount * 72)
+/obj/item/weapon/rcd/borg/New()
+	..()
+	no_ammo_message = "<span class='warning'>Insufficient charge.</span>"
 
 /obj/item/weapon/rcd/borg/New()
 	..()
 	desc = "A device used to rapidly build walls and floors."
 	canRturf = 1
+
+/obj/item/weapon/rcd/borg/useResource(amount, mob/user)
+	if(!isrobot(user))
+		return 0
+	var/mob/living/silicon/robot/R = user
+	return R.cell.use(amount * 72) //borgs get 1.3x the use of their RCDs
+
+/obj/item/weapon/rcd/borg/checkResource(amount, mob/user)
+	if(!isrobot(user))
+		return 0
+	var/mob/living/silicon/robot/R = user
+	return R.cell.charge >= (amount * 72)
 
 /obj/item/weapon/rcd/loaded
 	matter = 160

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -330,7 +330,6 @@ RCD
 					activate()
 					S.ChangeTurf(/turf/open/floor/plating)
 					return 1
-				user << no_ammo_message
 				return 0
 
 			if(istype(A, /turf/open/floor))
@@ -342,13 +341,11 @@ RCD
 						if(!istype(F, /turf/open/floor)) //The turf might have changed during the do_after
 							return 0
 						if(!useResource(wallcost, user))
-							user << no_ammo_message
 							return 0
 						activate()
 						F.ChangeTurf(/turf/closed/wall)
 						return 1
 					return 0
-				user << no_ammo_message
 				return 0
 
 		if(2)
@@ -365,7 +362,6 @@ RCD
 						playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 						if(do_after(user, airlockdelay, target = A))
 							if(!useResource(airlockcost, user))
-								user << no_ammo_message
 								return 0
 							activate()
 							var/obj/machinery/door/airlock/T = new airlock_type( A )
@@ -391,7 +387,6 @@ RCD
 					else
 						user << "<span class='warning'>There is another door here!</span>"
 						return 0
-				user << no_ammo_message
 				return 0
 
 		if(3)
@@ -404,13 +399,11 @@ RCD
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, deconwalldelay, target = A))
 						if(!useResource(deconwallcost, user))
-							user << no_ammo_message
 							return 0
 						activate()
 						W.ChangeTurf(/turf/open/floor/plating)
 						return 1
 					return 0
-				user << no_ammo_message
 				return 0
 
 			if(istype(A, /turf/open/floor))
@@ -425,13 +418,11 @@ RCD
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, deconfloordelay, target = A))
 						if(!useResource(deconfloorcost, user))
-							user << no_ammo_message
 							return 0
 						activate()
 						F.ChangeTurf(F.baseturf)
 						return 1
 					return 0
-				user << no_ammo_message
 				return 0
 
 			if(istype(A, /obj/machinery/door/airlock))
@@ -440,13 +431,11 @@ RCD
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, deconairlockdelay, target = A))
 						if(!useResource(deconairlockcost, user))
-							user << no_ammo_message
 							return 0
 						activate()
 						qdel(A)
 						return 1
 					return 0
-				user << no_ammo_message
 				return	0
 
 			if(istype(A, /obj/structure/window))
@@ -455,13 +444,11 @@ RCD
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, deconwindowdelay, target = A))
 						if(!useResource(deconwindowcost, user))
-							user << no_ammo_message
 							return 0
 						activate()
 						qdel(A)
 						return 1
 					return 0
-				user << no_ammo_message
 				return	0
 
 			if(istype(A, /obj/structure/grille))
@@ -473,27 +460,26 @@ RCD
 						playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 						qdel(A)
 						return 1
-					user << no_ammo_message
 					return 0
 
 		if (4)
 			if(istype(A, /turf/open/floor))
 				if(checkResource(grillecost, user))
-					for(var/obj/structure/grille/GRILLE in A)
+					if(locate(/obj/structure/grille) in A)
 						user << "<span class='warning'>There is already a grille there!</span>"
 						return 0
 					user << "<span class='notice'>You start building a grille...</span>"
 					playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
 					if(do_after(user, grilledelay, target = A))
+						if(locate(/obj/structure/grille) in A)
+							return 0
 						if(!useResource(grillecost, user))
-							user << no_ammo_message
 							return 0
 						activate()
 						var/obj/structure/grille/G = new/obj/structure/grille(A)
 						G.anchored = 1
 						return 1
 					return 0
-				user << no_ammo_message
 				return 0
 			if(istype(A, /obj/structure/grille))
 				if(checkResource(windowcost, user))
@@ -502,14 +488,12 @@ RCD
 					if(do_after(user, windowdelay, target = A))
 						if(locate(/obj/structure/window) in A.loc) return 0
 						if(!useResource(windowcost, user))
-							user << no_ammo_message
 							return 0
 						activate()
 						var/obj/structure/window/WD = new/obj/structure/window/fulltile(A.loc)
 						WD.anchored = 1
 						return 1
 					return 0
-				user << no_ammo_message
 				return 0
 
 		else
@@ -518,13 +502,18 @@ RCD
 
 /obj/item/weapon/rcd/proc/useResource(amount, mob/user)
 	if(matter < amount)
+		if(user)
+			user << no_ammo_message
 		return 0
 	matter -= amount
 	desc = "An RCD. It currently holds [matter]/[max_matter] matter-units."
 	return 1
 
 /obj/item/weapon/rcd/proc/checkResource(amount, mob/user)
-	return matter >= amount
+	. = (matter >= amount)
+	if(!. && user)
+		user << no_ammo_message
+	return .
 
 /obj/item/weapon/rcd/borg/New()
 	..()
@@ -540,16 +529,24 @@ RCD
 		return 0
 	var/mob/living/silicon/robot/R = user
 	if(!R.cell)
+		user << no_ammo_message
 		return 0
-	return R.cell.use(amount * 72) //borgs get 1.3x the use of their RCDs
+	. = R.cell.use(amount * 72) //borgs get 1.3x the use of their RCDs
+	if(!. && user)
+		user << no_ammo_message
+	return .
 
 /obj/item/weapon/rcd/borg/checkResource(amount, mob/user)
 	if(!isrobot(user))
 		return 0
 	var/mob/living/silicon/robot/R = user
 	if(!R.cell)
+		user << no_ammo_message
 		return 0
-	return R.cell.charge >= (amount * 72)
+	. = (R.cell.charge >= (amount * 72))
+	if(!. && user)
+		user << no_ammo_message
+	return .
 
 /obj/item/weapon/rcd/loaded
 	matter = 160

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -539,12 +539,16 @@ RCD
 	if(!isrobot(user))
 		return 0
 	var/mob/living/silicon/robot/R = user
+	if(!R.cell)
+		return 0
 	return R.cell.use(amount * 72) //borgs get 1.3x the use of their RCDs
 
 /obj/item/weapon/rcd/borg/checkResource(amount, mob/user)
 	if(!isrobot(user))
 		return 0
 	var/mob/living/silicon/robot/R = user
+	if(!R.cell)
+		return 0
 	return R.cell.charge >= (amount * 72)
 
 /obj/item/weapon/rcd/loaded

--- a/code/game/objects/items/weapons/Rapid_Engineering_Device.dm
+++ b/code/game/objects/items/weapons/Rapid_Engineering_Device.dm
@@ -1,6 +1,6 @@
 
 /obj/item/weapon/rapid_engineering_device
-	name = "Rapid Engineering Device (RED)"
+	name = "\improper Rapid Engineering Device (RED)"
 	desc = "A device used to rapidly build, paint, and deconstruct pipes, walls, floors, and doors."
 	icon = 'icons/obj/tools.dmi'
 	icon_state = "HT_RCD"
@@ -35,6 +35,7 @@
 	rcd.max_matter = 200
 	rcd.name = name
 	rcd.abbreviated_name = "RED"
+	rcd.no_ammo_message = "<span class='warning'>The \'Low Ammo\' light on \the [src] blinks yellow.</span>"
 
 	painter = new /obj/item/weapon/airlock_painter(src)
 	painter.name = name

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -69,7 +69,7 @@
 	if(over_object == usr && Adjacent(usr))
 		if(!ishuman(usr))
 			return 0
-		if(buckled_mobs.len)
+		if(has_buckled_mobs())
 			return 0
 		if(usr.incapacitated())
 			usr << "<span class='warning'>You can't do that right now!</span>"

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -54,7 +54,7 @@
 		return ..()
 
 /obj/structure/kitchenspike/attack_hand(mob/user)
-	if(user.pulling && isliving(user.pulling) && user.a_intent == "grab" && !buckled_mobs.len)
+	if(user.pulling && isliving(user.pulling) && user.a_intent == "grab" && !has_buckled_mobs())
 		var/mob/living/L = user.pulling
 		if(do_mob(user, src, 120))
 			if(has_buckled_mobs()) //to prevent spam/queing up attacks
@@ -78,7 +78,7 @@
 		..()
 
 /obj/structure/kitchenspike/MouseDrop_T(mob/living/target, mob/living/carbon/human/user)
-	if(!isliving(target) || buckled_mobs.len)
+	if(!isliving(target) || has_buckled_mobs())
 		return
 	if(user.pulling != target)
 		return

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/he_pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/he_pipes.dm
@@ -50,7 +50,7 @@
 		var/hc = pipe_air.heat_capacity()
 		var/mob/living/heat_source = buckled_mobs[1]
 		//Best guess-estimate of the total bodytemperature of all the mobs, since they share the same environment it's ~ok~ to guess like this
-		var/avg_temp = (pipe_air.temperature * hc + (heat_source.bodytemperature * buckled_mobs.len) * 3500) / (hc + (buckled_mobs.len * 3500))
+		var/avg_temp = (pipe_air.temperature * hc + (heat_source.bodytemperature * buckled_mobs.len) * 3500) / (hc + (buckled_mobs ? buckled_mobs.len * 3500 : 0))
 		for(var/m in buckled_mobs)
 			var/mob/living/L = m
 			L.bodytemperature = avg_temp

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -543,7 +543,7 @@
 	if(!has_buckled_mobs() && prob(25))
 		for(var/mob/living/V in src.loc)
 			entangle(V)
-			if(buckled_mobs.len)
+			if(has_buckled_mobs())
 				break //only capture one mob at a time
 
 

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -44,7 +44,7 @@
 	if(M.get_num_legs() < 2)
 		vehicle_move_delay ++
 		if(M.get_num_arms() <= 0)
-			if(buckled_mobs.len)//to prevent the message displaying twice due to unbuckling
+			if(has_buckled_mobs())//to prevent the message displaying twice due to unbuckling
 				M << "<span class='warning'>Your limbless body flops off \the [src].</span>"
 			unbuckle_mob(M)
 


### PR DESCRIPTION
:cl:
rscadd: RCDs now give feedback when they do not have enough ammo to complete an operation.
bugfix: Spamming an RCD to build the same wall multiple times on a tile will no longer drain all your ammo.
bugfix: RCDs can no longer build multiple grilles on the same tile.
/:cl:

RCDs now give feedback when they do not have enough ammo to complete an operation.
Fixed some unrelated runtimes with buckled mobs.
