### PR TITLE
Re-adds total of antag weight caching on clients during candidate picking

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -400,6 +400,7 @@
 
 		for(var/client/C in clients)
 			C.last_cached_weight = output[C.ckey]
+			C.last_cached_total_weight = total
 
 		for(var/i in 1 to amount)
 			if(!candidates.len)


### PR DESCRIPTION
When I was fixing the antag weights, I removed the caching of the total, because I actually though that we didn't have the antag weight checking verb...whoops.

This doesn't matter too much, but this does decrease the times DB is queried.

NOTICE: The total antag weight might not be perfectly accurate, since it doesn't account for weight changes AFTER it's cached in pick_candidate.
