### PR TITLE
[DNM]Removes Autorifles from cargo, reduces export value of minerals 5 times.

### DIFF
--- a/code/modules/cargo/exports/materials.dm
+++ b/code/modules/cargo/exports/materials.dm
@@ -46,7 +46,7 @@
 
 // Plasma. The oil of 26 century. The reason why you are here.
 /datum/export/material/plasma
-	cost = 500
+	cost = 100
 	material_id = MAT_PLASMA
 	message = "cm3 of plasma"
 
@@ -57,19 +57,19 @@
 
 // Uranium. Still useful for both power generation and nuclear annihilation.
 /datum/export/material/uranium
-	cost = 400
+	cost = 80
 	material_id = MAT_URANIUM
 	message = "cm3 of uranium"
 
 // Gold. Used in electronics and corrosion-resistant plating.
 /datum/export/material/gold
-	cost = 250
+	cost = 50
 	material_id = MAT_GOLD
 	message = "cm3 of gold"
 
 // Silver.
 /datum/export/material/silver
-	cost = 100
+	cost = 20
 	material_id = MAT_SILVER
 	message = "cm3 of silver"
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -326,22 +326,6 @@
 	crate_type = /obj/structure/closet/crate/secure/plasma
 	dangerous = TRUE
 
-/datum/supply_pack/security/armory/wt550
-	name = "WT-550 Auto Rifle Crate"
-	cost = 3500
-	contains = list(/obj/item/weapon/gun/projectile/automatic/wt550,
-					/obj/item/weapon/gun/projectile/automatic/wt550)
-	crate_name = "auto rifle crate"
-
-/datum/supply_pack/security/armory/wt550ammo
-	name = "WT-550 Auto Rifle Ammo Crate"
-	cost = 3000
-	contains = list(/obj/item/ammo_box/magazine/wt550m9,
-					/obj/item/ammo_box/magazine/wt550m9,
-					/obj/item/ammo_box/magazine/wt550m9,
-					/obj/item/ammo_box/magazine/wt550m9)
-	crate_name = "auto rifle ammo crate"
-
 /datum/supply_pack/security/armory/mindshield
 	name = "mindshield implants Crate"
 	cost = 4000


### PR DESCRIPTION
Use shotguns for which you can't carry twenty magazines in your bag and can't quick reload them to just mow down the megafauna now. The guns were hardly ever ordered for any other reason than megafauna hunting, also shotguns>rifles.

Reasoning for export changes - Muh infinite credits 5 minutes into a round. QM can pretty much just go and mine plasma for two minutes to get more credits than he will ever use, or wait 10-15 for miners to bring him the shit. Values for diamonds and bananium unchanged due to how rare they are.

:cl: The Sad Fox
rscdel: Autorifles were removed from cargo. Glory to shotguns!
tweak: Export values for minerals were reduced dramatically.
/:cl:
