### PR TITLE
AI eye qdel restriction

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -156,7 +156,13 @@ var/list/ai_list = list()
 	ai_list -= src
 	shuttle_caller_list -= src
 	SSshuttle.autoEvac()
+	qdel(holo_icon)
+	aiPDA = null
+	aiMulti = null
+	builtInCamera = null
+	eyeobj.ai = null
 	qdel(eyeobj) // No AI, no Eye
+	eyeobj = null
 	return ..()
 
 

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -38,8 +38,10 @@
 	return null
 
 /mob/camera/aiEye/Destroy()
-	ai = null
-	return ..()
+	if(ai)
+		return
+	else
+		return ..()
 
 /atom/proc/move_camera_by_click()
 	if(istype(usr, /mob/living/silicon/ai))


### PR DESCRIPTION
Doesn't fix the underlying problem (whatever tries to delete the AI eye).
AI eye will abort its qdeletion if its AI still exists.

Also nulls a bunch of references on AI qdel
Fixes #560
