### PR TITLE
removes some obscure space tiles

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicatepod.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicatepod.dmm
@@ -9,7 +9,7 @@
 "i" = (/obj/effect/decal/cleanable/xenoblood,/obj/machinery/light{dir = 1},/obj/item/weapon/tank/internals/oxygen,/turf/open/floor/plasteel/shuttle/red,/area/ruin/powered)
 "j" = (/turf/closed/wall/shuttle/smooth,/area/ruin/powered)
 "k" = (/obj/machinery/door/airlock/hatch,/obj/structure/fans/tiny/invisible,/turf/open/floor/plasteel/shuttle/red,/area/ruin/powered)
-"l" = (/obj/structure/chair,/mob/living/carbon/alien/humanoid/sentinel,/turf/open/floor/plasteel/shuttle/red,/area/ruin/powered)
+"l" = (/obj/structure/chair,/mob/living/simple_animal/hostile/alien/sentinel,/turf/open/floor/plasteel/shuttle/red,/area/ruin/powered)
 "m" = (/obj/structure/chair,/turf/open/floor/plasteel/shuttle/red,/area/ruin/powered)
 "n" = (/obj/effect/decal/cleanable/blood,/obj/item/chair,/obj/effect/mob_spawn/human/corpse/syndicatesoldier,/turf/open/floor/plasteel/shuttle/red,/area/ruin/powered)
 "o" = (/obj/item/trash/syndi_cakes,/turf/open/floor/plasteel/shuttle/red,/area/ruin/powered)
@@ -17,12 +17,11 @@
 "q" = (/obj/effect/decal/cleanable/xenoblood,/turf/open/floor/plasteel/shuttle/red,/area/ruin/powered)
 "r" = (/obj/machinery/light{dir = 4; icon_state = "tube1"},/turf/open/floor/plasteel/shuttle/red,/area/ruin/powered)
 "s" = (/obj/machinery/light{icon_state = "tube1"; dir = 8},/turf/open/floor/plasteel/shuttle/red,/area/ruin/powered)
-"t" = (/obj/effect/decal/cleanable/blood,/obj/item/ammo_box/magazine/pistolm9mm,/obj/effect/mob_spawn/human/corpse/syndicatesoldier,/turf/open/floor/plasteel/shuttle/red,/area/ruin/powered)
-"u" = (/obj/item/chair,/turf/open/floor/plasteel/shuttle/red,/area/ruin/powered)
-"v" = (/obj/structure/closet/crate,/obj/item/clothing/glasses/meson/night,/obj/item/toy/nuke,/obj/item/toy/figure/syndie,/turf/open/floor/plasteel/shuttle/red,/area/ruin/powered)
-"w" = (/obj/structure/table,/obj/item/weapon/gun/projectile/automatic/pistol,/turf/open/floor/plasteel/shuttle/red,/area/ruin/powered)
-"x" = (/obj/structure/shuttle/engine/platform,/turf/closed/wall/shuttle/smooth,/area/ruin/powered)
-"y" = (/obj/structure/shuttle/engine/propulsion,/turf/open/space,/area/ruin/powered)
+"t" = (/obj/item/chair,/turf/open/floor/plasteel/shuttle/red,/area/ruin/powered)
+"u" = (/obj/structure/closet/crate,/obj/item/clothing/glasses/meson/night,/obj/item/toy/nuke,/obj/item/toy/figure/syndie,/turf/open/floor/plasteel/shuttle/red,/area/ruin/powered)
+"v" = (/obj/structure/table,/obj/item/weapon/gun/projectile/automatic/pistol,/turf/open/floor/plasteel/shuttle/red,/area/ruin/powered)
+"w" = (/obj/structure/shuttle/engine/platform,/turf/closed/wall/shuttle/smooth,/area/ruin/powered)
+"x" = (/obj/structure/shuttle/engine/propulsion,/turf/template_noop,/area/template_noop)
 
 (1,1,1) = {"
 abcdedcbaa
@@ -31,8 +30,8 @@ adjjkjjdaa
 adlmfmnjaa
 adopqfrjaa
 adsffpfjaa
-ajtuvqwjaa
-abxjjjxbaa
-aayaaayaaa
+ajgtuqvjaa
+abwjjjwbaa
+aaxaaaxaaa
 aaaaaaaaaa
 "}


### PR DESCRIPTION
Syndicate pod ruin had some obscure space tiles because of the way propulsion tiles worked, fixed. Also fixed the hostile npc which wasnt even a hostile npc previously and removed the useless 9mm ammo.

:cl: Stealthkibbler
bugfix: syndicate pod no longer breaches lavaland
/:cl:
