### PR TITLE
Using Telekinesis adds hiddenprints to objects

### DIFF
--- a/code/_onclick/telekinesis.dm
+++ b/code/_onclick/telekinesis.dm
@@ -40,6 +40,7 @@ var/const/tk_maxrange = 15
 	user.put_in_active_hand(O)
 	O.host = user
 	O.focus_object(src)
+	add_hiddenprint(user)
 	return
 
 /obj/item/attack_tk(mob/user)
@@ -49,6 +50,7 @@ var/const/tk_maxrange = 15
 	user.put_in_active_hand(O)
 	O.host = user
 	O.focus_object(src)
+	add_hiddenprint(user)
 	return
 
 


### PR DESCRIPTION
TK'ing an item or an object didn't leave hiddenprints for administrative purposes.
### Tests performed
- Grabbing a Welding Helmet or Toolbelt left hidden fingerprints on those items;
- Grabbing a locker with TK left hidden prints;

:cl: X-TheDark
rscadd: Using Telekinesis on items now adds hidden fingerprints.
/:cl:
