### PR TITLE
Defines setBruteLoss/setFireLoss for human mobs

### DIFF
--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -33,6 +33,24 @@
 		amount += BP.burn_dam
 	return amount
 
+//Set brute/burn damages to the amount specified. Cheats by distributing/healing limbs randomly
+/mob/living/carbon/human/setBruteLoss(amount)
+	var/set_damage = max(0, amount)
+	var/current_damage = getBruteLoss()
+
+	if(current_damage > set_damage)
+		heal_overall_damage(current_damage - set_damage, 0)
+	else if(current_damage < set_damage)
+		take_overall_damage(set_damage - current_damage, 0)
+
+/mob/living/carbon/human/setFireLoss(amount)
+	var/set_damage = max(0, amount)
+	var/current_damage = getFireLoss()
+	
+	if(current_damage > set_damage)
+		heal_overall_damage(0, current_damage - set_damage)
+	else if(current_damage < set_damage)
+		take_overall_damage(0, set_damage - current_damage)
 
 /mob/living/carbon/human/adjustBruteLoss(amount)
 	if(status_flags & GODMODE)

--- a/code/modules/mob/living/carbon/human/human_damage.dm
+++ b/code/modules/mob/living/carbon/human/human_damage.dm
@@ -33,7 +33,7 @@
 		amount += BP.burn_dam
 	return amount
 
-//Set brute/burn damages to the amount specified. Cheats by distributing/healing limbs randomly
+//Set brute/burn damages to the amount specified.
 /mob/living/carbon/human/setBruteLoss(amount)
 	var/set_damage = max(0, amount)
 	var/current_damage = getBruteLoss()


### PR DESCRIPTION
fixes #471

Uses take/heal_overall_damage() procs, doesn't take negative values.

This definitely turned out to be not too elegant of a solution...
This time, I did test it (sorry for not doing this in the last PR) for both NOBREATH and regular mobs...it works fine now.
