### PR TITLE
Minor shield rebalancing

### DIFF
--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -116,7 +116,6 @@
 	desc = "Bears an inscription on the inside: <i>\"Romanes venio domus\"</i>."
 	icon_state = "roman_shield"
 	item_state = "roman_shield"
-	block_limit = 15
 
 /obj/item/weapon/shield/riot/roman/prop
 	desc = "Made of cheap, lightweight plastic. Bears an inscription on the inside: <i>\"Romanes venio domus\"</i>."
@@ -135,6 +134,7 @@
 	materials = list()
 	origin_tech = "materials=1;combat=3;biotech=2"
 	burn_state = FLAMMABLE
+	block_limit = 15
 	block_chance = 30
 
 /obj/item/weapon/shield/energy

--- a/code/game/objects/items/weapons/shields.dm
+++ b/code/game/objects/items/weapons/shields.dm
@@ -84,7 +84,7 @@
 		return ..()
 	else if(attack_type == PROJECTILE_ATTACK)
 		return ..()
-	else if(attack_type == MELEE_ATTACK && damage > block_limit)
+	else if(attack_type == MELEE_ATTACK && damage >= block_limit)
 		playsound(src, 'sound/effects/bang.ogg', 50, 1)
 		var/roll_for_shatter = check_shatter(owner, damage)
 		if(roll_for_shatter)
@@ -116,6 +116,7 @@
 	desc = "Bears an inscription on the inside: <i>\"Romanes venio domus\"</i>."
 	icon_state = "roman_shield"
 	item_state = "roman_shield"
+	block_limit = 15
 
 /obj/item/weapon/shield/riot/roman/prop
 	desc = "Made of cheap, lightweight plastic. Bears an inscription on the inside: <i>\"Romanes venio domus\"</i>."


### PR DESCRIPTION
:cl: Super3222
rscadd: Weapons / Melee attacks that do 25 brute damage now breach riot shields.
rscadd: Wooden buckler block limits are reduced to 15.
/:cl:

Thanks to the fox of yogstation for informing me about this one.
