### PR TITLE
Fixed bugs with nuclear bombs, photograph descriptions, and the EMP kit description.

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -210,7 +210,10 @@ var/bomb_set
 
 /obj/machinery/nuclearbomb/process()
 	if (timing > 0)
-		countdown.start()
+		if(countdown)
+			countdown.start()
+		else
+			countdown = new(src)
 		bomb_set = 1 //So long as there is one nuke timing, it means one nuke is armed.
 		timeleft--
 		if (timeleft <= 0)
@@ -222,7 +225,8 @@ var/bomb_set
 			if ((M.client && M.machine == src))
 				attack_hand(M)
 	else
-		countdown.stop()
+		if(countdown)
+			countdown.stop()
 
 /obj/machinery/nuclearbomb/attack_paw(mob/user)
 	return attack_hand(user)

--- a/code/modules/paperwork/photography.dm
+++ b/code/modules/paperwork/photography.dm
@@ -258,9 +258,9 @@
 						holding = "They are holding \a [L.r_hand]"
 
 			if(!mob_detail)
-				mob_detail = "You can see [L] on the photo[L.health < 75 ? " - [L] looks hurt":""].[holding ? " [holding]":"."]. "
+				mob_detail = "You can see [L] on the photo[L.health < (L.maxHealth * 0.75) ? " - [L] looks hurt":""].[holding ? " [holding]":"."]. "
 			else
-				mob_detail += "You can also see [L] on the photo[L.health < 75 ? " - [L] looks hurt":""].[holding ? " [holding]":"."]."
+				mob_detail += "You can also see [L] on the photo[L.health < (L.maxHealth * 0.75) ? " - [L] looks hurt":""].[holding ? " [holding]":"."]."
 
 
 	return mob_detail

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -241,7 +241,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 
 /datum/uplink_item/dangerous/emp
 	name = "EMP Grenades and Implanter Kit"
-	desc = "A box that contains two EMP grenades and an EMP implant. Useful to disrupt communication, \
+	desc = "A box that contains five EMP grenades and an EMP implant. Useful to disrupt communication, \
 			security's energy weapons, and silicon lifeforms when you're in a tight spot."
 	item = /obj/item/weapon/storage/box/syndie_kit/emp
 	cost = 2


### PR DESCRIPTION
:cl:
bugfix: The EMP kit no longer claims to contain two EMP grenades even though it actually contains five.
bugfix: Photo descriptions will now show creatures as being hurt when they are below 75% health, instead of below 75 health.
bugfix: Fixed a bug where the nuke would sometimes not count down.
/:cl:

Fixed the nuke not working if its countdown got deleted. One round the ghost countdown got deleted somehow, and it stopped the nuke from working.

Photos were showing animals with less than 75 health as always being injured.

The EMP kit has way more than two grenades in it.
