### PR TITLE
Restricts Silicon players from becoming Double Agents

### DIFF
--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -6,6 +6,7 @@
 	required_enemies = 5
 	recommended_enemies = 8
 	reroll_friendly = 0
+	restricted_jobs = list("AI", "Cyborg")
 
 	traitors_possible = 10 //hard limit on traitors if scaling is turned off
 	num_modifier = 6 // Six additional traitors


### PR DESCRIPTION
Fixes https://github.com/yogstation13/yogstation/issues/513
:cl: Super3222
tweak: Silicons can no longer become double agents.
/:cl:
