### PR TITLE
Crafting a cloth muzzle now uses the cloth

### DIFF
--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -28,7 +28,7 @@
 /datum/crafting_recipe/cloth_muzzle
 	name = "cloth muzzle"
 	reqs = list(
-		/obj/item/clothing/torncloth
+		/obj/item/clothing/torncloth = 1
 	)
 	result = /obj/item/clothing/mask/muzzle/cloth
 	category = CAT_WEAPON


### PR DESCRIPTION
Fixes an oversight on my part, causing you to be able to craft infinite cloth muzzles.

:cl:
rscfix: Fixes cloth muzzle
rscadd: Adds purrbation 
rscadd: Adds a donor tab
tweak: Moved the old donor features to the donor tab
rscfix: Fixes missing bulletproof flashlight sprite
/:cl:
Also adds some changelog I messed up
