### PR TITLE
Removes drone fabricator and logs more grabs.

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -54251,14 +54251,6 @@
 	dir = 4
 	},
 /obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 50
-	},
-/obj/item/stack/sheet/glass{
-	amount = 50;
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /turf/open/floor/plasteel,
 /area/toxins/misc_lab)
 "ccR" = (
@@ -54268,7 +54260,6 @@
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
-/obj/machinery/droneDispenser,
 /turf/open/floor/plasteel,
 /area/toxins/misc_lab)
 "ccS" = (

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -251,6 +251,7 @@
 				if(!buckled && !density)
 					Move(user.loc)
 			if(GRAB_KILL)
+				add_logs(user, src, "strangled")
 				visible_message("<span class='danger'>[user] is strangling [src]!</span>", \
 								"<span class='userdanger'>[user] is strangling you!</span>")
 				update_canmove() //we fall down

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -311,6 +311,7 @@ var/next_mob_id = 0
 		return
 
 	AM.add_fingerprint(src)
+	add_logs(src, AM, "grabbed")
 
 	// If we're pulling something then drop what we're currently pulling and pull this instead.
 	if(pulling)


### PR DESCRIPTION
Fixes https://github.com/yogstation13/yogstation/issues/433
Fixes https://github.com/yogstation13/yogstation/issues/466

:cl: Super3222
tweak: Normal grab and Strangling grabs are now logged.
rscdel: Drone Fabricator has been taken off the map.
/:cl:
