### PR TITLE
Organ Decay

### DIFF
--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -78,6 +78,7 @@
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "demon_heart-on"
 	origin_tech = "combat=5;biotech=7"
+	decay_time = 0
 
 /obj/item/organ/heart/demon/update_icon()
 	return //always beating visually

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -181,10 +181,6 @@ MASS SPECTROMETER
 	// Time of death
 	if(M.tod && (M.stat == DEAD || (M.status_flags & FAKEDEATH)))
 		user << "<span class='info'>Time of Death:</span> [M.tod]"
-		var/tdelta = round(world.time - M.timeofdeath)
-		if(tdelta < (DEFIB_TIME_LIMIT * 10))
-			user << "<span class='danger'>Subject died [tdelta / 10] seconds \
-				ago, defibrillation may be possible!</span>"
 
 	for(var/datum/disease/D in M.viruses)
 		if(!(D.visibility_flags & HIDDEN_SCANNER))
@@ -217,6 +213,17 @@ MASS SPECTROMETER
 		if(implant_detect)
 			user << "<span class='notice'>Detected cybernetic modifications:</span>"
 			user << "<span class='notice'>[implant_detect]</span>"
+	//Organ Decay
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		for(var/obj/item/organ/O in C.internal_organs)
+			if(O.decay_time && O.decay)
+				if(O.decay >= O.decay_time)
+					user << "<span class='notice'>\The [O] of the subject has decayed past the point of no return.</span>"
+				else
+					user << "<span class='notice'>\The [O] of the subject is [round(O.decay / O.decay_time, 0.1)]% decayed.</span>"
+	if(!M.getorgan(/obj/item/organ/heart))
+		user << "<span class='warning'>Subject does not have a heart.</span>"
 
 /proc/chemscan(mob/living/user, mob/living/M)
 	if(ishuman(M))

--- a/code/game/objects/items/weapons/defib.dm
+++ b/code/game/objects/items/weapons/defib.dm
@@ -505,15 +505,16 @@
 				total_burn	= H.getFireLoss()
 
 				var/failed = null
+				var/obj/item/organ/heart/heart = H.getorgan(/obj/item/organ/heart)
 
 				if (H.suiciding || (H.disabilities & NOCLONE))
 					failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Recovery of patient impossible. Further attempts futile.</span>"
 				else if (H.hellbound)
 					failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Patient's soul appears to be on another plane of existance.  Further attempts futile.</span>"
-				else if (tplus > tlimit)
-					failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Body has decayed for too long. Further attempts futile.</span>"
-				else if (!H.getorgan(/obj/item/organ/heart))
+				else if (!heart)
 					failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Patient's heart is missing.</span>"
+				else if (heart.decay_time && heart.decay >= heart.decay_time)
+					failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Patient's heart tissue has decayed for too long. Further attempts futile.</span>"
 				else if(total_burn >= 180 || total_brute >= 180)
 					failed = "<span class='warning'>[req_defib ? "[defib]" : "[src]"] buzzes: Resuscitation failed - Severe tissue damage makes recovery of patient impossible via defibrillator. Further attempts futile.</span>"
 				else if(H.get_ghost())
@@ -552,7 +553,7 @@
 					defib.cooldowncheck(user)
 				else
 					recharge(60)
-			else if(H.heart_attack)
+			else if(H.heart_attack && H.getorgan(/obj/item/organ/heart))
 				H.heart_attack = 0
 				user.visible_message("<span class='notice'>[req_defib ? "[defib]" : "[src]"] pings: Patient's heart is now beating again.</span>")
 				playsound(get_turf(src), 'sound/machines/defib_zap.ogg', 50, 1, -1)

--- a/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/freezer.dm
@@ -1,5 +1,16 @@
 /obj/structure/closet/secure_closet/freezer
 	icon_state = "freezer"
+	var/target_temp = T0C - 40
+	var/cooling_power = 40
+
+/obj/structure/closet/secure_closet/freezer/return_air()
+	var/datum/gas_mixture/gas = ..()
+	if(!gas)
+		return null
+	var/datum/gas_mixture/newgas = gas.copy()
+	if(newgas.temperature > target_temp)
+		newgas.temperature = max(target_temp, newgas.temperature - cooling_power)
+	return newgas
 
 /obj/structure/closet/secure_closet/freezer/kitchen
 	name = "kitchen Cabinet"

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -70,6 +70,17 @@
 	desc = "A freezer."
 	name = "freezer"
 	icon_state = "freezer"
+	var/target_temp = T0C - 40
+	var/cooling_power = 40
+
+/obj/structure/closet/crate/freezer/return_air()
+	var/datum/gas_mixture/gas = ..()
+	if(!gas)
+		return null
+	var/datum/gas_mixture/newgas = gas.copy()
+	if(newgas.temperature > target_temp)
+		newgas.temperature = max(target_temp, newgas.temperature - cooling_power)
+	return newgas
 
 /obj/structure/closet/crate/freezer/blood
 	name = "blood freezer"

--- a/code/modules/atmospherics/gasmixtures/gas_mixture.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_mixture.dm
@@ -372,7 +372,7 @@ var/list/gaslist_cache = null
 
 	copy.temperature = temperature
 	for(var/id in cached_gases)
-		add_gas(id)
+		copy.add_gas(id)
 		copy_gases[id][MOLES] = cached_gases[id][MOLES]
 
 	return copy

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -11,7 +11,33 @@
 	var/slot
 	// DO NOT add slots with matching names to different zones - it will break internal_organs_slot list!
 	var/vital = 0
+	var/decay_time = 0
+	var/decay = 0
 
+/obj/item/organ/New()
+	if(decay_time)
+		SSobj.processing += src
+
+/obj/item/organ/process()
+	handle_decay()
+
+/obj/item/organ/proc/handle_decay()
+	if(owner && !(owner.stat & DEAD))
+		decay = max(0, decay-1)
+	else
+		var/temperature
+		if(owner)
+			temperature = owner.bodytemperature
+		else
+			var/datum/gas_mixture/air = return_air()
+			if(!air)
+				return
+			temperature = air.temperature
+
+		if(temperature > T0C - 10)
+			decay = min(decay_time, decay + 1)
+	if(decay >= decay_time)
+		SSobj.processing -= src
 
 /obj/item/organ/proc/Insert(mob/living/carbon/M, special = 0)
 	if(!iscarbon(M) || owner == M)
@@ -94,6 +120,20 @@
 /obj/item/organ/item_action_slot_check(slot,mob/user)
 	return //so we don't grant the organ's action to mobs who pick up the organ.
 
+/obj/item/organ/attackby(obj/item/I, mob/user, proximity_flag)
+	if(!proximity_flag)
+		return 0
+	if(is_health_analyzer(I))
+		if(decay_time)
+			if(decay >= decay_time)
+				user << "<span class='notice'>\The [src] has decayed beyond the point of no return.</span>"
+			else
+				user << "<span class='notice'>\The [src] is [round(decay / decay_time, 0.1)]% decayed.</span>"
+		else
+			user << "<span class='notice'>\The [src] will not decay.</span>"
+		return 1
+	return 0
+
 //Looking for brains?
 //Try code/modules/mob/living/carbon/brain/brain_item.dm
 
@@ -108,6 +148,7 @@
 	var/beating = 1
 	var/icon_base = "heart"
 	attack_verb = list("beat", "thumped")
+	decay_time = DEFIB_TIME_LIMIT
 
 /obj/item/organ/heart/update_icon()
 	if(beating)
@@ -134,10 +175,11 @@
 /obj/item/organ/heart/attack_self(mob/user)
 	..()
 	if(!beating)
-		visible_message("<span class='notice'>[user] squeezes [src] to \
-			make it beat again!</span>")
-		Restart()
-		addtimer(src, "stop_if_unowned", 80)
+		if(Restart())
+			user.visible_message("<span class='notice'>[user] squeezes [src] to make it beat again!</span>")
+			addtimer(src, "stop_if_unowned", 80)
+		else
+			user.visible_message("<span class='warning'>[user] squeezes [src], but it does not start to beat.</span>")
 
 /obj/item/organ/heart/Insert(mob/living/carbon/M, special = 0)
 	..()
@@ -153,9 +195,16 @@
 	return 1
 
 /obj/item/organ/heart/proc/Restart()
+	if(decay_time && decay >= decay_time)
+		return 0
 	beating = 1
 	update_icon()
 	return 1
+
+/obj/item/organ/heart/handle_decay()
+	..()
+	if(decay_time && decay >= decay_time)
+		Stop()
 
 /obj/item/organ/heart/prepare_eat()
 	var/obj/S = ..()
@@ -170,6 +219,7 @@
 	icon_base = "cursedheart"
 	origin_tech = "biotech=6"
 	actions_types = list(/datum/action/item_action/organ_action/cursed_heart)
+	decay_time = 0
 	var/last_pump = 0
 	var/add_colour = TRUE //So we're not constantly recreating colour datums
 	var/pump_delay = 30 //you can pump 1 second early, for lag, but no more (otherwise you could spam heal)


### PR DESCRIPTION
Ports organ decay and freezer closets and crates cooling their contents. Since organ decay uses SSobj.processing instead of world.time, it is possible that dead bodies will last a little longer if the server is lagging heavily.

:cl:
rscadd: You can once again perform heart transplants to defibrillate people whose bodies have decayed.
rscadd: Organs once again decay when they are not inside a living body, unless the temperature is very low.
rscadd: Freezer crates and closets once again cool their contents down enough to preserve organs or dead bodies.
/:cl:

Incidentally, freezers now cool you down enough to make cryoxidone work at its least effectiveness. Cold showers or a dip in vacuum are still more effective, but it works for small heals.
