### PR TITLE
changes bubblegum's loot to be less griefy

### DIFF
--- a/code/game/gamemodes/antag_spawner.dm
+++ b/code/game/gamemodes/antag_spawner.dm
@@ -238,7 +238,7 @@
 
 /obj/item/weapon/antag_spawner/slaughter_demon/attack_self(mob/user)
 	var/list/demon_candidates = get_candidates(ROLE_ALIEN)
-	if(user.z != 1)
+	if(user.z != ZLEVEL_STATION)
 		user << "<span class='notice'>You should probably wait until you reach the station.</span>"
 		return
 	if(demon_candidates.len > 0)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -730,3 +730,9 @@
 	desc = "You almost regret picking this up."
 	force = 25
 	color = "#FF0000"
+
+
+/obj/item/weapon/nullrod/chainsaw/bubblegum/suicide_act(mob/user)
+	user.visible_message("<span class='suicide'>[user] is feeding \himself to \the [src.name]! It looks like \he's trying to join Bubblegum!</span>")
+	playsound(user.loc, 'sound/magic/Demon_consume.ogg', 100, 1)'sound/magic/Demon_consume.ogg'
+	qdel(user)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -662,9 +662,9 @@
 		if(1)
 			new /obj/item/weapon/antag_spawner/slaughter_demon(src)
 		if(2)
-			new /obj/item/mayhem(src)
+			new /obj/item/bloodvial/bloodcrawl(src)
 		if(3)
-			new /obj/item/blood_contract(src)
+			new /obj/item/bloodvial/unlucky(src)
 
 /obj/item/blood_contract
 	name = "blood contract"
@@ -704,4 +704,31 @@
 			H << "<span class='userdanger'>You have an overwhelming desire to kill [L]. They have been marked red! Go kill them!</span>"
 			H.equip_to_slot_or_del(new /obj/item/weapon/kitchen/knife/butcher(H), slot_l_hand)
 
+	qdel(src)
+
+/obj/item/bloodvial//parent typing for identical looking loot
+	name = "vial of blood" //aestetically identical to the demon spawner
+	desc = "A magically infused bottle of blood, distilled from countless murder victims. Used in unholy rituals to attract horrifying creatures."
+	icon = 'icons/obj/wizard.dmi'
+	icon_state = "vial"
+
+
+/obj/item/bloodvial/bloodcrawl
+
+/obj/item/bloodvial/bloodcrawl/attack_self(mob/user)
+	user <<"<span class='warning'>You break [src], feeling immense power overcome you.../span>"
+	user.bloodcrawl = BLOODCRAWL
+	playsound(user.loc, 'sound/effects/Glassbr1.ogg', 100, 1)
+	qdel(src)
+
+
+/obj/item/bloodvial/unlucky
+
+/obj/item/bloodvial/unlucky/attack_self(mob/user)
+	user <<"<span class='warning'>You break [src], feeling... a thick coating of blood splatter onto you.</span>"
+	user.visible_message("<span class='danger'>[user] is drenched in blood!</span>")
+	playsound(user.loc, 'sound/effects/Glassbr1.ogg', 100, 1)
+	playsound(user.loc,'sound/effects/splat.ogg', 100, 1, -1)
+	user.color = "FF0000"
+	new /obj/effect/decal/cleanable/blood(get_turf(user))
 	qdel(src)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -664,7 +664,7 @@
 		if(2)
 			new /obj/item/bloodvial/bloodcrawl(src)
 		if(3)
-			new /obj/item/bloodvial/unlucky(src)
+			new /obj/item/weapon/nullrod/chainsaw/bubblegum(src)
 
 /obj/item/blood_contract
 	name = "blood contract"
@@ -715,20 +715,18 @@
 
 /obj/item/bloodvial/bloodcrawl
 
-/obj/item/bloodvial/bloodcrawl/attack_self(mob/user)
+/obj/item/bloodvial/bloodcrawl/attack_self(mob/living/carbon/user)
+	if(user.z != 1) //so you can't see if it's demon spawner on lavaland
+		user << "<span class='notice'>You should probably wait until you reach the station.</span>"
+		return
 	user <<"<span class='warning'>You break [src], feeling immense power overcome you.../span>"
 	user.bloodcrawl = BLOODCRAWL
 	playsound(user.loc, 'sound/effects/Glassbr1.ogg', 100, 1)
 	qdel(src)
 
 
-/obj/item/bloodvial/unlucky
-
-/obj/item/bloodvial/unlucky/attack_self(mob/user)
-	user <<"<span class='warning'>You break [src], feeling... a thick coating of blood splatter onto you.</span>"
-	user.visible_message("<span class='danger'>[user] is drenched in blood!</span>")
-	playsound(user.loc, 'sound/effects/Glassbr1.ogg', 100, 1)
-	playsound(user.loc,'sound/effects/splat.ogg', 100, 1, -1)
-	user.color = "FF0000"
-	new /obj/effect/decal/cleanable/blood(get_turf(user))
-	qdel(src)
+/obj/item/weapon/nullrod/chainsaw/bubblegum
+	name = "demonic chainsaw"
+	desc = "You almost regret picking this up."
+	force = 25
+	color = "#FF0000"

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -664,7 +664,7 @@
 		if(2)
 			new /obj/item/bloodvial/bloodcrawl(src)
 		if(3)
-			new /obj/item/weapon/chainsaw_bubblegum(src)
+			new /obj/item/bloodvial/saw(src)
 
 /obj/item/blood_contract
 	name = "blood contract"
@@ -728,6 +728,18 @@
 	playsound(user.loc, 'sound/effects/Glassbr1.ogg', 100, 1)
 	qdel(src)
 
+/obj/item/bloodvial/saw
+
+/obj/item/bloodvial/saw/attack_self(mob/living/carbon/user)
+	if(user.z != 1) //so you can't see if it's demon spawner on lavaland
+		user << "<span class='notice'>You should probably wait until you reach the station.</span>"
+		return
+	playsound(user.loc, 'sound/effects/Glassbr1.ogg', 100, 1)
+	user.unEquip(src)
+	var/obj/item/weapon/chainsaw_bubblegum/C = new
+	user.put_in_active_hand(C)
+	qdel(src)
+
 
 /obj/item/weapon/chainsaw_bubblegum
 	name = "demonic chainsaw"
@@ -743,11 +755,11 @@
 	armour_penetration = 30
 	color = "#FF0000"
 
-/obj/item/weapon/chainsaw_bubblegum/pickup(mob/living/user)
+/obj/item/weapon/chainsaw_bubblegum/equipped(mob/living/user)
 	..()
 	user.visible_message(
 		"<span class='danger'>[user] looks visibly angrier as they pick up [src]!</span>",
-		"<span class='warning'>You feel intense rage build up within you as you pick up [src]!</span>")
+		"<span class='warning'><b>You feel intense rage build up within you as you pick up [src]!</b></span>")
 	user.color = "#FF0000"
 
 /obj/item/weapon/chainsaw_bubblegum/suicide_act(mob/user)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -664,7 +664,7 @@
 		if(2)
 			new /obj/item/bloodvial/bloodcrawl(src)
 		if(3)
-			new /obj/item/weapon/nullrod/chainsaw/bubblegum(src)
+			new /obj/item/weapon/chainsaw_bubblegum(src)
 
 /obj/item/blood_contract
 	name = "blood contract"
@@ -729,15 +729,28 @@
 	qdel(src)
 
 
-/obj/item/weapon/nullrod/chainsaw/bubblegum
+/obj/item/weapon/chainsaw_bubblegum
 	name = "demonic chainsaw"
 	desc = "You almost regret picking this up."
 	force = 25
+	icon_state = "chainsaw_on"
+	item_state = "mounted_chainsaw"
+	w_class = 5
+	flags = NODROP | ABSTRACT
+	sharpness = IS_SHARP
+	attack_verb = list("sawed", "torn", "cut", "chopped", "diced","eviscerated")
+	hitsound = 'sound/weapons/chainsawhit.ogg'
 	armour_penetration = 30
 	color = "#FF0000"
 
+/obj/item/weapon/chainsaw_bubblegum/pickup(mob/living/user)
+	..()
+	user.visible_message(
+		"<span class='danger'>[user] looks visibly angrier as they pick up [src]!</span>",
+		"<span class='warning'>You feel intense rage build up within you as you pick up [src]!</span>")
+	user.color = "#FF0000"
 
-/obj/item/weapon/nullrod/chainsaw/bubblegum/suicide_act(mob/user)
+/obj/item/weapon/chainsaw_bubblegum/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is feeding \himself to \the [src.name]! It looks like \he's trying to join Bubblegum!</span>")
 	visible_message("<span class='warning'><b>[src] devours [user]!</b></span>")
 	playsound(user.loc, 'sound/magic/Demon_consume.ogg', 100, 1)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -716,7 +716,7 @@
 /obj/item/bloodvial/bloodcrawl
 
 /obj/item/bloodvial/bloodcrawl/attack_self(mob/living/carbon/user)
-	if(user.z != 1) //so you can't see if it's demon spawner on lavaland
+	if(user.z != ZLEVEL_STATION) //so you can't see if it's demon spawner on lavaland
 		user << "<span class='notice'>You should probably wait until you reach the station.</span>"
 		return
 	if(user.bloodcrawl == BLOODCRAWL || user.bloodcrawl == BLOODCRAWL_EAT)
@@ -731,7 +731,7 @@
 /obj/item/bloodvial/saw
 
 /obj/item/bloodvial/saw/attack_self(mob/living/carbon/user)
-	if(user.z != 1) //so you can't see if it's demon spawner on lavaland
+	if(user.z != ZLEVEL_STATION) //so you can't see if it's demon spawner on lavaland
 		user << "<span class='notice'>You should probably wait until you reach the station.</span>"
 		return
 	playsound(user.loc, 'sound/effects/Glassbr1.ogg', 100, 1)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -719,6 +719,10 @@
 	if(user.z != 1) //so you can't see if it's demon spawner on lavaland
 		user << "<span class='notice'>You should probably wait until you reach the station.</span>"
 		return
+	if(user.bloodcrawl == BLOODCRAWL || user.bloodcrawl == BLOODCRAWL_EAT)
+		user <<"<span class='warning'>You break [src], but nothing happens.../span>"
+		qdel(src)
+		return
 	user <<"<span class='warning'>You break [src], feeling immense power overcome you.../span>"
 	user.bloodcrawl = BLOODCRAWL
 	playsound(user.loc, 'sound/effects/Glassbr1.ogg', 100, 1)
@@ -729,6 +733,7 @@
 	name = "demonic chainsaw"
 	desc = "You almost regret picking this up."
 	force = 25
+	armour_penetration = 30
 	color = "#FF0000"
 
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -734,5 +734,6 @@
 
 /obj/item/weapon/nullrod/chainsaw/bubblegum/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is feeding \himself to \the [src.name]! It looks like \he's trying to join Bubblegum!</span>")
-	playsound(user.loc, 'sound/magic/Demon_consume.ogg', 100, 1)'sound/magic/Demon_consume.ogg'
+	visible_message("<span class='warning'><b>[src] devours [user]!</b></span>")
+	playsound(user.loc, 'sound/magic/Demon_consume.ogg', 100, 1)
 	qdel(user)


### PR DESCRIPTION
Refer to issue #698 .

removed the grief loot but kept the demon spawner

new loot: a blood vial that gives you bloodcrawl, and a nodrop chainsaw that's red

:cl: ShadowDeath6
tweak: Bubblegum's loot chest now drops different, less griefy loot. It all looks the same, though!
/:cl:
