### PR TITLE
Removes portal storm event

### DIFF
--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -2,7 +2,7 @@
 	name = "Portal Storm: Syndicate Shocktroops"
 	typepath = /datum/round_event/portal_storm/syndicate_shocktroop
 	weight = 0 //Set to 1 or 2 to enable, you monster
-	min_players = 15
+	min_players = 666 //To make sure it never starts
 	earliest_start = 18000
 
 /datum/round_event/portal_storm/syndicate_shocktroop

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/portal_storm_syndicate
 	name = "Portal Storm: Syndicate Shocktroops"
 	typepath = /datum/round_event/portal_storm/syndicate_shocktroop
-	weight = 2
+	weight = 0 //Set to 1 or 2 to enable, you monster
 	min_players = 15
 	earliest_start = 18000
 

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -1,15 +1,14 @@
-/datum/round_event_control/portal_storm_syndicate
+/* /datum/round_event_control/portal_storm_syndicate
 	name = "Portal Storm: Syndicate Shocktroops"
 	typepath = /datum/round_event/portal_storm/syndicate_shocktroop
-	weight = 0 //Set to 1 or 2 to enable, you monster
-	min_players = 666 //To make sure it never starts
-	earliest_start = 18000
-	max_occurences = 0 //This actually does something, probably
+	weight = 2 //Set to 1 or 2 to enable, you monster
+	min_players = 15 //To make sure it never starts
+	earliest_start = 18000 
 
 /datum/round_event/portal_storm/syndicate_shocktroop
 	boss_types = list(/mob/living/simple_animal/hostile/syndicate/melee/space/stormtrooper = 2)
 	hostile_types = list(/mob/living/simple_animal/hostile/syndicate/melee/space/noloot = 8,\
-						/mob/living/simple_animal/hostile/syndicate/ranged/space/noloot = 2)
+						/mob/living/simple_animal/hostile/syndicate/ranged/space/noloot = 2) */
 
 /datum/round_event_control/portal_storm_narsie
 	name = "Portal Storm: Constructs"

--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -4,6 +4,7 @@
 	weight = 0 //Set to 1 or 2 to enable, you monster
 	min_players = 666 //To make sure it never starts
 	earliest_start = 18000
+	max_occurences = 0 //This actually does something, probably
 
 /datum/round_event/portal_storm/syndicate_shocktroop
 	boss_types = list(/mob/living/simple_animal/hostile/syndicate/melee/space/stormtrooper = 2)


### PR DESCRIPTION
Alternative to: #447

The only way to fix this is to remove this.

Sorry fluffy.

:cl: God
bugfix: Removes portal storm. It's existence is a bug, to humanity.
/:cl:
