### PR TITLE
Adds a chameleon box to the syndicate uplink

### DIFF
--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -849,3 +849,26 @@
 	new /obj/item/weapon/grenade/barrier(src)
 	new /obj/item/weapon/grenade/barrier(src)
 	new /obj/item/weapon/grenade/barrier(src)
+
+/obj/item/weapon/storage/box/chameleon
+	name = "chameleon box"
+	desc = "An eerie box with the label 'syndicate (TM)'"
+	icon_state = "box_of_doom"
+
+/obj/item/weapon/storage/box/chameleon/New()
+	..()
+	var/datum/action/item_action/chameleon/change/chameleon_action = new(src)
+	chameleon_action.chameleon_type = /obj/item/weapon/storage/box
+	chameleon_action.chameleon_name = "Box"
+	chameleon_action.initialize_disguises()
+
+
+/obj/item/weapon/storage/box/chameleon/examine(mob/user)
+	..()
+	if(user.mind in ticker.mode.traitors)
+		user << "<span class='notice'>Activate to chamouflage the [src.name]</span>"
+
+/obj/item/weapon/storage/box/chameleon/attack_self(mob/user)
+	return
+
+

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -866,7 +866,7 @@
 /obj/item/weapon/storage/box/chameleon/examine(mob/user)
 	..()
 	if(user.mind in ticker.mode.traitors)
-		user << "<span class='notice'>Activate to chamouflage the [src.name]</span>"
+		user << "<span class='notice'>Activate to camouflage the [src.name]</span>"
 
 /obj/item/weapon/storage/box/chameleon/attack_self(mob/user)
 	return

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -281,10 +281,10 @@
 	new /obj/item/weapon/reagent_containers/syringe(src)
 	new /obj/item/weapon/reagent_containers/glass/bottle/tuberculosiscure(src)
 
-/obj/item/weapon/storage/box/syndie_kit/chameleon
+/obj/item/weapon/storage/box/chameleon
 	name = "chameleon kit"
 
-/obj/item/weapon/storage/box/syndie_kit/chameleon/New()
+/obj/item/weapon/storage/box/chameleon/New()
 	..()
 	new /obj/item/clothing/under/chameleon(src)
 	new /obj/item/clothing/suit/chameleon(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -22,6 +22,7 @@
 			new /obj/item/device/chameleon(src)
 			new /obj/item/weapon/soap/syndie(src)
 			new /obj/item/clothing/glasses/thermal/syndi(src)
+			new /obj/item/weapon/storage/box/chameleon(src)
 			return
 
 		if("bond")

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -648,6 +648,12 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	item = /obj/item/weapon/storage/box/syndie_kit/chameleon
 	cost = 4
 
+/datum/uplink_item/stealthy_tools/chambox
+	name = "Chameleon Box"
+	desc = "A versatile box that can be disguised as any other box (match box etc) to avoid security searching it."
+	item = /obj/item/weapon/storage/box/chameleon
+	cost = 1
+
 /datum/uplink_item/stealthy_tools/syndigaloshes
 	name = "No-Slip Chameleon Shoes"
 	desc = "These shoes will allow the wearer to run on wet floors and slippery objects without falling down. \

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -645,14 +645,8 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 /datum/uplink_item/stealthy_tools/chameleon
 	name = "Chameleon Kit"
 	desc = "A set of items that contain chameleon technology allowing you to disguise as pretty much anything on the station, and more!"
-	item = /obj/item/weapon/storage/box/syndie_kit/chameleon
-	cost = 4
-
-/datum/uplink_item/stealthy_tools/chambox
-	name = "Chameleon Box"
-	desc = "A versatile box that can be disguised as any other box (match box etc) to avoid security searching it."
 	item = /obj/item/weapon/storage/box/chameleon
-	cost = 1
+	cost = 4
 
 /datum/uplink_item/stealthy_tools/syndigaloshes
 	name = "No-Slip Chameleon Shoes"


### PR DESCRIPTION
Adds a chameleon box that can be disguised into about any other box and alike.

Thanks to the chameleon copy pasta code this was done very easily, so I don't mind if this get's rejected.

:cl:
rscadd: The cameleon kit now spawns in a cameleon box.
/:cl:

Idea by: RoboticPotato
