### PR TITLE
buffing construct cult again

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -890,7 +890,7 @@ var/list/teleport_runes = list()
 			ghosts_on_rune |= O
 	var/mob/dead/observer/ghost_to_spawn = pick(ghosts_on_rune)
 	for(var/obj/item/device/soulstone/S in get_turf(src))
-		user <<"<span class='warning'>You absorb the manifested soul of [ghost_to_spawn] through [S]!</span>"
+		user <<"<span class='warning'>You attempt to absorb the manifested soul of [ghost_to_spawn] through [S]!</span>"
 		add_logs(user, ghost_to_spawn, "captured [ghost_to_spawn.name]'s soul", S)
 		S.transfer_soul("VICTIM", ghost_to_spawn, user)
 		return

--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -855,7 +855,7 @@ var/list/teleport_runes = list()
 //Rite of Spectral Manifestation: Summons a ghost on top of the rune as a cultist human with no items. User must stand on the rune at all times, and takes damage for each summoned ghost.
 /obj/effect/rune/manifest
 	cultist_name = "Manifest Spirit"
-	cultist_desc = "manifests a spirit as a servant of the Geometer. The invoker must not move from atop the rune, and will take damage for each summoned spirit."
+	cultist_desc = "manifests a spirit as a servant of the Geometer. The invoker must not move from atop the rune, and will take damage for each summoned spirit. Placing a soulstone on the rune will capture the soul of the manifested spirit."
 	invocation = "Gal'h'rfikk harfrandid mud'gib!" //how the fuck do you pronounce this
 	icon_state = "6"
 	construct_invoke = 0
@@ -889,6 +889,11 @@ var/list/teleport_runes = list()
 		if(O.client && !jobban_isbanned(O, ROLE_CULTIST))
 			ghosts_on_rune |= O
 	var/mob/dead/observer/ghost_to_spawn = pick(ghosts_on_rune)
+	for(var/obj/item/device/soulstone/S in get_turf(src))
+		user <<"<span class='warning'>You absorb the manifested soul of [ghost_to_spawn] through [S]!</span>"
+		add_logs(user, ghost_to_spawn, "captured [ghost_to_spawn.name]'s soul", S)
+		S.transfer_soul("VICTIM", ghost_to_spawn, user)
+		return
 	var/mob/living/carbon/human/new_human = new(get_turf(src))
 	new_human.real_name = ghost_to_spawn.real_name
 	new_human.alpha = 150 //Makes them translucent

--- a/code/game/gamemodes/cult/talisman.dm
+++ b/code/game/gamemodes/cult/talisman.dm
@@ -315,20 +315,20 @@
 //Talisman of Fabrication: Creates a construct shell out of 25 metal sheets.
 /obj/item/weapon/paper/talisman/construction
 	cultist_name = "Talisman of Construction"
-	cultist_desc = "Use this talisman on at least twenty-five metal sheets to create an empty construct shell"
+	cultist_desc = "Use this talisman on construction materials to form advanced items for the cult. Using it on 25 sheets of regular metal will form a construct shell. Using it on plasteel will convert it into runed metal. Using it on 25 sheets of reinforced glass will create a soulstone."
 	invocation = "Ethra p'ni dedol!"
 	color = "#000000" // black
 
 /obj/item/weapon/paper/talisman/construction/attack_self(mob/living/user)
 	if(iscultist(user))
-		user << "<span class='warning'>To use this talisman, place it upon a stack of metal sheets.</span>"
+		user << "<span class='warning'>To use this talisman, place it upon a stack of metal sheets, plasteel, or reinforced glass.</span>"
 	else
 		user << "<span class='danger'>There are indecipherable images scrawled on the paper in what looks to be... <i>blood?</i></span>"
 
 
 /obj/item/weapon/paper/talisman/construction/attack(obj/M,mob/living/user)
 	if(iscultist(user))
-		user << "<span class='cultitalic'>This talisman will only work on a stack of metal sheets!</span>"
+		user << "<span class='cultitalic'>This talisman will only work on metal, plasteel, and reinforced glass!</span>"
 		log_game("Construct talisman failed - not a valid target")
 
 /obj/item/weapon/paper/talisman/construction/afterattack(obj/item/stack/sheet/target, mob/user, proximity_flag, click_parameters)
@@ -349,8 +349,15 @@
 			user << "<span class='warning'>The talisman clings to the plasteel, transforming it into runed metal!</span>"
 			user << sound('sound/effects/magic.ogg',0,1,25)
 			qdel(src)
+		if(istype(target, /obj/item/stack/sheet/rglass))
+			var/turf/T = get_turf(target)
+			if(target.use(25))
+				new /obj/item/device/soulstone(T)
+				user <<"<span class='warning'>The talisman clings to the glass, forcing it to contract and twist, turning a bloody red!</span>"
+				user << sound('sound/effects/magic.ogg',0,1,25)
+				qdel(src)
 		else
-			user << "<span class='warning'>The talisman must be used on metal or plasteel!</span>"
+			user << "<span class='warning'>The talisman must be used on metal, plasteel, or reinforced glass!</span>"
 
 
 //Talisman of Shackling: Applies special cuffs directly from the talisman


### PR DESCRIPTION
https://github.com/yogstation13/yogstation/issues/694

Makes soulstones able to be constructed via talisman for 25 reinforced glass
putting a soulstone on top of a manifest rune will manifest the captured soul INTO the stone

no bugs I swear

:cl: ShadowDeath6
rscadd: The Talisman of Construction can be used on 25 sheets of reinforced glass to create a soulstone.
rscadd: Soulstones can be placed on manifest runes to pull ghosts into soulstones.
/:cl:
