### PR TITLE
Makes GPS's easier to use

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -8,6 +8,38 @@
 	active_power_usage = 500
 	circuit = /obj/item/weapon/circuitboard/computer/crew
 
+/obj/machinery/computer/crew/attacked_by(obj/item/I, mob/living/user)
+	..()
+	if(istype(I, /obj/item/device/gps/))
+		var/obj/item/device/gps/G = I
+		if(G.channel != "medical")
+			user << "<span class='warning'>Your GPS has an incompatiable channel!"
+			return
+
+		var/list/trackedmobs = list()
+
+		for(var/mob/living/carbon/human/H in mob_list)
+			if(H.z == z)
+				var/obj/item/clothing/under/U = H.w_uniform
+				if (U.has_sensor && U.sensor_mode)
+					if(H.name == "Unknown")
+						continue
+
+					trackedmobs += H
+
+
+		var/selection2 = input(user, "Medical GPS Interface", name) as anything in trackedmobs
+		if(!selection2)
+			return
+		if(G.emagged)
+			return
+
+		var/mob/M = selection2
+		var/turf/pos = get_turf(M)
+
+		G.savedlocation = "([pos.x], [pos.y], [pos.z])"
+		user << "<span class='notice'>Your GPS has saved the last position of [M.name].</span>"
+
 /obj/machinery/computer/crew/attack_ai(mob/user)
 	if(stat & (BROKEN|NOPOWER))
 		return

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -146,3 +146,4 @@
 	new /obj/item/weapon/defibrillator/loaded(src)
 	new /obj/item/device/radio/headset/headset_med(src)
 	new /obj/item/weapon/storage/belt/medical(src)
+	new /obj/item/device/gps/medical(src)

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -1,4 +1,5 @@
 var/list/GPS_list = list()
+
 /obj/item/device/gps
 	name = "global positioning system"
 	desc = "Helping lost spacemen find their way through the planets since 2016. Alt+click to toggle power."
@@ -11,7 +12,9 @@ var/list/GPS_list = list()
 	var/emped = 0
 	var/turf/locked_location
 	var/tracking = FALSE
-	var/channel = "Common"
+	var/channel = "common"
+	var/emagged = 0
+	var/savedlocation // preferably filled with x,y,z
 
 /obj/item/device/gps/New()
 	..()
@@ -53,12 +56,16 @@ var/list/GPS_list = list()
 		return
 
 	var/obj/item/device/gps/t = ""
+	var/turf/gpsturf = get_turf(src)
+	var/area/gpsarea = get_area(src)
 	var/gps_window_height = 110 + GPS_list.len * 20 // Variable window height, depending on how many GPS units there are to show
 	if(emped)
 		t += "ERROR"
 	else
-		t += "<BR><A href='?src=\ref[src];tag=1'>Set Tag</A> "
-		t += "<BR>Tag: [gpstag]"
+		t += "<BR><A href='?src=\ref[src];tag=1'>Set Tag</A>"
+		t += "<BR><B>[gpstag]: [format_text(gpsarea.name)] ([gpsturf.x], [gpsturf.y], [gpsturf.z])</B>"
+		if(savedlocation)
+			t += "<BR><B>SAVE: [savedlocation]</B>"
 		if(locked_location && locked_location.loc)
 			t += "<BR>Bluespace coordinates saved: [locked_location.loc]"
 			gps_window_height += 20
@@ -67,9 +74,11 @@ var/list/GPS_list = list()
 			var/turf/pos = get_turf(G)
 			var/area/gps_area = get_area(G)
 			var/tracked_gpstag = G.gpstag
+			if(G == src)
+				continue
 			if(channel != G.channel)
 				continue
-			if(G.emped == 1)
+			if((G.emagged || G.emped) == 1)
 				t += "<BR>[tracked_gpstag]: ERROR"
 			else if(G.tracking)
 				t += "<BR>[tracked_gpstag]: [format_text(gps_area.name)] ([pos.x], [pos.y], [pos.z])"
@@ -87,8 +96,36 @@ var/list/GPS_list = list()
 		a = uppertext(copytext(sanitize(a), 1, 5))
 		if(in_range(src, usr))
 			gpstag = a
-			name = "global positioning system ([gpstag])"
+			if(emagged)
+				name = "ERROR"
+			else
+				name = "global positioning system ([gpstag])"
 			attack_self(usr)
+
+
+/obj/item/device/gps/attackby(obj/item/I, mob/user, params)
+	..()
+	if(istype(I, /obj/item/device/multitool))
+		playsound(loc, 'sound/machines/click.ogg', 20, 1)
+		var/pointing_a_remote_at_the_tv = input(user, "Please choose a channel", name, gpstag) as anything in list("common", "medical", "science", "engine", "lavaland")
+
+		if(!pointing_a_remote_at_the_tv)
+			return
+
+		if(emagged)
+			return
+
+		channel = "[pointing_a_remote_at_the_tv]"
+		user << "<span class='notice'>You change the GPS's channel to [pointing_a_remote_at_the_tv]."
+
+/obj/item/device/gps/emag_act(mob/user)
+	if(!emagged)
+		user << "<span class='warning'>You scramble the GPS's tag interface."
+		emagged = 1
+
+/obj/item/device/gps/medical
+	gpstag = "MED0"
+	channel = "medical"
 
 /obj/item/device/gps/science
 	icon_state = "gps-s"


### PR DESCRIPTION
This was originally going to be a PR allowing people to create "human cakes" inspired by papa franku but meh.

:cl: Super3222
rscadd: You can now change the channel of your GPS by using a multitool on it.
rscadd: Medical GPS's can download information from crew monitors, allowing you to save the last location of anyone that has their suit sensors up. +1 to Paramedics.
tweak: Emagging a GPS will make it harder to operate. This cannot be undone. Watch out for sneaky miners emagging all the GPS's.
tweak: GPS's now start their lists with YOUR GPS. You can find it in bold letters when you use them.
/:cl:

![](http://image.prntscr.com/image/109594cedf76446eb1f9a7c612398a92.png)
