### PR TITLE
Fixes hand tele portals sometimes not expiring

### DIFF
--- a/code/game/objects/items/weapons/teleportation.dm
+++ b/code/game/objects/items/weapons/teleportation.dm
@@ -149,9 +149,9 @@ Frequency:
 			if(A.noteleport)
 				continue
 			if(com.power_station && com.power_station.teleporter_hub && com.power_station.engaged)
-				L["[get_area(com.target)] (Active)"] = com.target
+				L["[get_area(com.target)] (Active)"] = com.target.loc
 			else
-				L["[get_area(com.target)] (Inactive)"] = com.target
+				L["[get_area(com.target)] (Inactive)"] = com.target.loc
 	var/list/turfs = list(	)
 	for(var/turf/T in urange(10, orange=1))
 		if(T.x>world.maxx-8 || T.x<8)


### PR DESCRIPTION
fixes #580

We expect the portal `turf/target` to be a turf, but pass it the beacon itself, instead of the beacon's location turf.

:cl: X-TheDark
bugfix: Hand tele no longer create infinite duration portals.
/:cl:
