### PR TITLE
Fixes turfs not applying slowdown to mob movement

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -166,7 +166,11 @@ var/next_mob_id = 0
 		M.show_message( message, 2, deaf_message, 1)
 
 /mob/proc/movement_delay()
-	return 0
+	. = 0
+	if(isturf(loc))
+		var/turf/open/current_loc = loc
+		. += current_loc.slowdown
+	return .
 
 /mob/proc/Life()
 	set waitfor = 0


### PR DESCRIPTION
fixes #685 

:cl: X-TheDark
bugfix: Turfs/Tiles now actually apply their slowdown to mob movement speed.
/:cl:
