### PR TITLE
horrorform var tweaks plus making it so they can't be cuffed EVER

### DIFF
--- a/code/game/gamemodes/changeling/powers/horrorform.dm
+++ b/code/game/gamemodes/changeling/powers/horrorform.dm
@@ -50,15 +50,18 @@
 			var/list/missing = H.get_missing_limbs()
 			if(missing.len)
 				H.regenerate_limbs(1)
-			for(var/datum/reagent/R in H.reagents.reagent_list)
-				qdel(R)
 			H.underwear = "Nude"
 			H.undershirt = "Nude"
 			H.socks = "Nude"
 			var/newNameId = "Shambling Abomination"
 			user.real_name = newNameId
 			user.name = usr.real_name
+			user.SetParalysis(0)
 			user.SetStunned(0)
+			user.SetWeakened(0)
+			user.reagents.clear_reagents()
+			for(var/obj/item/I in user) //cuffing while permastunned was a shit oversight
+				user.unEquip(I)
 			for(var/obj/item/I in user) //in case any weird stuff happens with flesh clothing
 				qdel(I)
 			user.equip_to_slot_or_del(new /obj/item/clothing/shoes/abomination(user), slot_shoes)
@@ -95,7 +98,7 @@
 		changeling.reverting = 1
 		changeling.geneticdamage += 50
 		user.Weaken(15)
-		user.apply_damage(10, CLONE)
+		user.apply_damage(30, CLONE)
 
 	if(changeling.chem_charges == 0)
 		user.visible_message("<span class='warning'>[user] suddenly shrinks back down to a normal size.</span>")
@@ -106,7 +109,7 @@
 			HM.force_lose(H)
 		changeling.reverting = 1
 		changeling.geneticdamage += 20
-		user.Weaken(8)
+		user.Weaken(5)
 
 
 	if(changeling.reverting == 1)

--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -29,6 +29,10 @@
 		apply_cuffs(user,user)
 		return
 
+	if(C.dna.species.id == "abomination")
+		user <<"<span class='warning'>[C] doesn't have much hands to speak of!</span>"
+		return
+
 	if(!C.handcuffed)
 		if(C.get_num_arms() >= 2)
 			add_logs(user, C, "attempted to handcuff")
@@ -37,6 +41,9 @@
 
 			playsound(loc, cuffsound, 30, 1, -2)
 			if(do_mob(user, C, 30) && C.get_num_arms() >= 2)
+				if(C.dna.species.id == "abomination")
+					user <<"<span class='warning'>[C] doesn't have much hands to speak of!</span>"
+					return
 				apply_cuffs(C,user)
 				user << "<span class='notice'>You handcuff [C].</span>"
 				if(istype(src, /obj/item/weapon/restraints/handcuffs/cable))


### PR DESCRIPTION
unironically makes horrorform more effective at killing 

-correctly unstuns from everything upon transformation
-decreases chemloss per tick because even at max chems it's difficult to effectively chase people down and kill them without reverting
-REMOVED HORRORFORM CUFFING COMPLETELY FUCK CUFFS
-slightly decreased stun upon chemloss reversion
-increased clone damage upon reversion via damage, 10 damage wasn't enough to give a shit about

:cl: ShadowDeath6
rscdel: Cuffing abominations
tweak: Decreased horrorform's chemical drain
/:cl:
