### PR TITLE
Fixes antag weights (again)

### DIFF
--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -38,15 +38,15 @@ var/list/blobs_legit = list() //used for win-score calculations, contains only b
 
 	blobwincount = initial(blobwincount) * cores_to_spawn
 
-	for(var/j = 0, j < cores_to_spawn, j++)
-		if (!antag_candidates.len)
-			break
-		var/datum/mind/blob = pick_candidate()
+	var/list/datum/mind/infestators = pick_candidate(amount = cores_to_spawn)
+	update_not_chosen_candidates()
+
+	for(var/v in infestators)
+		var/datum/mind/blob = v
 		blob_overminds += blob
 		blob.assigned_role = "Blob"
 		blob.special_role = "Blob"
 		log_game("[blob.key] (ckey) has been selected as a Blob")
-		antag_candidates -= blob
 
 	if(!blob_overminds.len)
 		return 0

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -39,18 +39,19 @@
 	else
 		num_changelings = max(1, min(num_players(), changeling_amount/2))
 
-	if(possible_changelings.len>0)
-		for(var/j = 0, j < num_changelings, j++)
-			if(!possible_changelings.len) break
-			var/datum/mind/changeling = pick(possible_changelings)
-			antag_candidates -= changeling
-			possible_changelings -= changeling
-			changelings += changeling
-			modePlayer += changelings
-			changeling.restricted_roles = restricted_jobs
-		return ..()
-	else
+	if(!possible_changelings.len)
 		return 0
+	
+	//THE ONLY PLACE IN ENTIRE GAMEMODE CODE I HAVE TO DO THIS IN FULL, JUST FUCKING FUCK
+	var/list/datum/mind/alien_mutants = pick_candidate(possible_changelings, num_changelings, 1)
+
+	for(var/v in alien_mutants)
+		var/datum/mind/changeling = v
+		changelings += changeling
+		modePlayer += changelings
+		changeling.restricted_roles = restricted_jobs
+
+	return ..()
 
 /datum/game_mode/traitor/changeling/post_setup()
 	for(var/datum/mind/changeling in changelings)

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -165,7 +165,7 @@ This file's folder contains:
 	enemy_minimum_age = 14
 	protected_jobs = list("AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Prison Officer") //Silicons can eventually be converted
 	restricted_jobs = list("Chaplain", "Captain")
-	var/servants_to_serve = list()
+	var/list/servants_to_serve = list()
 
 /datum/game_mode/clockwork_cult/announce()
 	world << "<b>The game mode is: Clockwork Cult!</b>"
@@ -178,17 +178,23 @@ This file's folder contains:
 		restricted_jobs += protected_jobs
 	if(config.protect_assistant_from_antagonist)
 		restricted_jobs += "Assistant"
-	var/starter_servants = max(1, round(num_players() / 10)) //Guaranteed one cultist - otherwise, about one cultist for every ten players
-	while(starter_servants)
-		var/datum/mind/servant = pick_candidate()
+	var/starter_servants = max(required_enemies, round(num_players() / 10)) //Guaranteed <required_enemies> cultist(s) - otherwise, about one cultist for every ten players
+
+	var/list/datum/mind/followers_of_holy_light = pick_candidate(amount = starter_servants)
+	update_not_chosen_candidates()
+
+	for(var/v in followers_of_holy_light)
+		var/datum/mind/servant = v
 		servants_to_serve += servant
-		antag_candidates -= servant
 		modePlayer += servant
 		servant.special_role = "Servant of Ratvar"
 		servant.restricted_roles = restricted_jobs
-		starter_servants--
 
+	if(servants_to_serve.len < required_enemies)
+		return 0
+	
 	handle_AI_Traitors()
+
 	return 1
 
 /datum/game_mode/clockwork_cult/post_setup()

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -72,20 +72,22 @@
 	//cult scaling goes here
 	recommended_enemies = 3 + round(num_players()/15)
 
+	var/list/datum/mind/cultists = pick_candidate(amount = recommended_enemies)
+	update_not_chosen_candidates()
 
-	for(var/cultists_number = 1 to recommended_enemies)
-		if(!antag_candidates.len)
-			break
-		var/datum/mind/cultist = pick_candidate()
-		antag_candidates -= cultist
+	for(var/v in cultists)
+		var/datum/mind/cultist = v
 		cultists_to_cult += cultist
 		cultist.special_role = "Cultist"
 		cultist.restricted_roles = restricted_jobs
 		log_game("[cultist.key] (ckey) has been selected as a cultist")
 
+	if(cultists_to_cult.len < required_enemies)
+		return 0
+	
 	handle_AI_Traitors()
 
-	return (cultists_to_cult.len>=required_enemies)
+	return 1
 
 
 /datum/game_mode/cult/proc/memorize_cult_objectives(datum/mind/cult_mind)

--- a/code/game/gamemodes/cybermen/cybermen.dm
+++ b/code/game/gamemodes/cybermen/cybermen.dm
@@ -55,14 +55,18 @@ var/datum/cyberman_network/cyberman_network
 	var/cybermen_num = max(3, round(num_players()/14))
 	#endif
 
-	while(cybermen_num)
-		var/datum/mind/cyberman = pick_candidate()
+	var/list/datum/mind/tinmen = pick_candidate(amount = cybermen_num)
+	update_not_chosen_candidates()
+
+	for(var/v in tinmen)
+		var/datum/mind/cyberman = v
 		cyberman_network.cybermen += cyberman
 		cyberman.cyberman = new /datum/cyberman_datum()
-		antag_candidates -= cyberman
 		cyberman.special_role = "Cyberman"
 		cyberman.restricted_roles = restricted_jobs
-		cybermen_num--
+
+	if(cyberman_network.cybermen.len < required_enemies)
+		return 0
 
 	handle_AI_Traitors()
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -179,8 +179,10 @@
 		if(istype(player.current,/mob/living/silicon/ai))
 			A = player.current
 
-	if(A.stat == 2 || !A.client || !A.mind) return
-	if(is_special_character(A)) return
+	if(!A || A.stat == DEAD || !A.client || !A.mind)
+		return
+	if(is_special_character(A))
+		return
 
 	ticker.mode.traitors += A.mind
 	A.mind.special_role = "traitor"
@@ -351,19 +353,25 @@
 	if(security_level < SEC_LEVEL_BLUE)
 		set_security_level(SEC_LEVEL_BLUE)
 
-// Function to pull an antag from our list of antag candidates
-/datum/game_mode/proc/pick_candidate()
+// Function to pull an antag from our list of antag candidates, by default, use antag_candidates, but can specify
+// any list of minds (this is only useful for changelings at the moment)
+// Also needs to specify amount as to not screw over the antag_weights and if we remove the chosen candidate from the
+// global antag_candidates list (fucking changeling pick code, man)
+/datum/game_mode/proc/pick_candidate(list/datum/mind/candidates = antag_candidates, amount = 0, remove_from_antag_candidates = 0)
+	if(!amount)
+		return
+	var/list/datum/mind/chosen_ones = list()
 	// If the DB is connected, use the new function. Otherwise revert to legacy pick() selection
 	if(dbcon.IsConnected())
 		var/list/ckey_listed = list()
 		var/ckey_for_sql = ""
 
-		for(var/datum/mind/player in antag_candidates)
+		for(var/datum/mind/player in candidates)
 			if(istype(player.current,/mob/living/silicon/ai))
-				antag_candidates.Remove(player) //All AI antag roles are handled seperately.  See handle_AI_Traitors()
+				candidates.Remove(player) //All AI antag roles are handled seperately.  See handle_AI_Traitors()
 
 		// Add all our antag candidates to a list()
-		for (var/datum/mind/player in antag_candidates)
+		for (var/datum/mind/player in candidates)
 			ckey_listed += sanitizeSQL(get_ckey(player))
 
 		// Turn the list into a string that we will use to filter the player table
@@ -385,46 +393,75 @@
 			output[ckey] = weight
 			total += weight
 
-		// Find a number between 0 and our weight upper bound
-		var/R = rand(0, total)
-
-		var/cumulativeWeight = 0
-		var/datum/mind/final_candidate
-		// We will loop through each antag candidate until we find the point where the
-		// random number given intersects with a candidate. All other candidates will
-		// have their chance to be antag increased while the selected candidate will have
-		// their chance decreased
-		for(var/ckey in output)
-			var/weight = output[ckey]
-			cumulativeWeight += weight
-
-			if(R <= cumulativeWeight && !final_candidate)
-				// Lowest weight is 25.
-				weight = max(25, weight / 1.5)
-				var/DBQuery/query = dbcon.NewQuery("UPDATE [format_table_name("player")] SET `antag_weight` = [weight] WHERE `ckey` = '[ckey]'")
-				query.Execute()
-
-				for(var/datum/mind/candidate in antag_candidates)
-					if(lowertext(get_ckey(candidate)) == lowertext(ckey))
-						final_candidate = candidate
-						break
-			else
-				// Maximum weight is 400.
-				weight = min(400, weight * 1.5)
-				var/DBQuery/query = dbcon.NewQuery("UPDATE [format_table_name("player")] SET `antag_weight` = [weight] WHERE `ckey` = '[ckey]'")
-				query.Execute()
-
 		for(var/client/C in clients)
 			C.last_cached_weight = output[C.ckey]
-			C.last_cached_total_weight = total
 
-		// If after all this we still don't have a candidate, then use the legacy system
-		if(!final_candidate)
-			return pick(antag_candidates)
-		else
-			return final_candidate
+		for(var/i in 1 to amount)
+			if(!candidates.len)
+				break
+
+			// Find a number between 0 and our weight upper bound
+			var/R = rand(0, total)
+			var/cumulativeWeight = 0
+			var/datum/mind/final_candidate
+			// We will loop through each antag candidate until we find the point where the
+			// random number given intersects with a candidate. All other candidates will
+			// have their chance to be antag increased while the selected candidate will have
+			// their chance decreased
+			for(var/ckey in output)
+				var/weight = output[ckey]
+				cumulativeWeight += weight
+
+				if(R <= cumulativeWeight && !final_candidate)
+					// Lowest weight is 25.
+					weight = max(25, weight / 1.5)
+					var/DBQuery/query = dbcon.NewQuery("UPDATE [format_table_name("player")] SET `antag_weight` = [weight] WHERE `ckey` = '[ckey]'")
+					query.Execute()
+
+					for(var/datum/mind/candidate in candidates)
+						if(get_ckey(candidate) == ckey)
+							final_candidate = candidate
+							total -= output[ckey]
+							break
+			// If after all this we still don't have a candidate, then use the legacy system
+			if(!final_candidate)
+				final_candidate = pick(candidates)
+
+			chosen_ones += final_candidate
+
+			if(remove_from_antag_candidates)
+				antag_candidates -= final_candidate
+			candidates -= final_candidate
 	else
-		return pick(antag_candidates)
+		for(var/i in 1 to amount)
+			var/datum/mind/final_candidate = pick(candidates)
+			chosen_ones += final_candidate
+
+			if(remove_from_antag_candidates)
+				antag_candidates -= final_candidate
+			candidates -= final_candidate
+
+	return chosen_ones
+
+
+/datum/game_mode/proc/update_not_chosen_candidates(list/datum/mind/not_chosen = antag_candidates)
+	if(dbcon.IsConnected())
+		//Ok, we're cheating quite a bit here, since this is ASSUMED to always run after we pick candidates, we
+		//have cached antag weights saved on clients that were eligible via `last_cached_weight` variable
+		//no need to query DB again
+		for(var/v in not_chosen)
+			var/datum/mind/candidate = v
+
+			if(candidate.current && candidate.current.client)
+				var/client/C = candidate.current.client
+
+				if(C && C.last_cached_weight) //if it's not null, we've updated it during the picking stage
+					var/SQL_ckey = sanitizeSQL(ckey(C.ckey)) //Better safe than sorry
+					var/weight = C.last_cached_weight
+					weight = min(400, weight * 1.5)
+					var/DBQuery/query = dbcon.NewQuery("UPDATE [format_table_name("player")] SET `antag_weight` = [weight] WHERE `ckey` = '[SQL_ckey]'")
+					query.Execute()
+					C.last_cached_weight = weight
 
 /datum/game_mode/proc/get_players_for_role(role)
 	var/list/players = list()

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -52,17 +52,16 @@ var/list/gang_colors_pool = list("red","orange","yellow","green","blue","purple"
 	if(prob(num_players() * 2))
 		gangs_to_create ++
 
-	for(var/i=1 to gangs_to_create)
-		if(!antag_candidates.len)
-			break
+	var/list/datum/mind/mafiosos = pick_candidate(amount = gangs_to_create)
+	update_not_chosen_candidates()
 
+	for(var/v in mafiosos)
 		//Create the gang
 		var/datum/gang/G = new()
 		gangs += G
 
 		//Now assign a boss for the gang
-		var/datum/mind/boss = pick_candidate()
-		antag_candidates -= boss
+		var/datum/mind/boss = v
 		G.bosses += boss
 		boss.gang_datum = G
 		boss.special_role = "[G.name] Gang Boss"

--- a/code/game/gamemodes/handofgod/_handofgod.dm
+++ b/code/game/gamemodes/handofgod/_handofgod.dm
@@ -49,10 +49,11 @@ var/global/list/global_handofgod_structuretypes = list()
 	if(config.protect_assistant_from_antagonist)
 		restricted_jobs += "Assistant"
 
-	for(var/F in 1 to recommended_enemies)
-		if(!antag_candidates.len)
-			break
-		var/datum/mind/follower = pick_n_take(antag_candidates)
+	var/list/datum/mind/hogs = pick_candidate(amount = recommended_enemies)
+	update_not_chosen_candidates()
+
+	for(var/F in hogs)
+		var/datum/mind/follower = F
 		unassigned_followers += follower
 		follower.restricted_roles = restricted_jobs
 		log_game("[follower.key] (ckey) has been selected as a follower, however teams have not been decided yet.")

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -29,11 +29,12 @@
 	if(antag_candidates.len < n_agents) //In the case of having less candidates than the selected number of agents
 		n_agents = antag_candidates.len
 
-	while(n_agents > 0)
+	var/list/datum/mind/new_cops = pick_candidate(amount = n_agents)
+	update_not_chosen_candidates()
+
+	for(var/v in new_cops)
 		var/datum/mind/new_syndicate = pick_candidate()
 		syndicates += new_syndicate
-		antag_candidates -= new_syndicate //So it doesn't pick the same guy each time.
-		n_agents--
 
 	for(var/datum/mind/synd_mind in syndicates)
 		synd_mind.assigned_role = "Syndicate"

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -44,11 +44,11 @@
 	if(config.protect_assistant_from_antagonist)
 		restricted_jobs += "Assistant"
 
-	for (var/i=1 to max_headrevs)
-		if (antag_candidates.len==0)
-			break
-		var/datum/mind/lenin = pick_candidate()
-		antag_candidates -= lenin
+	var/list/datum/mind/communists = pick_candidate(amount = max_headrevs)
+	update_not_chosen_candidates()
+
+	for(var/v in communists)
+		var/datum/mind/lenin = v
 		head_revolutionaries += lenin
 		lenin.restricted_roles = restricted_jobs
 

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -87,15 +87,15 @@ Made by Xhuis
 
 	var/shadowlings = max(2, round(num_players()/10))
 
+	var/list/datum/mind/shadowmen = pick_candidate(amount = shadowlings)
+	update_not_chosen_candidates()
 
-	while(shadowlings)
-		var/datum/mind/shadow = pick_candidate()
+	for(var/v in shadowmen)
+		var/datum/mind/shadow = v
 		shadows += shadow
-		antag_candidates -= shadow
 		modePlayer += shadow
 		shadow.special_role = "Shadowling"
 		shadow.restricted_roles = restricted_jobs
-		shadowlings--
 
 	handle_AI_Traitors()
 	return 1

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -40,21 +40,22 @@
 		num_traitors = max(1, min( round(num_players()/(config.traitor_scaling_coeff*2))+ 2 + num_modifier, round(num_players()/(config.traitor_scaling_coeff)) + num_modifier ))
 	else
 		num_traitors = max(1, min(num_players(), traitors_possible))
+		
+	var/list/datum/mind/backstabbers = pick_candidate(amount = num_traitors)
+	update_not_chosen_candidates()
 
-	for(var/j = 0, j < num_traitors, j++)
-		if (!antag_candidates.len)
-			break
-		var/datum/mind/traitor = pick_candidate()
+	for(var/v in backstabbers)
+		var/datum/mind/traitor = v
 		traitors += traitor
 		traitor.special_role = traitor_name
 		traitor.restricted_roles = restricted_jobs
 		log_game("[traitor.key] (ckey) has been selected as a [traitor_name]")
-		antag_candidates.Remove(traitor)
 
 	handle_AI_Traitors()
 
 	if(traitors.len < required_enemies)
 		return 0
+
 	return 1
 
 

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -19,15 +19,20 @@
 	world << "<B>There is a <span class='danger'>SPACE WIZARD</span>\black on the station. You can't let him achieve his objective!</B>"
 
 /datum/game_mode/wizard/pre_setup()
+	//Potential here, people. Magin' Rages Light
+	var/list/datum/mind/wizards = pick_candidate(amount = required_enemies)
+	update_not_chosen_candidates()
+	
+	for(var/v in wizards)
+		var/datum/mind/wizard = v
+		wizards += wizard
+		modePlayer += wizard
+		wizard.assigned_role = "Wizard"
+		wizard.special_role = "Wizard"
+		if(wizardstart.len == 0)
+			wizard.current << "<span class='boldannounce'>A starting location for you could not be found, please report this bug!</span>"
+			return 0
 
-	var/datum/mind/wizard = pick_candidate()
-	wizards += wizard
-	modePlayer += wizard
-	wizard.assigned_role = "Wizard"
-	wizard.special_role = "Wizard"
-	if(wizardstart.len == 0)
-		wizard.current << "<span class='boldannounce'>A starting location for you could not be found, please report this bug!</span>"
-		return 0
 	for(var/datum/mind/wiz in wizards)
 		wiz.current.loc = pick(wizardstart)
 


### PR DESCRIPTION
fixes #505 

**Tested with 1/2 clients on traitor mode with 1/2 possible traitors. Everything works properly.**

**Cause:** pick_candidate() was ran as many times as we need candidates. Since this proc picks ONE candidate (decreasing the weight) and increases the weight of those it didn't pick, we ended up in a situation where, because this proc was called multiple times, it increased weights more than once (even if the candidate was picked later).
In fact, math works out in such a way that only the first candidate to get picked actually get their weight decreased (divided by 1.5), 2nd candidate weight didn't change (multiplied by 1.5 on first pick_candidate(), divided by 1.5 on second pick_candidate()), 3rd candidate got their weight multiplied by 1.5 (/1.5 \* 1.5 \* 1.5).

**Fix:** REWRITE FUCKING EVERYTHING. Not really, but still, the fix wasn't as simple as I'd like it to be. Had to add some parameters to make it loop and separate non-picked candidate weight update into another proc.

:cl: X-TheDark
bugfix: Antagonist weights should be working properly now.
/:cl:
