### PR TITLE
Cult changes

### DIFF
--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -147,12 +147,15 @@
 		if(S.current_charges >= 3)
 			user <<"<span class='warning'>[I] is already fully charged!</span>"
 			return
-		user <<"<span class='notice'>You hold [I] up to [src]. Hold still...</span>"
-		if(do_mob(user, user, 200))
-			S.current_charges = 3
-			user <<"<span class='notice'>[I] is fully charged.</span>"
-	else
-		return ..()
+		if(cooldowntime > world.time)
+			user << "<span class='cultitalic'>The magic in [src] is weak, it will be ready to use again in [getETA()].</span>"
+			return
+		if(src && !qdeleted(src) && anchored && Adjacent(user) && !user.incapacitated() && iscultist(user) && cooldowntime <= world.time)
+			user <<"<span class='notice'>You hold [I] up to [src]. Hold still...</span>"
+			if(do_mob(user, user, 200))
+				S.current_charges = 3
+				user <<"<span class='notice'>[I] is fully charged.</span>"
+				cooldowntime = world.time + 1200
 
 /obj/structure/cult/tome
 	name = "archives"

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -150,7 +150,7 @@
 		if(cooldowntime > world.time)
 			user << "<span class='cultitalic'>The magic in [src] is weak, it will be ready to use again in [getETA()].</span>"
 			return
-		if(src && !qdeleted(src) && anchored && Adjacent(user) && !user.incapacitated() && iscultist(user) && cooldowntime <= world.time)
+		if(anchored && Adjacent(user) && cooldowntime <= world.time)
 			user <<"<span class='notice'>You hold [I] up to [src]. Hold still...</span>"
 			if(do_mob(user, user, 200))
 				S.current_charges = 3

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -147,10 +147,15 @@
 		if(S.current_charges >= 3)
 			user <<"<span class='warning'>[I] is already fully charged!</span>"
 			return
-		user <<"<span class='notice'>You hold [I] up to [src]. Hold still...</span>"
-		if(do_mob(user, user, 200))
-			S.current_charges = 3
-			user <<"<span class='notice'>[I] is fully charged.</span>"
+		if(cooldowntime > world.time)
+			user << "<span class='cultitalic'>The magic in [src] is weak, it will be ready to use again in [getETA()].</span>"
+			return
+		if(src && !qdeleted(src) && anchored && Adjacent(user) && !user.incapacitated() && iscultist(user) && cooldowntime <= world.time)
+			user <<"<span class='notice'>You hold [I] up to [src]. Hold still...</span>"
+			if(do_mob(user, user, 200))
+				S.current_charges = 3
+				user <<"<span class='notice'>[I] is fully charged.</span>"
+				cooldowntime = world.time + 1200
 	else
 		return ..()
 

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -141,6 +141,19 @@
 		else
 			last_corrupt = world.time + corrupt_delay*2
 
+/obj/structure/cult/pylon/attackby(obj/I, mob/user, params)
+	if(istype(I, /obj/item/clothing/suit/hooded/cultrobes/cult_shield) && iscultist(user))
+		var/obj/item/clothing/suit/hooded/cultrobes/cult_shield/S = I
+		if(S.current_charges >= 3)
+			user <<"<span class='warning'>[I] is already fully charged!</span>"
+			return
+		user <<"<span class='notice'>You hold [I] up to [src]. Hold still...</span>"
+		if(do_mob(user, user, 200))
+			S.current_charges = 3
+			user <<"<span class='notice'>[I] is fully charged.</span>"
+	else
+		return ..()
+
 /obj/structure/cult/tome
 	name = "archives"
 	desc = "A desk covered in arcane manuscripts and tomes in unknown languages. Looking at the text makes your skin crawl."

--- a/code/game/gamemodes/cult/cult_structures.dm
+++ b/code/game/gamemodes/cult/cult_structures.dm
@@ -147,15 +147,10 @@
 		if(S.current_charges >= 3)
 			user <<"<span class='warning'>[I] is already fully charged!</span>"
 			return
-		if(cooldowntime > world.time)
-			user << "<span class='cultitalic'>The magic in [src] is weak, it will be ready to use again in [getETA()].</span>"
-			return
-		if(src && !qdeleted(src) && anchored && Adjacent(user) && !user.incapacitated() && iscultist(user) && cooldowntime <= world.time)
-			user <<"<span class='notice'>You hold [I] up to [src]. Hold still...</span>"
-			if(do_mob(user, user, 200))
-				S.current_charges = 3
-				user <<"<span class='notice'>[I] is fully charged.</span>"
-				cooldowntime = world.time + 1200
+		user <<"<span class='notice'>You hold [I] up to [src]. Hold still...</span>"
+		if(do_mob(user, user, 200))
+			S.current_charges = 3
+			user <<"<span class='notice'>[I] is fully charged.</span>"
 	else
 		return ..()
 

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -6,6 +6,7 @@
 	desc = "A fragment of the legendary treasure known simply as the 'Soul Stone'. The shard still flickers with a fraction of the full artefact's power."
 	w_class = 1
 	slot_flags = SLOT_BELT
+	layer = BELOW_MOB_LAYER
 	origin_tech = "bluespace=4;materials=5"
 	var/usability = 0
 

--- a/code/game/turfs/simulated/floor.dm
+++ b/code/game/turfs/simulated/floor.dm
@@ -180,7 +180,7 @@ var/list/icons_to_ignore_at_floor_init = list("damaged1","damaged2","damaged3","
 	if(prob(20))
 		ChangeTurf(/turf/open/floor/engine/cult)
 
-/turf/simulated/floor/attack_animal(mob/living/simple_animal/M)
+/turf/open/floor/attack_animal(mob/living/simple_animal/M)
 	if(istype(M,/mob/living/simple_animal/hostile/construct/builder)||istype(M,/mob/living/simple_animal/hostile/construct/harvester))//only cult things can interact with floors so far
 		if(istype(src, /turf/open/floor/engine/cult))
 			return

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -121,9 +121,27 @@
 		phasable = 2
 		while(phasable>0)
 			src.density = 0
+			src.alpha = 60
+			src.opacity = 0
 			sleep(10)
 			phasable--
 		src.density = 1
+		src.alpha = initial(src.alpha)
+		src.opacity = 1
+	return
+
+/turf/closed/wall/mineral/cult/attackby(obj/item/weapon/W, mob/user, params)
+	if(istype(W, /obj/item/weapon/tome) && iscultist(user))
+		if(src.density == 1)
+			user <<"<span class='notice'>Your tome passes through the wall as if it's thin air.</span>"
+			src.alpha = 60
+			src.density = 0
+			src.opacity = 0
+		else
+			user <<"<span class='notice'>Your tome solidly connects with the wall.</span>"
+			src.alpha = initial(src.alpha)
+			src.density = 1
+			src.opacity = 1
 	return
 
 /turf/closed/wall/attack_hulk(mob/user)

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -115,35 +115,6 @@
 		dismantle_wall(1)
 		return
 
-/turf/closed/wall/mineral/cult/Bumped(atom/movable/C as mob)
-	var/phasable=0
-	if(istype(C,/mob/living/simple_animal/hostile/construct/builder)||istype(C,/mob/living/simple_animal/hostile/construct/wraith)||istype(C,/mob/living/simple_animal/hostile/construct/harvester))
-		phasable = 2
-		while(phasable>0)
-			src.density = 0
-			src.alpha = 60
-			src.opacity = 0
-			sleep(10)
-			phasable--
-		src.density = 1
-		src.alpha = initial(src.alpha)
-		src.opacity = 1
-	return
-
-/turf/closed/wall/mineral/cult/attackby(obj/item/weapon/W, mob/user, params)
-	if(istype(W, /obj/item/weapon/tome) && iscultist(user))
-		if(src.density == 1)
-			user <<"<span class='notice'>Your tome passes through the wall as if it's thin air.</span>"
-			src.alpha = 60
-			src.density = 0
-			src.opacity = 0
-		else
-			user <<"<span class='notice'>Your tome solidly connects with the wall.</span>"
-			src.alpha = initial(src.alpha)
-			src.density = 1
-			src.opacity = 1
-	return
-
 /turf/closed/wall/attack_hulk(mob/user)
 	..(user, 1)
 	if(prob(hardness))

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -28,6 +28,40 @@
 		color = "#FAE48C"
 		animate(src, color = previouscolor, time = 8)
 
+/turf/closed/wall/mineral/cult/Bumped(atom/movable/C as mob)
+	var/phasable=0
+	if(istype(C,/mob/living/simple_animal/hostile/construct))
+		var/mob/living/simple_animal/hostile/construct/construct = C
+		if(!construct.phaser)
+			return
+		phasable = 2
+		while(phasable>0)
+			if(construct.pulling)
+				construct.stop_pulling()
+			src.density = 0
+			src.alpha = 60
+			src.opacity = 0
+			sleep(10)
+			phasable--
+		src.density = 1
+		src.alpha = initial(src.alpha)
+		src.opacity = 1
+	return
+
+/turf/closed/wall/mineral/cult/attackby(obj/item/weapon/W, mob/user, params)
+	if(istype(W, /obj/item/weapon/tome) && iscultist(user))
+		if(src.density == 1)
+			user <<"<span class='notice'>Your tome passes through the wall as if it's thin air.</span>"
+			src.alpha = 60
+			src.density = 0
+			src.opacity = 0
+		else
+			user <<"<span class='notice'>Your tome solidly connects with the wall.</span>"
+			src.alpha = initial(src.alpha)
+			src.density = 1
+			src.opacity = 1
+	return
+
 /turf/closed/wall/mineral/cult/artificer
 	name = "runed stone wall"
 	desc = "A cold stone wall engraved with indecipherable symbols. Studying them causes your head to pound."

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -30,6 +30,7 @@
 	deathmessage = "collapses in a shattered heap."
 	var/list/construct_spells = list()
 	var/playstyle_string = "<b>You are a generic construct! Your job is to not exist, and you should probably adminhelp this.</b>"
+	var/phaser = FALSE
 
 
 /mob/living/simple_animal/hostile/construct/New()
@@ -153,6 +154,7 @@
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	construct_spells = list(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift)
 	playstyle_string = "<b>You are a Wraith. Though relatively fragile, you are fast, deadly, and even able to phase through walls.</b>"
+	phaser = TRUE
 
 /mob/living/simple_animal/hostile/construct/wraith/hostile //actually hostile, will move around, hit things
 	AIStatus = AI_ON
@@ -187,6 +189,7 @@
 						use magic missile, repair allied constructs (by clicking on them), \
 						</B><I>and most important of all create new constructs</I><B> \
 						(Use your Artificer spell to summon a new construct shell and Summon Soulstone to create a new soulstone).</B>"
+	phaser = TRUE
 
 /mob/living/simple_animal/hostile/construct/builder/Found(atom/A) //what have we found here?
 	if(isconstruct(A)) //is it a construct?
@@ -259,6 +262,7 @@
 							/obj/effect/proc_holder/spell/targeted/smoke/disable)
 	playstyle_string = "<B>You are a Harvester. You are not strong, but your powers of domination will assist you in your role: \
 						Bring those who still cling to this world of illusion back to the Geometer so they may know Truth.</B>"
+	phaser = TRUE
 
 /mob/living/simple_animal/hostile/construct/harvester/hostile //actually hostile, will move around, hit things
 	AIStatus = AI_ON

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -13,7 +13,8 @@
 	stop_automated_movement = 1
 	status_flags = CANPUSH
 	attack_sound = 'sound/weapons/punch1.ogg'
-	see_in_dark = 7
+	see_in_dark = 8
+	see_invisible = SEE_INVISIBLE_MINIMUM
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
@@ -96,8 +97,6 @@
 	attacktext = "smashes their armored gauntlet into"
 	speed = 3
 	environment_smash = 2
-	see_in_dark = 8
-	see_invisible = SEE_INVISIBLE_MINIMUM
 	attack_sound = 'sound/weapons/punch3.ogg'
 	status_flags = 0
 	mob_size = MOB_SIZE_LARGE
@@ -151,8 +150,6 @@
 	melee_damage_upper = 25
 	retreat_distance = 2 //AI wraiths will move in and out of combat
 	attacktext = "slashes"
-	see_in_dark = 8
-	see_invisible = SEE_INVISIBLE_MINIMUM
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	construct_spells = list(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift)
 	playstyle_string = "<b>You are a Wraith. Though relatively fragile, you are fast, deadly, and even able to phase through walls.</b>"
@@ -178,8 +175,6 @@
 	retreat_distance = 10
 	minimum_distance = 10 //AI artificers will flee like fuck
 	attacktext = "rams"
-	see_in_dark = 8
-	see_invisible = SEE_INVISIBLE_MINIMUM
 	environment_smash = 2
 	attack_sound = 'sound/weapons/punch2.ogg'
 	construct_spells = list(/obj/effect/proc_holder/spell/aoe_turf/conjure/wall,

--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -132,12 +132,10 @@
 	invocation = "none"
 	invocation_type = "none"
 	proj_lifespan = 10
-	max_targets = 11
+	max_targets = 6
 	action_icon_state = "magicm"
 	action_background_icon_state = "bg_demon"
 
-/obj/effect/proc_holder/spell/targeted/inflict_handler/magic_missile
-	amt_weakened = 1
 
 /obj/effect/proc_holder/spell/targeted/smoke/disable
 	name = "Paralysing Smoke"

--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -132,10 +132,12 @@
 	invocation = "none"
 	invocation_type = "none"
 	proj_lifespan = 10
-	max_targets = 6
+	max_targets = 11
 	action_icon_state = "magicm"
 	action_background_icon_state = "bg_demon"
 
+/obj/effect/proc_holder/spell/targeted/inflict_handler/magic_missile
+	amt_weakened = 1
 
 /obj/effect/proc_holder/spell/targeted/smoke/disable
 	name = "Paralysing Smoke"


### PR DESCRIPTION
best group antag tbh

Cultists can now slap a pylon with a shielded robe to recharge it, hopefully fixing the meme of throwing useless robes onto the ground because no more shield. Time to recharge is 20 seconds, could be changed based on feedback

Cultists can now hit a runed wall with their tome to toggle phasability or not. This was done because artificers were just spamming walls and nobody could do anything about it other than artificers.

Phasable walls are now no longer opaque so you can see through them, and they have a slightly modified alpha so it's a bit more obvious that you can walk through them.

fixed bugs: 
harvesters can now see in the dark correctly
harvesters and artificers now correctly corrupt floors on click

now with 100% more actual testing!

:cl: ShadowDeath6
rscadd: Cultists can now hit a runed wall with their tome to make it phasable.
rscadd: Cultists can now recharge shielded robes by using them on a pylon.
rscadd: Soulstones now appear above items on the ground.
rscdel: Constructs can no longer pull people through walls.
bugfix: Harvesters and Artificers can now correctly corrupt floors.
bugfix: Harvesters can now correctly see in the dark.
tweak: Phasable cult walls are now more obvious and are see-through.
/:cl:
