### PR TITLE
Fixes Toxin Testing Range sometimes returning the bomb

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -48836,9 +48836,9 @@
 /area/toxins/mixing)
 "bSd" = (
 /obj/item/target,
-/turf/open/floor/plating{
-	icon_state = "warnplate";
-	dir = 1
+/turf/open/floor/plating/airless{
+	dir = 1;
+	icon_state = "warnplate"
 	},
 /area/toxins/test_area)
 "bSe" = (
@@ -50788,9 +50788,10 @@
 /obj/item/target/alien{
 	anchored = 1
 	},
-/turf/open/floor/plating{
+/turf/open/indestructible{
 	dir = 4;
 	icon_state = "warnplate";
+	initial_gas_mix = "TEMP=2.7";
 	luminosity = 2
 	},
 /area/toxins/test_area)
@@ -52717,7 +52718,8 @@
 /area/space)
 "bZI" = (
 /obj/item/target,
-/turf/open/floor/plating{
+/turf/open/floor/plating/airless{
+	dir = 2;
 	icon_state = "warnplate"
 	},
 /area/toxins/test_area)


### PR DESCRIPTION
The bomb strikes back like a boomerang...no more. Apparently the bomb bounces off the indestructible wall and returns to the sender sometimes.

To fix this, I just replaced the tile under the camera with a indestructible one that I modified the air mix and dir variables.
