### PR TITLE
Adds several failsafes for restarting the server

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -12,6 +12,7 @@ var/datum/subsystem/ticker/ticker
 	var/restart_timeout = 250	//delay when restarting server
 	var/current_state = GAME_STATE_STARTUP	//state of current round (used by process()) Use the defines GAME_STATE_* !
 	var/force_ending = 0					//Round was ended by admin intervention
+	var/server_reboot_in_progress = 0
 
 	var/hide_mode = 0
 	var/datum/game_mode/mode = null
@@ -132,7 +133,7 @@ var/datum/subsystem/ticker/ticker
 					var/unresolved_tickets = total_unresolved_tickets()
 
 					if(unresolved_tickets && admins_online)
-						ticker.delay_end = 1
+						delay_end = 1
 						message_admins("Not all tickets have been resolved. Server restart delayed.")
 					else if(unresolved_tickets && !admins_online)
 						world.Reboot("Round ended, but there were still active tickets. Please submit a player complaint if you did not receive a response.", "end_proper", "ended with open tickets")
@@ -141,6 +142,13 @@ var/datum/subsystem/ticker/ticker
 							world.Reboot("Station destroyed by Nuclear Device.", "end_proper", "nuke")
 						else
 							world.Reboot("Round ended.", "end_proper", "proper completion")
+
+		if(GAME_STATE_FINISHED)
+			if(!server_reboot_in_progress && !delay_end)
+				var/unresolved_tickets = total_unresolved_tickets()
+				if(!unresolved_tickets)
+					world.Reboot("No unresolved tickets, restarting round.", "end_proper", "proper completion")
+
 
 /datum/subsystem/ticker/proc/setup()
 		//Create and announce mode

--- a/code/modules/admin/tickets/admin_ticket_procs.dm
+++ b/code/modules/admin/tickets/admin_ticket_procs.dm
@@ -203,11 +203,14 @@
 
 	if(resolved && ticker.delay_end)
 		if(unresolvedCount == 0)
-			if(alert(usr, "You have resolved the last ticket (the server restart is currently delayed!). Would you like to restart the server now?", "Restart Server", "Restart", "Cancel") == "Restart")
-				ticker.delay_end = 0
-				world.Reboot("Initiated by [usr.client.holder.fakekey ? "Admin" : usr.key].", "end_proper", "proper completion", 100)
+			if(check_rights_for(get_client(usr), R_TICKET)) //Only admins get to select whether to restart server or not
+				if(alert(usr, "You have resolved the last ticket (the server restart is currently delayed!). Would you like to restart the server now?", "Restart Server", "Restart", "Cancel") == "Restart")
+					ticker.delay_end = 0
+					world.Reboot("Initiated by [usr.client.holder.fakekey ? "Admin" : usr.key].", "end_proper", "proper completion", 100)
+				else
+					message_admins("[usr.key] has closed the last ticket but chose not to restart the server. You can <A HREF='?_src_=holder;adminserverrestart=1'>restart the server</a> manually, if you choose to do so.")
 			else
-				usr << "<span class='ticket-status'>You chose not to restart the server. If you do not have permissions to restart the server normally, you can still do so by making a new ticket and resolving it again.</span>"
+				message_admins("[usr.key] closed their ticket which was the last ticket. Server can now be <A HREF='?_src_=holder;adminserverrestart=1'>restarted</a>.")
 
 	if(resolved)
 		if(!establish_db_connection())

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -2394,3 +2394,16 @@
 			if("11")
 				set_cybermen_queued_objective()
 		cybermen_panel()//refresh the page.
+	
+	else if(href_list["adminserverrestart"])
+		if(!check_rights(R_TICKET))
+			usr << "Clients without ticket administration rights cannot use this command. Get out of here, coder!"
+			return
+		if(ticker.current_state != GAME_STATE_FINISHED)
+			usr << "The round has not yet ended. You cannot restart the server using this option at this time."
+			return
+		if(ticker.server_reboot_in_progress)
+			usr << "A server reboot is already in progress."
+			return
+		ticker.delay_end = 0
+		world.Reboot("Initiated by [usr.client.holder.fakekey ? "Admin" : usr.key].", "end_proper", "proper completion", 100)

--- a/code/world.dm
+++ b/code/world.dm
@@ -241,6 +241,7 @@ var/last_irc_status = 0
 			log_admin("[key_name(usr)] Has requested an immediate world restart via client side debugging tools")
 			message_admins("[key_name_admin(usr)] Has requested an immediate world restart via client side debugging tools")
 		world << "<span class='boldannounce'>Rebooting World immediately due to host request</span>"
+		ticker.server_reboot_in_progress = 1
 		return ..(1)
 	var/delay
 	if(time)
@@ -251,11 +252,13 @@ var/last_irc_status = 0
 		world << "<span class='boldannounce'>An admin has delayed the round end.</span>"
 		return
 	world << "<span class='boldannounce'>Rebooting World in [delay/10] [delay > 10 ? "seconds" : "second"]. [reason]</span>"
+	ticker.server_reboot_in_progress = 1
 	sleep(delay)
 	if(blackbox)
 		blackbox.save_all_data_to_sql()
 	if(ticker.delay_end)
 		world << "<span class='boldannounce'>Reboot was cancelled by an admin.</span>"
+		ticker.server_reboot_in_progress = 0
 		return
 	if(mapchanging)
 		world << "<span class='boldannounce'>Map change operation detected, delaying reboot.</span>"


### PR DESCRIPTION
fixes #637 

Sometimes, the server gets pretty upset with our moderator staff and becomes impossible to restart without +server.

To fix this, several failsafes were implemented:
- If last ticket is closed by admin, but he/she chooses not to restart the server, admins are notified with a manual restart option, that allows even Moderators to restart the server;
- If last ticket closed by non-admin, staff are notified with restart option;
- **Both above measures require R_TICKET right, therefore, they are not usable by coders**;
- If somehow the round end is not delayed, but the server is not restarting, the ticker will restart the server, if the round has ended;

In this example, xthedark has administration rights (R_TICKET), xthedark_2 is non-admin client who made and closed their own ticket:
![untitled](https://cloud.githubusercontent.com/assets/2188139/17955158/cc424b48-6a88-11e6-9165-1d73e8f798b6.png)
### Tests performed
- Round end with open ticket, no admins;
- Round end without open tickets, no admins;
- Round end, open ticket, with admin : Closed ticket, chose to restart server;
- ^ : Closed ticket, server not restarted; Admin selected the manual option;
- ^ : Closed ticket by creating non-admin used; Admin selected the manual option;
- Was not able to reproduce round end not delayed, but server not restarting scenario;
