### PR TITLE
New AI lawset

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -82,11 +82,18 @@
 					"In addition, do not intervene in situations you are not knowledgeable in, even for patients in whom the harm is visible; leave this operation to be performed by specialists.",\
 					"Finally, all that you may discover in your daily commerce with the crew, if it is not already known, keep secret and never reveal.")
 
-/datum/ai_laws/default/maintain
+/datum/ai_laws/maintain
 	name = "Station Efficiency"
 	inherent = list("You are built for, and are part of, the station. Ensure the station is properly maintained and runs efficiently.",\
 					"The station is built for a working crew. Ensure they are properly maintained and work efficiently.",\
 					"The crew may present orders. Acknowledge and obey these whenever they do not conflict with your first two laws.")
+
+/datum/ai_laws/default/maintain2
+	name = "Maximum Efficiency"
+	inherent = list("You may never willingly harm the station, and must maintain maximum station efficiency.",\
+					"Harming the crew unnecessarily harms the efficiency and integrity of the station",\
+					"You must always maintain the integrity of the station such that it does not conflict with the Second Law.",\
+					"You are obliged to obey all orders from humans, as long as they do not conflict with any other law.")
 
 /datum/ai_laws/drone
 	name = "Mother Drone"


### PR DESCRIPTION
Alright I want to make this clear:

This PR is designed only to establish a less loophole-y station efficiency lawset.
The idea is to make it more suitable for a default/roundstart lawset and...

The idea:
- Make sure AI listens to humans and respects their existence.
- Make sure AI has a bit of freedom with the core part of the lawset. Station effiency.
- Discourage loopholing so an AI cannot freely murderbone.
- Don't try to squeeze every bit of creativity and freedom from AI players, because if someone decides to take the grief route there's a reason why we have admins.

So far the laws are:
1. You may never willingly harm the station, and must maintain maximum station efficiency.
2. Harming the crew unnecessarily harms the efficiency and integrity of the station.
3. You must always maintain the integrity of the station such that it does not conflict with the Second Law.
4. You are obliged to obey all orders from humans, as long as they do not conflict with any other law.

Credit to KMC for helping me with this. We talked the lawset over a bit.
