### PR TITLE
Cleans up some unnecessary junk in notes.

### DIFF
--- a/code/modules/admin/sql_notes.dm
+++ b/code/modules/admin/sql_notes.dm
@@ -136,7 +136,7 @@
 			var/adminckey = query_get_notes.item[4]
 			var/last_editor = query_get_notes.item[5]
 			var/server = query_get_notes.item[6]
-			output += "<b>[timestamp] | [server] | [adminckey]</b>"
+			output += "<b>[timestamp] | [adminckey]</b>"
 			if(!linkless)
 				output += " <a href='?_src_=holder;removenote=[id]'>\[Remove Note\]</a> <a href='?_src_=holder;editnote=[id]'>\[Edit Note\]</a>"
 				if(last_editor)

--- a/code/modules/admin/sql_notes.dm
+++ b/code/modules/admin/sql_notes.dm
@@ -135,7 +135,7 @@
 			var/notetext = query_get_notes.item[3]
 			var/adminckey = query_get_notes.item[4]
 			var/last_editor = query_get_notes.item[5]
-			var/server = query_get_notes.item[6]
+			//var/server = query_get_notes.item[6] //notice: this was removed because when you've got only 1 server, what is the point of displaying the long ass name that ends up being cut up anyway?
 			output += "<b>[timestamp] | [adminckey]</b>"
 			if(!linkless)
 				output += " <a href='?_src_=holder;removenote=[id]'>\[Remove Note\]</a> <a href='?_src_=holder;editnote=[id]'>\[Edit Note\]</a>"

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1087,7 +1087,7 @@
 			//var/adminckey = query_get_notes.item[4]
 			//var/last_editor = query_get_notes.item[5]
 			var/server = query_get_notes.item[6]
-			output += "<p style='margin-bottom: 0px;'><b>[timestamp] | [server]</b><br />"
+			output += "<p style='margin-bottom: 0px;'><b>[timestamp]</b><br />"
 			output += "<span style='margin-left: 16px; margin-top: 0px;'>[notetext]</span></p>"
 
 		usr << browse(output, "window=noteexport;size=800x650")

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1086,7 +1086,7 @@
 			var/notetext = query_get_notes.item[3]
 			//var/adminckey = query_get_notes.item[4]
 			//var/last_editor = query_get_notes.item[5]
-			var/server = query_get_notes.item[6]
+			//var/server = query_get_notes.item[6] //notice: this was removed because when you've got only 1 server, what is the point of displaying the long ass name that ends up being cut up anyway?
 			output += "<p style='margin-bottom: 0px;'><b>[timestamp]</b><br />"
 			output += "<span style='margin-left: 16px; margin-top: 0px;'>[notetext]</span></p>"
 


### PR DESCRIPTION
Having the server name (chopped up) on every single note is plain unnecessary when you've only got 1 server. I kinda understand it for /tg/ as they have two servers running, but still. So this pull requests removes the `[server]` portion which makes it so that only the timespan shows. The actual sorting by server is still a thing, so if we ever want to re-add it, all we have to do is to put the `[server]` back in it's place.

Also, this is what my notes look like: 
![d66d438a958642e18b30f0aa97d8c881](https://cloud.githubusercontent.com/assets/13056792/17445157/ce6e2b84-5b43-11e6-9629-16109507b2b0.png)

Really messy.
