### PR TITLE
Balance tweaks to Zombie Implants

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -121,6 +121,10 @@
 		M << "<span class='warning'>You can't put them out with just your bare hands!"
 		return
 
+	if(reagents.has_reagent("capilletum") && lying)
+		M << "<span class='warning'>[src] is dead!</span>"
+		return
+
 	if(health >= 0)
 
 		if(lying)
@@ -130,12 +134,6 @@
 			M.visible_message("<span class='notice'>[M] hugs [src] to make them feel better!</span>", \
 						"<span class='notice'>You hug [src] to make them feel better!</span>")
 
-
-		playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-
-		if(reagents.has_reagent("capilletum") && lying)
-			return
-
 		AdjustSleeping(-5)
 		AdjustParalysis(-3)
 		AdjustStunned(-3)
@@ -143,6 +141,8 @@
 		if(resting)
 			resting = 0
 			update_canmove()
+
+		playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
 /mob/living/carbon/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0)
 	. = ..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -129,6 +129,13 @@
 		else
 			M.visible_message("<span class='notice'>[M] hugs [src] to make them feel better!</span>", \
 						"<span class='notice'>You hug [src] to make them feel better!</span>")
+
+
+		playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+
+		if(reagents.has_reagent("capilletum") && lying)
+			return
+
 		AdjustSleeping(-5)
 		AdjustParalysis(-3)
 		AdjustStunned(-3)
@@ -136,8 +143,6 @@
 		if(resting)
 			resting = 0
 			update_canmove()
-
-		playsound(loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
 /mob/living/carbon/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0, visual = 0)
 	. = ..()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -678,8 +678,13 @@
 	id = "capilletum"
 	description = "A powerful toxin that exemplifies the patterns of punctured skin, matching their pigments and shapes, and then expands them across the body. Unlike other toxins, it does not have any negative effects."
 	color = "#FFB9D2"
-	metabolization_rate = 0.5 * REAGENTS_METABOLISM
-	toxpwr = 0 // no side effects
+	metabolization_rate = 0.3
+	toxpwr = 0 // the only side effect is loss of nutrition
+
+
+/datum/reagent/toxin/capilletum/on_mob_life(mob/living/M)
+	M.nutrition -= rand(20,45)
+	..()
 
 //ACID
 

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -977,6 +977,13 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_freedom
 	cost = 5
 
+/datum/uplink_item/implants/zombie
+	name = "Zombie Implant"
+	desc = "An implant injected into the body, and later activated using a bodily gesture to inject a specially formulated sedative. \
+	When lying on the ground you will appear dead and minor damage done to your body will appear more drastic than it actually is. Medical scanners will pick up on that."
+	item = /obj/item/weapon/storage/box/syndie_kit/imp_zombie
+	cost = 5
+
 /datum/uplink_item/implants/uplink
 	name = "Uplink Implant"
 	desc = "An implant injected into the body, and later activated at the user's will. It will open a separate uplink \
@@ -1016,13 +1023,6 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_macrobomb
 	cost = 20
 	include_modes = list(/datum/game_mode/nuclear)
-
-/datum/uplink_item/implants/zombie
-	name = "Zombie Implant"
-	desc = "An implant injected into the body, and later activated using a bodily gesture to inject a specially formulated sedative. \
-	When lying on the ground you will appear dead and minor damage done to your body will appear more drastic than it actually is. Medical scanners will pick up on that."
-	item = /obj/item/weapon/storage/box/syndie_kit/imp_zombie
-	cost = 7
 
 /datum/uplink_item/implants/mindslave
 	name = "Mindslave Implant"


### PR DESCRIPTION
:cl: Super3222
tweak: (buff) You can no longer help someone lying down, up on their feet if they have capilletum in their blood steam (zombie implant chemical).
tweak: (buff) Zombie implant cost is dropped to 5 from 7. It is definitely in the same tier as freedom implants.
tweak: (nerf) Zombie implants drain a random amount of nutrients from the user while capilletum is in their blood.
/:cl:
