### PR TITLE
Constructs can no longer pull people through rune walls

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -115,17 +115,6 @@
 		dismantle_wall(1)
 		return
 
-/turf/closed/wall/mineral/cult/Bumped(atom/movable/C as mob)
-	var/phasable=0
-	if(istype(C,/mob/living/simple_animal/hostile/construct/builder)||istype(C,/mob/living/simple_animal/hostile/construct/wraith)||istype(C,/mob/living/simple_animal/hostile/construct/harvester))
-		phasable = 2
-		while(phasable>0)
-			src.density = 0
-			sleep(10)
-			phasable--
-		src.density = 1
-	return
-
 /turf/closed/wall/attack_hulk(mob/user)
 	..(user, 1)
 	if(prob(hardness))

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -28,6 +28,22 @@
 		color = "#FAE48C"
 		animate(src, color = previouscolor, time = 8)
 
+/turf/closed/wall/mineral/cult/Bumped(atom/movable/C as mob)
+	var/phasable = 0
+	if(istype(C, /mob/living/simple_animal/hostile/construct))
+		var/mob/living/simple_animal/hostile/construct/construct = C
+		if(!construct.phaser)
+			return
+		phasable = 2
+		while(phasable > 0)
+			if(construct.pulling)
+				construct.stop_pulling()
+			density = 0
+			sleep(10)
+			phasable--
+		density = 1
+
+
 /turf/closed/wall/mineral/cult/artificer
 	name = "runed stone wall"
 	desc = "A cold stone wall engraved with indecipherable symbols. Studying them causes your head to pound."

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -29,7 +29,7 @@
 	deathmessage = "collapses in a shattered heap."
 	var/list/construct_spells = list()
 	var/playstyle_string = "<b>You are a generic construct! Your job is to not exist, and you should probably adminhelp this.</b>"
-
+	var/phaser = FALSE
 
 /mob/living/simple_animal/hostile/construct/New()
 	..()
@@ -156,6 +156,7 @@
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	construct_spells = list(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift)
 	playstyle_string = "<b>You are a Wraith. Though relatively fragile, you are fast, deadly, and even able to phase through walls.</b>"
+	phaser = TRUE
 
 /mob/living/simple_animal/hostile/construct/wraith/hostile //actually hostile, will move around, hit things
 	AIStatus = AI_ON
@@ -192,6 +193,7 @@
 						use magic missile, repair allied constructs (by clicking on them), \
 						</B><I>and most important of all create new constructs</I><B> \
 						(Use your Artificer spell to summon a new construct shell and Summon Soulstone to create a new soulstone).</B>"
+	phaser = TRUE
 
 /mob/living/simple_animal/hostile/construct/builder/Found(atom/A) //what have we found here?
 	if(isconstruct(A)) //is it a construct?
@@ -264,6 +266,7 @@
 							/obj/effect/proc_holder/spell/targeted/smoke/disable)
 	playstyle_string = "<B>You are a Harvester. You are not strong, but your powers of domination will assist you in your role: \
 						Bring those who still cling to this world of illusion back to the Geometer so they may know Truth.</B>"
+	phaser = TRUE
 
 /mob/living/simple_animal/hostile/construct/harvester/hostile //actually hostile, will move around, hit things
 	AIStatus = AI_ON


### PR DESCRIPTION
- Places rune walls `/Bumped()` call in the right file
- Constructs can no longer pull people through rune walls.

https://github.com/yogstation13/yogstation/pull/460

:cl: Super3222
tweak: Constructs can no longer pull people through rune/cult walls.
/:cl:
