### PR TITLE
You can now feed people crayons

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -329,14 +329,28 @@
 
 /obj/item/toy/crayon/attack(mob/M, mob/user)
 	if(edible && (M == user))
-		user << "You take a bite of the [src.name]. Delicious!"
-		var/eaten = use_charges(5)
-		var/fraction = min(eaten / reagents.total_volume, 1)
-		reagents.reaction(M, INGEST, fraction * volume_multiplier)
-		reagents.trans_to(M, eaten, volume_multiplier)
-		// check_empty() is called during afterattack
+		user << "<span class='notice'>You take a bite of the [src.name]. Delicious!</span>"
+		eatcrayon(M, user)
+	if(edible && (M != user))
+		if(istype(M, /mob/living/carbon/human))
+			user << "<span class='notice'>You start feeding [M.name] the [src.name]</span>"
+			M << "<span class='warning'>[user.name] is feeding you the [src.name]!</span>"
+			if(do_after(user, 30, target = M))
+				M.visible_message("<span class='notice'>[user.name] feeds [M.name] the [src.name]. Delicious!</span>")
+				eatcrayon(M, user)
+		else
+			..()
+
 	else
 		..()
+
+/obj/item/toy/crayon/proc/eatcrayon(mob/M, mob/user)
+	var/eaten = use_charges(5)
+	var/fraction = min(eaten / reagents.total_volume, 1)
+	reagents.reaction(M, INGEST, fraction * volume_multiplier)
+	reagents.trans_to(M, eaten, volume_multiplier)
+	// check_empty() is called during afterattack
+	playsound(M.loc,'sound/items/eatfood.ogg', rand(10,50), 1)
 
 /obj/item/toy/crayon/proc/can_claim_for_gang(mob/user, atom/target)
 	// Check area validity.

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -266,6 +266,8 @@
 			var/washears = 1
 			var/washglasses = 1
 
+			M.color = null //Washes off the colorful reagent color, mainly a counter to the clowns rainbow crayon
+
 			if(H.wear_suit)
 				washgloves = !(H.wear_suit.flags_inv & HIDEGLOVES)
 				washshoes = !(H.wear_suit.flags_inv & HIDESHOES)


### PR DESCRIPTION
You can now feed crayons to other people. It has the normal timer when aiming at someone else.

Also, this means the rainbow crayon can be fed to other people to color them.

Showers now remove color overlays to combat the clowns crayon. Space cleaner doesn't work, I did that on purpose to force people to shower.

:cl:
tweak: You can now feed crayons to others
tweak: The shower now removes color overlays
/:cl:
