### PR TITLE
Fixes airlocks not closing properly when sped up

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -989,11 +989,6 @@ var/list/airlock_overlays = list()
 	else
 		playsound(src.loc, 'sound/machines/airlockforced.ogg', 30, 1)
 
-	if(autoclose && normalspeed)
-		addtimer(src, "autoclose", 150)
-	else if(autoclose && !normalspeed)
-		addtimer(src, "autoclose", 10)
-
 	if(!density)
 		return 1
 	if(!ticker || !ticker.mode)
@@ -1010,6 +1005,12 @@ var/list/airlock_overlays = list()
 	operating = 0
 	air_update_turf(1)
 	update_freelook_sight()
+
+	if(autoclose && normalspeed)
+		addtimer(src, "autoclose", 150)
+	else if(autoclose && !normalspeed)
+		addtimer(src, "autoclose", 10)
+
 	return 1
 
 


### PR DESCRIPTION
Riiight, since TGUI interface is a bust, I should probably PR this separately.

During the TGUI'fication of airlock interface, I've discovered that the airlock sleeps for a total of 14 ticks and we add a timer to close door after 10 ticks before the sleep, so the airlock never closes. Just switching the place where it adds the timer.

:cl: X-TheDark
bugfix: Airlocks now work properly if their timing is changed.
/:cl:
