### PR TITLE
Adds a time estimate to cloning completion in cloning pods

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -276,6 +276,13 @@ Sorry Giacom. Please don't be mad :(
 	if(updating_health)
 		updatehealth()
 
+/mob/living/proc/setBruteLoss(amount, updating_health=1)
+	if(status_flags & GODMODE)
+		return 0
+	bruteloss = amount
+	if(updating_health)
+		updatehealth()
+
 /mob/living/proc/getOxyLoss()
 	return oxyloss
 
@@ -318,6 +325,13 @@ Sorry Giacom. Please don't be mad :(
 	if(status_flags & GODMODE)
 		return 0
 	fireloss = Clamp(fireloss + amount, 0, maxHealth*2)
+	if(updating_health)
+		updatehealth()
+
+/mob/living/proc/setFireLoss(amount, updating_health=1)
+	if(status_flags & GODMODE)
+		return 0
+	fireloss = amount
 	if(updating_health)
 		updatehealth()
 


### PR DESCRIPTION
Quality of Life, aka Power Creep

Also refactors cloning pod process code a bit, namely:
- Replaces the hacky way of putting reagents into mob to cure Oxyloss/Brute loss caused by crit with setBruteLoss/setOxyLoss procs;
- Health is updated only after we run the healing loop in process(), instead of each time we call adjustXLoss/setXLoss procs (not mentioning the updatehealth() called by the reagents that were put into the mob to heal oxyloss/bruteloss);
- NOBREATH mobs are handled better;

Additions to mob/living
- **Adds setBruteLoss/setFireLoss procs** to mob/living, since it already had setOxyLoss, etc.

![untitled](https://cloud.githubusercontent.com/assets/2188139/17432942/93bb4280-5b0a-11e6-9e31-6562bb8bee5d.png)
