### PR TITLE
Fixes NODISMEMBER flag screwing up species changes

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -105,7 +105,10 @@ Please contact me on #coderbus IRC. ~Carnie x
 	//CHECK FOR UPDATE
 	var/oldkey = icon_render_key
 	icon_render_key = generate_icon_render_key()
-	if(oldkey == icon_render_key)
+
+	//Skip bodypart generation if keys match if and only if we actually have the bodypart overlay as well
+	//If we changed our species from NODISMEMBER to one without that, we WON'T have the bodypart overlays, even if the rendering keys will match
+	if((oldkey == icon_render_key) && overlays_standing[BODYPARTS_LAYER])
 		return
 
 	remove_overlay(BODYPARTS_LAYER)


### PR DESCRIPTION
fixes #683

**Issue:** NODISMEMBER caused `update_body_parts()` to delete the bodypart overlay and never regenerated it due to matching icon rendering keys. Basically, it's because of how NODISMEMBER species don't use bodyparts, which screws everything up when you becomes a dismemberable species.

**Fix:** Add a check for existance of bodypart overlay. If we don't have it, we force the update of bodyparts (and creation of overlay), even if the keys match.

A less ass fix would be to port /tg/'s (by phil) changes that make all species (even NODISMEMBER ones) use the bodypart system to create their sprite.
