### PR TITLE
Grief ghost is back on the menu (along with Transmit quick-cast and some runtime fixes)

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -175,8 +175,8 @@
 
 
 /datum/mind/proc/remove_gang()
-		ticker.mode.remove_gangster(src,0,1,1)
-		remove_objectives()
+	ticker.mode.remove_gangster(src,0,1,1)
+	remove_objectives()
 
 /datum/mind/proc/remove_hog_follower_prophet()
 	ticker.mode.red_deity_followers -= src
@@ -212,7 +212,8 @@
 	ticker.mode.update_wiz_icons_removed(src)
 	ticker.mode.update_cult_icons_removed(src)
 	ticker.mode.update_rev_icons_removed(src)
-	gang_datum.remove_gang_hud(src)
+	if(gang_datum)
+		gang_datum.remove_gang_hud(src)
 
 
 /datum/mind/proc/show_memory(mob/recipient, window=1)

--- a/code/game/gamemodes/miniantags/revenant/revenant.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant.dm
@@ -60,6 +60,7 @@
 	var/list/drained_mobs = list() //Cannot harvest the same mob twice
 	var/perfectsouls = 0 //How many perfect, regen-cap increasing souls the revenant has. //TODO, add objective for getting a perfect soul(s?)
 	var/image/ghostimage = null //Visible to ghost with darkness off
+	var/obj/effect/proc_holder/spell/targeted/revenant_transmit/revtransmit //Need this for quick-casting transmit
 
 /mob/living/simple_animal/revenant/New()
 	..()
@@ -90,13 +91,13 @@
 			src.mind.objectives += objective2
 			src << "<b>Objective #2</b>: [objective2.explanation_text]"
 			ticker.mode.traitors |= src.mind //Necessary for announcing
+		revtransmit = new(null)
 		AddSpell(new /obj/effect/proc_holder/spell/targeted/night_vision/revenant(null))
-		AddSpell(new /obj/effect/proc_holder/spell/targeted/revenant_transmit(null))
+		AddSpell(revtransmit)
 		AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/revenant/defile(null))
 		AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/revenant/overload(null))
 		AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/revenant/malfunction(null))
 		AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/revenant/blight(null))
-
 
 //Life, Stat, Hud Updates, and Say
 /mob/living/simple_animal/revenant/Life()
@@ -210,6 +211,7 @@
 	notransform = 1
 	revealed = 1
 	invisibility = 0
+	revtransmit = null
 	playsound(src, 'sound/effects/screech.ogg', 100, 1)
 	visible_message("<span class='warning'>[src] lets out a waning screech as violet mist swirls around its dissolving body!</span>")
 	icon_state = "revenant_draining"

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -1,12 +1,28 @@
 
 //Harvest; activated ly clicking the target, will try to drain their essence.
+//CTRL+Clicking a living mob will quick-cast Transmit
 /mob/living/simple_animal/revenant/ClickOn(atom/A, params) //revenants can't interact with the world directly.
+	var/list/modifiers = params2list(params)
+	if(modifiers["ctrl"])
+		CtrlClickOn(A)
+		return
+
 	A.examine(src)
 	if(ishuman(A))
 		if(A in drained_mobs)
 			src << "<span class='revenwarning'>[A]'s soul is dead and empty.</span>" //feedback at any range
 		else if(in_range(src, A))
 			Harvest(A)
+
+//Quick-cast transmit
+/mob/living/simple_animal/revenant/CtrlClickOn(atom/A, params)
+	if(!revtransmit)
+		return
+	if(istype(A, /mob/living))
+		var/mob/living/LM = A
+		var/list/targets = list()
+		targets += LM
+		revtransmit.cast(targets)
 
 /mob/living/simple_animal/revenant/proc/Harvest(mob/living/carbon/human/target)
 	if(!castcheck(0))

--- a/code/game/gamemodes/miniantags/revenant/revenant_spawn_event.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_spawn_event.dm
@@ -13,8 +13,8 @@
 	var/force_spawn
 	role_name = "revenant"
 
-/datum/round_event/ghost_role/revenant/New(my_force_spawn = FALSE)
-	..()
+/datum/round_event/ghost_role/revenant/New(my_force_spawn = FALSE, my_processing = TRUE)
+	..(my_processing)
 	force_spawn = my_force_spawn
 
 /datum/round_event/ghost_role/revenant/spawn_role()
@@ -41,15 +41,15 @@
 			switch(L.name)
 				if("revenantspawn")
 					spawn_locs += L.loc
-	if(!spawn_locs) //If we can't find any revenant spawns, try the carp spawns
+	if(!spawn_locs.len) //If we can't find any revenant spawns, try the carp spawns
 		for(var/obj/effect/landmark/L in landmarks_list)
 			if(isturf(L.loc))
 				switch(L.name)
 					if("carpspawn")
 						spawn_locs += L.loc
-	if(!spawn_locs) //If we can't find either, just spawn the revenant at the player's location
+	if(!spawn_locs.len) //If we can't find either, just spawn the revenant at the player's location
 		spawn_locs += get_turf(player_mind.current)
-	if(!spawn_locs) //If we can't find THAT, then just give up and cry
+	if(!spawn_locs.len) //If we can't find THAT, then just give up and cry
 		return MAP_ERROR
 
 	var/mob/living/simple_animal/revenant/revvie = new /mob/living/simple_animal/revenant/(pick(spawn_locs))

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -516,7 +516,8 @@
 	return 1
 
 /datum/admins/proc/makeRevenant()
-	new /datum/round_event/ghost_role/revenant
+	new /datum/round_event/ghost_role/revenant(TRUE)
+	return 1
 
 //Shadowling
 /datum/admins/proc/makeShadowling()

--- a/code/modules/spells/spell_types/bloodcrawl.dm
+++ b/code/modules/spells/spell_types/bloodcrawl.dm
@@ -54,6 +54,8 @@
 
 
 /turf/CtrlClick(var/mob/living/user)
+	if(!istype(user))
+		return
 	if(user.bloodcrawl)
 		for(var/obj/effect/decal/cleanable/B in src.contents)
 			if(istype(B, /obj/effect/decal/cleanable/blood) || istype(B, /obj/effect/decal/cleanable/trail_holder))


### PR DESCRIPTION
- Ports over Transmit quick-cast via CTRL+Clicking a mob;
- Fixes runtime with Ctrl+Clicking turf as a non-living mob due to not having the variable "bloodcrawl";
- Fixes runtime with Gang Datum deletion (due to it not being checked for existing first);
- Admin "Create Antagonist" now forces revenant creation;
- **Fixes revenant not spawning**

The reason I mentioned this last is because the reason it didn't spawn was pretty interesting (and quite hard to debug (disregarding the incorrect checking of spawn_loc length)). So, we have this thing (https://github.com/yogstation13/yogstation/blob/master/code/modules/events/_event.dm#L154):

```
/datum/round_event/New(my_processing = TRUE)
    setup()
    processing = my_processing
    SSevent.running += src
        return ..()
```

And the revenant New() had this: (you get a proverbial internet cookie if you can find the cause without my explanation)

```
/datum/round_event/ghost_role/revenant/New(my_force_spawn = FALSE)
    ..()
    force_spawn = my_force_spawn
```

**Q:** Why doesn't it spawn?
**A:** Because `my_force_spawn` (which is FALSE) was passed to the parent **as `my_processing`, setting it to FALSE**. Since processing was set to FALSE...it never processed. Really cool bug, but really not easy to find.
