### PR TITLE
Increases AFK Threshold for Admin ticket discord messages and round end ticket delay

### DIFF
--- a/code/modules/admin/admin_helper.dm
+++ b/code/modules/admin/admin_helper.dm
@@ -5,7 +5,7 @@
 		var/invalid = 0
 		if(!check_rights_for(X, R_TICKET))
 			invalid = 1
-		if(X.is_afk(600))
+		if(X.is_afk())
 			invalid = 1
 		if(!invalid)
 			admins_online++


### PR DESCRIPTION
Increased time till an admin is considered AFK(Well, AFK according to the total_active_admins proc) to 5 minutes(Previously 1 minute)
