### PR TITLE
The rev flash flashes when it is on cooldown

### DIFF
--- a/code/game/gamemodes/revolution/revflash.dm
+++ b/code/game/gamemodes/revolution/revflash.dm
@@ -84,6 +84,8 @@
 			M.confused += power
 
 	rev_cooldown = 1
+	icon_state = "memorizer2"
 	spawn(REVPEN_COOLDOWN)
+		icon_state = initial(icon_state)
 		rev_cooldown = 0
 		src.visible_message("<span class='notice'>[src] vibrates.</span>")


### PR DESCRIPTION
The sprites were already in, I do not know why it was not doing this already.

:cl:
tweak: the rev flash now blinks when it is on cooldown
/:cl:
