### PR TITLE
Ports the cid randomizer detector from tgstation.

### DIFF
--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -72,6 +72,8 @@
 	var/forbid_singulo_possession = 0
 	var/useircbot = 0
 
+	var/check_randomizer = 0
+
 	var/admin_legacy_system = 0	//Defines whether the server uses the legacy admin system with admins.txt or the SQL system. Config option in config.txt
 	var/ban_legacy_system = 0	//Defines whether the server uses the legacy banning system with the files in /data or the SQL system. Config option in config.txt
 	var/use_antag_tokens = 0 //Defines whether the server uses the antag tokens system. Requires database.
@@ -438,6 +440,8 @@
 					config.client_error_message = value
 				if("discord_token")
 					discord_token = value
+				if("check_randomizer")
+					config.check_randomizer = 1
 
 				else
 					diary << "Unknown setting in configuration: '[name]'"

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -393,7 +393,7 @@ var/next_external_rsc = 0
 	if (!dbcon.IsConnected())
 		return
 
-	var/sql_ckey = sanitizeSQL(src.ckey)
+	var/sql_ckey = sanitizeSQL(ckey)
 
 	var/DBQuery/query_ip = dbcon.NewQuery("SELECT ckey FROM [format_table_name("player")] WHERE ip = '[address]' AND ckey != '[sql_ckey]'")
 	query_ip.Execute()
@@ -407,14 +407,19 @@ var/next_external_rsc = 0
 	while (query_cid.NextRow())
 		related_accounts_cid += "[query_cid.item[1]], "
 
+	var/admin_rank = "Player"
+	if (src.holder && src.holder.rank)
+		admin_rank = src.holder.rank.name
+	else
+		if (check_randomizer())
+			return
+
+
 	var/watchreason = check_watchlist(sql_ckey)
 	if(watchreason)
 		message_admins("<font color='red'><B>Notice: </B></font><font color='blue'>[key_name_admin(src)] is on the watchlist and has just connected - Reason: [watchreason]</font>")
 		send2irc_adminless_only("Watchlist", "[key_name(src)] is on the watchlist and has just connected - Reason: [watchreason]")
 
-	var/admin_rank = "Player"
-	if (src.holder && src.holder.rank)
-		admin_rank = src.holder.rank.name
 
 	var/sql_ip = sanitizeSQL(src.address)
 	var/sql_computerid = sanitizeSQL(src.computer_id)
@@ -473,3 +478,81 @@ var/next_external_rsc = 0
 	spawn (10) //removing this spawn causes all clients to not get verbs.
 		//Precache the client with all other assets slowly, so as to not block other browse() calls
 		getFilesSlow(src, SSasset.cache, register_asset = FALSE)
+
+/client/proc/check_randomizer()
+	. = FALSE
+	if (!config.check_randomizer)
+		return
+	var/static/cidcheck = list()
+	var/static/cidcheck_failedckeys = list() //to avoid spamming the admins if the same guy keeps trying.
+
+	var/oldcid = cidcheck[ckey]
+	if (oldcid)
+		if (oldcid != computer_id) //IT CHANGED!!!
+			cidcheck -= ckey //so they can try again after removing the cid randomizer.
+
+			src << "<span class='userdanger'>Connection Error:</span>"
+			src << "<span class='danger'>Invalid ComputerID(spoofed). Please remove the ComputerID spoofer from your byond installation and try again.</span>"
+
+			if (!cidcheck_failedckeys[ckey])
+				message_admins("<span class='adminnotice'>[key_name(src)] has been detected as using a cid randomizer. Connection rejected.</span>")
+				send2irc_adminless_only("CidRandomizer", "[key_name(src)] has been detected as using a cid randomizer. Connection rejected.")
+				cidcheck_failedckeys[ckey] = 1
+				note_randomizer_user()
+
+			log_access("Failed Login: [key] [computer_id] [address] - CID randomizer confirmed (oldcid: [oldcid])")
+
+			del(src)
+			return TRUE
+		else
+			if (cidcheck_failedckeys[ckey])
+				message_admins("<span class='adminnotice'>[key_name_admin(src)] has been allowed to connect after showing they removed their cid randomizer</span>")
+				send2irc_adminless_only("CidRandomizer", "[key_name(src)] has been allowed to connect after showing they removed their cid randomizer.")
+				cidcheck_failedckeys -= ckey
+			cidcheck -= ckey
+	else
+		var/sql_ckey = sanitizeSQL(ckey)
+		var/DBQuery/query_cidcheck = dbcon.NewQuery("SELECT computerid FROM [format_table_name("player")] WHERE ckey = '[sql_ckey]'")
+		query_cidcheck.Execute()
+
+		var/lastcid
+		if (query_cidcheck.NextRow())
+			lastcid = query_cidcheck.item[1]
+
+		if (computer_id != lastcid)
+			cidcheck[ckey] = computer_id
+			log_access("Failed Login: [key] [computer_id] [address] - CID randomizer check")
+
+			var/url = winget(src, null, "url")
+			//special javascript to make them reconnect under a new window.
+			src << browse("<a id='link' href=byond://[url]>byond://[url]</a><script type='text/javascript'>document.getElementById(\"link\").click();window.location=\"byond://winset?command=.quit\"</script>", "border=0;titlebar=0;size=1x1")
+			winset(src, "reconnectbutton", "is-disable=true") //reconnect keeps the same cid in the randomizer, they could use this button to fake it.
+			sleep(10) //browse is queued, we don't want them to disconnect before getting the browse() command.
+
+			//teeheehee (in case the above method doesn't work, its not 100% reliable.)
+			src << "<pre class=\"system system\">Network connection shutting down due to read error.</pre>"
+			del(src)
+			return TRUE
+
+/client/proc/note_randomizer_user()
+	var/const/adminckey = "CID-Error"
+	var/sql_ckey = sanitizeSQL(ckey)
+	//check to see if we noted them in the last day.
+	var/DBQuery/query_get_notes = dbcon.NewQuery("SELECT id FROM [format_table_name("notes")] WHERE ckey = '[sql_ckey]' AND adminckey = '[adminckey]' AND timestamp + INTERVAL 1 DAY < NOW()")
+	if(!query_get_notes.Execute())
+		var/err = query_get_notes.ErrorMsg()
+		log_game("SQL ERROR obtaining id from notes table. Error : \[[err]\]\n")
+		return
+	if (query_get_notes.NextRow())
+		return
+
+	//regardless of above, make sure their last note is not from us, as no point in repeating the same note over and over.
+	query_get_notes = dbcon.NewQuery("SELECT adminckey FROM [format_table_name("notes")] WHERE ckey = '[sql_ckey]' ORDER BY timestamp DESC LIMIT 1")
+	if(!query_get_notes.Execute())
+		var/err = query_get_notes.ErrorMsg()
+		log_game("SQL ERROR obtaining id from notes table. Error : \[[err]\]\n")
+		return
+	if (query_get_notes.NextRow())
+		if (query_get_notes.item[1] == adminckey)
+			return
+	add_note(ckey, "Detected as using a cid randomizer.", null, adminckey, logged = 0)

--- a/config/config.txt
+++ b/config/config.txt
@@ -114,6 +114,10 @@ HOSTEDBY Yogstation13-bot
 ## Uncomment this to stop people connecting to your server without a registered ckey. (i.e. guest-* are all blocked from connecting)
 GUEST_BAN
 
+## Comment to disable checking for the cid randomizer dll. (disabled if database isn't enabled or connected)
+CHECK_RANDOMIZER
+
+
 ## Uncomment to allow web client connections
 #ALLOW_WEBCLIENT
 

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -643,7 +643,7 @@ menu "menu"
 	elem
 		name = ""
 		category = "&File"
-	elem
+	elem "reconnectbutton"
 		name = "&Reconnect"
 		category = "&File"
 		command = ".reconnect"


### PR DESCRIPTION
Credit to @MrStonedOne at tgstation/tgstation#20058.

When a user's cid doesn't match their last cid, we open a new game window to the server, and close the old one, if it changed again, we disallow the connection.

They are free to try again once they remove the randomizer dll.

Admins are notified on first match for the user, and it will leave a note on the user as long as it hasn't left one recently.

It is a config, defaults on, but requires db before actually activating.
