### PR TITLE
adds some verbs to "remove all verbs"

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -346,7 +346,10 @@ var/list/admin_verbs_hideable = list(
 	set category = "Admin"
 
 	remove_admin_verbs()
+	verbs += /client/proc/adminwho
+	verbs += /client/proc/cmd_admin_say
 	verbs += /client/proc/show_verbs
+	verbs += /client/proc/dsay
 
 	src << "<span class='interface'>Almost all of your adminverbs have been hidden.</span>"
 	feedback_add_details("admin_verb","TAVVH") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1370,7 +1370,7 @@
 		M << "<span class='adminnotice'>You have been sent to Prison!</span>"
 
 		log_admin("[key_name(usr)] has sent [key_name(M)] to Prison!")
-		message_admins("[key_name_admin(usr)] has sent [key_name_admin(M)] Prison!")
+		message_admins("[key_name_admin(usr)] has sent [key_name_admin(M)] to Prison!")
 
 	else if(href_list["sendbacktolobby"])
 		if(!check_rights(R_ADMIN))


### PR DESCRIPTION
adds asay, dsay, and adminwho so admins who use the "remove all verbs" button can still do stuff

also fixes a spelling error in admin prisons

@SKR6DarkVoid 
