### PR TITLE
Adds Design and Technology disks that can hold more than one entry

### DIFF
--- a/code/game/gamemodes/cybermen/cybermen_hacking.dm
+++ b/code/game/gamemodes/cybermen/cybermen_hacking.dm
@@ -949,8 +949,13 @@
 
 /datum/cyberman_hack/tech_disk/complete()
 	var/obj/item/weapon/disk/tech_disk/D = target
-	if(get_research(D.stored))
-		D.stored = null
+	var/got_research = 0
+	for(var/i in 1 to D.max_tech_stored)
+		var/datum/tech/tech = D.tech_stored[i]
+		if(tech)
+			got_research |= get_research(tech)
+		D.tech_stored[i] = null
+	if(got_research)
 		cyberman_network.message_all_cybermen("New research levels uploaded. Cybermen network now has [calc_research_levels()] research level\s.")
 	..()
 

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -128,8 +128,9 @@
 		busy = 1
 		var/obj/item/weapon/disk/design_disk/D = O
 		if(do_after(user, 14.4, target = src))
-			files.AddDesign2Known(D.blueprint)
-
+			for(var/B in D.blueprints)
+				if(B)
+					files.AddDesign2Known(B)
 		busy = 0
 		return 1
 

--- a/code/modules/cargo/exports/research.dm
+++ b/code/modules/cargo/exports/research.dm
@@ -7,13 +7,19 @@
 
 /datum/export/tech/get_cost(obj/O)
 	var/obj/item/weapon/disk/tech_disk/D = O
-	if(!D.stored)
-		return 0
-	var/datum/tech/tech = D.stored
-	return ..() * tech.getCost(techLevels[tech.id])
+	var/cost = 0
+	for(var/V in D.tech_stored)
+		if(!V)
+			continue
+		var/datum/tech/tech = V
+		cost += tech.getCost(techLevels[tech.id])
+	return ..() * cost
 
 /datum/export/tech/sell_object(obj/O)
 	..()
 	var/obj/item/weapon/disk/tech_disk/D = O
-	var/datum/tech/tech = D.stored
-	techLevels[tech.id] = tech.level
+	for(var/V in D.tech_stored)
+		if(!V)
+			continue
+		var/datum/tech/tech = V
+		techLevels[tech.id] = tech.level

--- a/code/modules/hydroponics/biogenerator.dm
+++ b/code/modules/hydroponics/biogenerator.dm
@@ -140,7 +140,9 @@
 		processing = 1
 		var/obj/item/weapon/disk/design_disk/D = O
 		if(do_after(user, 10, target = src))
-			files.AddDesign2Known(D.blueprint)
+			for(var/B in D.blueprints)
+				if(B)
+					files.AddDesign2Known(B)
 		processing = 0
 		return 1
 	else

--- a/code/modules/ninja/suit/suit_attackby.dm
+++ b/code/modules/ninja/suit/suit_attackby.dm
@@ -41,15 +41,24 @@
 
 		else if(istype(I, /obj/item/weapon/disk/tech_disk))//If it's a data disk, we want to copy the research on to the suit.
 			var/obj/item/weapon/disk/tech_disk/TD = I
-			if(TD.stored)//If it has something on it.
+			var/has_research = 0
+			for(var/V in  TD.tech_stored)
+				if(V)
+					has_research = 1
+					break
+			if(has_research)//If it has something on it.
 				U << "Research information detected, processing..."
 				if(do_after(U,s_delay, target = src))
-					for(var/datum/tech/current_data in stored_research)
-						if(current_data.id==TD.stored.id)
-							if(current_data.level<TD.stored.level)
-								current_data.level=TD.stored.level
-							break
-					TD.stored = null
+					for(var/V1 in 1 to TD.max_tech_stored)
+						var/datum/tech/new_data = TD.tech_stored[V1]
+						TD.tech_stored[V1] = null
+						if(!new_data)
+							continue
+						for(var/V2 in stored_research)
+							var/datum/tech/current_data = V2
+							if(current_data.id == new_data.id)
+								current_data.level = max(current_data.level, new_data.level)
+								break
 					U << "<span class='notice'>Data analyzed and updated. Disk erased.</span>"
 				else
 					U << "<span class='userdanger'>ERROR</span>: Procedure interrupted. Process terminated."

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -46,15 +46,24 @@ other types of metals and chemistry for reagents).
 ////////////////////////////////////////
 
 /obj/item/weapon/disk/design_disk
-	name = "Component Design Disk"
+	name = "component design disk"
 	desc = "A disk for storing device design data for construction in lathes."
 	icon_state = "datadisk1"
-	materials = list(MAT_METAL=100, MAT_GLASS=100)
-	var/datum/design/blueprint
+	materials = list(MAT_METAL=300, MAT_GLASS=100)
+	var/list/blueprints = list()
+	var/max_blueprints = 1
 
 /obj/item/weapon/disk/design_disk/New()
 	src.pixel_x = rand(-5, 5)
 	src.pixel_y = rand(-5, 5)
+	for(var/i in 1 to max_blueprints)
+		blueprints += null
+
+/obj/item/weapon/disk/design_disk/adv
+	name = "advanced component design disk"
+	desc = "A disk for storing device design data for construction in lathes. This one has extra storage space."
+	materials = list(MAT_METAL=300, MAT_GLASS=100, MAT_SILVER = 50)
+	max_blueprints = 5
 
 ///////////////////////////////////
 /////Non-Board Computer Stuff//////
@@ -94,6 +103,16 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/disk/design_disk
 	category = list("Electronics")
 
+/datum/design/design_disk_adv
+	name = "Advanced Design Storage Disk"
+	desc = "Produce additional disks for storing device designs."
+	id = "design_disk_adv"
+	req_tech = list("programming" = 3)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 300, MAT_GLASS = 100, MAT_SILVER=50)
+	build_path = /obj/item/weapon/disk/design_disk/adv
+	category = list("Electronics")
+
 /datum/design/tech_disk
 	name = "Technology Data Storage Disk"
 	desc = "Produce additional disks for storing technology data."
@@ -104,6 +123,25 @@ other types of metals and chemistry for reagents).
 	build_path = /obj/item/weapon/disk/tech_disk
 	category = list("Electronics")
 
+/datum/design/tech_disk_adv
+	name = "Advanced Technology Data Storage Disk"
+	desc = "Produce disks with extra storage capacity for storing technology data."
+	id = "tech_disk_adv"
+	req_tech = list("programming" = 3)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 300, MAT_GLASS = 100, MAT_SILVER=50)
+	build_path = /obj/item/weapon/disk/tech_disk/adv
+	category = list("Electronics")
+
+/datum/design/tech_disk_super_adv
+	name = "Quantum Technology Data Storage Disk"
+	desc = "Produce disks with extremely large storage capacity for storing technology data."
+	id = "tech_disk_super_adv"
+	req_tech = list("programming" = 6)
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 300, MAT_GLASS = 100, MAT_SILVER=100, MAT_GOLD=100)
+	build_path = /obj/item/weapon/disk/tech_disk/super_adv
+	category = list("Electronics")
 
 /////////////////////////////////////////
 /////////////////Mining//////////////////

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -22,8 +22,8 @@ operations to skip that console. This is useful if you want to make a "public" R
 a circuit imprinter with certain designs on it and don't want it accidentally updating. The downside of this method is that you have
 to have physical access to the other console to send data back. Note: An R&D console is on Centcom so if a random griffan happens to
 cause a ton of data to be lost, an admin can go send it back.
-- The second method is with Technology Disks and Design Disks. Each of these disks can hold a single technology or design datum in
-it's entirety. You can then take the disk to any R&D console and upload it's data to it. This method is a lot more secure (since it
+- The second method is with Technology Disks and Design Disks. Each of these disks can hold technology or design datums in
+their entirety. You can then take the disk to any R&D console and upload it's data to it. This method is a lot more secure (since it
 won't update every console in existence) but it's more of a hassle to do. Also, the disks can be stolen.
 
 

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -51,6 +51,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 
 	var/selected_category
 	var/list/datum/design/matching_designs = list() //for the search function
+	var/disk_slot_selected = 0
 
 
 /proc/CallTechName(ID) //A simple helper proc to find the name of a tech with a given ID.
@@ -121,8 +122,10 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			user << "A disk is already loaded into the machine."
 			return
 
-		if(istype(D, /obj/item/weapon/disk/tech_disk)) t_disk = D
-		else if (istype(D, /obj/item/weapon/disk/design_disk)) d_disk = D
+		if(istype(D, /obj/item/weapon/disk/tech_disk))
+			t_disk = D
+		else if (istype(D, /obj/item/weapon/disk/design_disk))
+			d_disk = D
 		else
 			user << "<span class='danger'>Machine cannot accept disks in that format.</span>"
 			return
@@ -161,6 +164,9 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 	add_fingerprint(usr)
 
 	usr.set_machine(src)
+	if(href_list["disk_slot"])
+		disk_slot_selected = text2num(href_list["disk_slot"])
+
 	if(href_list["menu"]) //Switches menu screens. Converts a sent text string into a number. Saves a LOT of code.
 		var/temp_screen = text2num(href_list["menu"])
 		screen = temp_screen
@@ -169,16 +175,34 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		selected_category = href_list["category"]
 
 	else if(href_list["updt_tech"]) //Update the research holder with information from the technology disk.
+		var/n = text2num(href_list["updt_tech"])
 		screen = 0.0
-		spawn(50)
+		var/wait = 50
+		if(!n)
+			wait = 0
+			for(var/D in t_disk.tech_stored)
+				if(D)
+					wait += 50
+		spawn(wait)
 			screen = 1.2
-			files.AddTech2Known(t_disk.stored)
-			updateUsrDialog()
-			griefProtection() //Update centcom too
+			if(t_disk)
+				if(!n)
+					for(var/tech in t_disk.tech_stored)
+						if(tech)
+							files.AddTech2Known(tech)
+				else
+					files.AddTech2Known(t_disk.tech_stored[n])
+				updateUsrDialog()
+				griefProtection() //Update centcom too
 
 	else if(href_list["clear_tech"]) //Erase data on the technology disk.
 		if(t_disk)
-			t_disk.stored = null
+			var/n = text2num(href_list["clear_tech"])
+			if(!n)
+				for(var/i in 1 to t_disk.max_tech_stored)
+					t_disk.tech_stored[i] = null
+			else
+				t_disk.tech_stored[n] = null
 
 	else if(href_list["eject_tech"]) //Eject the technology disk.
 		if(t_disk)
@@ -187,20 +211,39 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		screen = 1.0
 
 	else if(href_list["copy_tech"]) //Copy some technology data from the research holder to the disk.
-		t_disk.stored = files.known_tech[href_list["copy_tech_ID"]]
+		var/slot = text2num(href_list["copy_tech"])
+		t_disk.tech_stored[slot] = files.known_tech[href_list["copy_tech_ID"]]
 		screen = 1.2
 
 	else if(href_list["updt_design"]) //Updates the research holder with design data from the design disk.
+		var/n = text2num(href_list["updt_design"])
 		screen = 0.0
-		spawn(50)
+		var/wait = 50
+		if(!n)
+			wait = 0
+			for(var/D in d_disk.blueprints)
+				if(D)
+					wait += 50
+		spawn(wait)
 			screen = 1.4
-			files.AddDesign2Known(d_disk.blueprint)
-			updateUsrDialog()
-			griefProtection() //Update centcom too
+			if(d_disk)
+				if(!n)
+					for(var/D in d_disk.blueprints)
+						if(D)
+							files.AddDesign2Known(D)
+				else
+					files.AddDesign2Known(d_disk.blueprints[n])
+				updateUsrDialog()
+				griefProtection() //Update centcom too
 
 	else if(href_list["clear_design"]) //Erases data on the design disk.
 		if(d_disk)
-			d_disk.blueprint = null
+			var/n = text2num(href_list["clear_design"])
+			if(!n)
+				for(var/i in 1 to d_disk.max_blueprints)
+					d_disk.blueprints[i] = null
+			else
+				d_disk.blueprints[n] = null
 
 	else if(href_list["eject_design"]) //Eject the design disk.
 		if(d_disk)
@@ -209,6 +252,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		screen = 1.0
 
 	else if(href_list["copy_design"]) //Copy design data from the research holder to the design disk.
+		var/slot = text2num(href_list["copy_design"])
 		var/datum/design/D = files.known_designs[href_list["copy_design_ID"]]
 		if(D)
 			var/autolathe_friendly = 1
@@ -224,7 +268,7 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			if(D.build_type & (AUTOLATHE|PROTOLATHE|CRAFTLATHE)) // Specifically excludes circuit imprinter and mechfab
 				D.build_type = autolathe_friendly ? (D.build_type | AUTOLATHE) : D.build_type
 				D.category |= "Imported"
-			d_disk.blueprint = D
+			d_disk.blueprints[slot] = D
 		screen = 1.4
 
 	else if(href_list["eject_item"]) //Eject the item inside the destructive analyzer.
@@ -525,6 +569,8 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 		griefProtection()
 		var/choice = alert("R&D Console Database Reset", "Are you sure you want to reset the R&D console's database? Data lost cannot be recovered.", "Continue", "Cancel")
 		if(choice == "Continue")
+			message_admins("[key_name_admin(usr)] reset \the [src.name]'s database")
+			log_game("[key_name_admin(usr)] reset \the [src.name]'s database")
 			screen = 0.0
 			qdel(files)
 			files = new /datum/research(src)
@@ -640,22 +686,19 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 			dat += "</div>"
 
 		if(1.2) //Technology Disk Menu
-
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
-			dat += "<div class='statusDisplay'>Technology Data Disk Contents:<BR><BR>"
-			if(t_disk.stored == null)
-				dat += "The disk has no data stored on it.</div>"
-				dat += "Operations: "
-				dat += "<A href='?src=\ref[src];menu=1.3'>Load Tech to Disk</A>"
-			else
-				dat += "Name: [t_disk.stored.name]<BR>"
-				dat += "Level: [t_disk.stored.level]<BR>"
-				dat += "Description: [t_disk.stored.desc]</div>"
-				dat += "Operations: "
-				dat += "<A href='?src=\ref[src];updt_tech=1'>Upload to Database</A>"
-				dat += "<A href='?src=\ref[src];clear_tech=1'>Clear Disk</A>"
-			dat += "<A href='?src=\ref[src];eject_tech=1'>Eject Disk</A>"
-
+			dat += "Disk Operations: <A href='?src=\ref[src];clear_tech=0'>Clear Disk</A><A href='?src=\ref[src];updt_tech=0'>Upload All</A><A href='?src=\ref[src];eject_tech=1'>Eject Disk</A>"
+			for(var/i in 1 to t_disk.max_tech_stored)
+				dat += "<div class='statusDisplay'>"
+				if(t_disk.tech_stored[i])
+					var/datum/tech/tech = t_disk.tech_stored[i]
+					dat += "Name: [tech.name]<BR>"
+					dat += "Level: [tech.level]<BR>"
+					dat += "Description: [tech.desc]<BR>"
+					dat += "Operations: <A href='?src=\ref[src];updt_tech=[i]'>Upload to Database</A><A href='?src=\ref[src];clear_tech=[i]'>Clear Slot</A>"
+				else
+					dat += "Empty Slot<BR>Operations: <A href='?src=\ref[src];menu=1.3;disk_slot=[i]'>Load Tech to Slot</A>"
+				dat += "</div>"
 		if(1.3) //Technology Disk submenu
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
 			dat += "<A href='?src=\ref[src];menu=1.2'>Return to Disk Operations</A><div class='statusDisplay'>"
@@ -664,43 +707,41 @@ won't update every console in existence) but it's more of a hassle to do. Also, 
 				var/datum/tech/T = files.known_tech[v]
 				if(T.level <= 0)
 					continue
-				dat += "[T.name] "
-				dat += "<A href='?src=\ref[src];copy_tech=1;copy_tech_ID=[T.id]'>Copy to Disk</A><BR>"
+				dat += "[T.name]"
+				dat += "<A href='?src=\ref[src];copy_tech=[disk_slot_selected];copy_tech_ID=[T.id]'>Copy to Disk</A><BR>"
 			dat += "</div>"
 
 		if(1.4) //Design Disk menu.
-			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><div class='statusDisplay'>"
-			if(d_disk.blueprint == null)
-				dat += "The disk has no data stored on it.</div>"
-				dat += "Operations: "
-				dat += "<A href='?src=\ref[src];menu=1.5'>Load Design to Disk</A>"
-			else
-				dat += "Name: [d_disk.blueprint.name]<BR>"
-				var/b_type = d_disk.blueprint.build_type
-				if(b_type)
-					dat += "Lathe Types:<BR>"
-					if(b_type & IMPRINTER) dat += "Circuit Imprinter<BR>"
-					if(b_type & PROTOLATHE) dat += "Protolathe<BR>"
-					if(b_type & AUTOLATHE) dat += "Autolathe<BR>"
-					if(b_type & MECHFAB) dat += "Exosuit Fabricator<BR>"
-					if(b_type & BIOGENERATOR) dat += "Biogenerator<BR>"
-				dat += "Required Materials:<BR>"
-				var/all_mats = d_disk.blueprint.materials + d_disk.blueprint.reagents
-				for(var/M in all_mats)
-					dat += "* [CallMaterialName(M)] x [all_mats[M]]<BR>"
-				dat += "</div>Operations: "
-				dat += "<A href='?src=\ref[src];updt_design=1'>Upload to Database</A>"
-				dat += "<A href='?src=\ref[src];clear_design=1'>Clear Disk</A>"
-			dat += "<A href='?src=\ref[src];eject_design=1'>Eject Disk</A>"
-
-		if(1.5) //Technology disk submenu
+			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A><HR>"
+			dat += "Disk Operations: <A href='?src=\ref[src];clear_design=0'>Clear Disk</A><A href='?src=\ref[src];updt_design=0'>Upload All</A><A href='?src=\ref[src];eject_design=1'>Eject Disk</A>"
+			for(var/i in 1 to d_disk.max_blueprints)
+				dat += "<div class='statusDisplay'>"
+				if(d_disk.blueprints[i])
+					var/datum/design/D = d_disk.blueprints[i]
+					dat += "Name: [D.name]<BR>"
+					if(D.build_type)
+						dat += "Lathe Types:<BR>"
+						if(D.build_type & IMPRINTER) dat += "Circuit Imprinter<BR>"
+						if(D.build_type & PROTOLATHE) dat += "Protolathe<BR>"
+						if(D.build_type & AUTOLATHE) dat += "Autolathe<BR>"
+						if(D.build_type & MECHFAB) dat += "Exosuit Fabricator<BR>"
+						if(D.build_type & BIOGENERATOR) dat += "Biogenerator<BR>"
+					dat += "Required Materials:<BR>"
+					var/all_mats = D.materials + D.reagents
+					for(var/M in all_mats)
+						dat += "* [CallMaterialName(M)] x [all_mats[M]]<BR>"
+					dat += "Operations: <A href='?src=\ref[src];updt_design=[i]'>Upload to Database</A> <A href='?src=\ref[src];clear_design=[i]'>Clear Slot</A>"
+				else
+					dat += "Empty Slot<BR>Operations: <A href='?src=\ref[src];menu=1.5;disk_slot=[i]'>Load Design to Slot</A>"
+				dat += "</div>"
+		if(1.5) //Design disk submenu
 			dat += "<A href='?src=\ref[src];menu=1.0'>Main Menu</A>"
 			dat += "<A href='?src=\ref[src];menu=1.4'>Return to Disk Operations</A><div class='statusDisplay'>"
 			dat += "<h3>Load Design to Disk:</h3><BR>"
 			for(var/v in files.known_designs)
 				var/datum/design/D = files.known_designs[v]
 				dat += "[D.name] "
-				dat += "<A href='?src=\ref[src];copy_design=1;copy_design_ID=[D.id]'>Copy to Disk</A><BR>"
+				dat += "<A href='?src=\ref[src];copy_design=[disk_slot_selected];copy_design_ID=[D.id]'>Copy to Disk</A><BR>"
 			dat += "</div>"
 
 		if(1.6) //R&D console settings

--- a/code/modules/research/research.dm
+++ b/code/modules/research/research.dm
@@ -289,12 +289,42 @@ research holder datum.
 	return cost
 
 /obj/item/weapon/disk/tech_disk
-	name = "Technology Disk"
+	name = "technology disk"
 	desc = "A disk for storing technology data for further research."
 	icon_state = "datadisk0"
-	materials = list(MAT_METAL=30, MAT_GLASS=10)
-	var/datum/tech/stored
+	materials = list(MAT_METAL=300, MAT_GLASS=100)
+	var/list/tech_stored = list()
+	var/max_tech_stored = 1
 
 /obj/item/weapon/disk/tech_disk/New()
 	src.pixel_x = rand(-5, 5)
 	src.pixel_y = rand(-5, 5)
+	for(var/i in 1 to max_tech_stored)
+		tech_stored += null
+
+/obj/item/weapon/disk/tech_disk/adv
+	name = "advanced technology disk"
+	desc = "A disk for storing technology data for further research. This one has extra storage space."
+	materials = list(MAT_METAL=300, MAT_GLASS=100, MAT_SILVER=50)
+	max_tech_stored = 5
+
+/obj/item/weapon/disk/tech_disk/super_adv
+	name = "quantum technology disk"
+	desc = "A disk for storing technology data for further research. This one has extremely large storage space."
+	materials = list(MAT_METAL=300, MAT_GLASS=100, MAT_SILVER=100, MAT_GOLD=100)
+	max_tech_stored = 10
+
+/obj/item/weapon/disk/tech_disk/debug
+	name = "centcomm technology disk"
+	desc = "A debug item for research"
+	materials = list()
+	max_tech_stored = 0
+
+/obj/item/weapon/disk/tech_disk/debug/New()
+	..()
+	var/list/techs = subtypesof(/datum/tech)
+	max_tech_stored = techs.len
+	for(var/V in techs)
+		var/datum/tech/T = new V()
+		tech_stored += T
+		T.level = 8

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -51,11 +51,12 @@
 	name = "Golem Creation Disk"
 	desc = "A gift from the Liberator."
 	icon_state = "datadisk1"
+	max_blueprints = 1
 
 /obj/item/weapon/disk/design_disk/golem_shell/New()
 	..()
 	var/datum/design/golem_shell/G = new
-	blueprint = G
+	blueprints[1] = G
 
 /datum/design/golem_shell
 	name = "Golem Shell Construction"


### PR DESCRIPTION
:cl:
rscadd: Space floppy-disk technology has advanced to the point that multiple #technologies or designs can be stored on a single disk.
/:cl:
Also made technology disks have the same materials as they cost to create.

Tier 1 tech disks hold 1 technology, require programming 1, and cost 300 metal and 100 glass
Tier 2 tech disks hold 5 technologies, require programming 3, and cost 300 metal, 100 glass, and 50 silver
Tier 3 tech disks hold 10 technologies, require programming 6, and cost 300 metal, 100 glass, 100 silver, and 100 gold

Tier 1 design disks hold 1 design, require programming 1, and cost 300 metal and 100 glass
Tier 2 design disks hold 5 designs, require programming 3, and cost 300 metal, 100 glass, and 50 silver

Added a debug design disk that has all technologies at level 8, because it's faster than deconstructing a research object seven times.
