### PR TITLE
Makes marrow weavers finally settle down

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -34,7 +34,7 @@
 "H" = (/obj/structure/table/optable,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "I" = (/mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "J" = (/obj/item/device/flashlight,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
-"K" = (/obj/structure/closet/crate/necropolis,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
+"K" = (/obj/structure/closet/crate/necropolis,/obj/item/stack/sheet/mineral/mythril{amount = 50},/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "L" = (/obj/structure/closet/crate/miningcar,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
 "M" = (/obj/item/weapon/twohanded/spear,/obj/structure/rack,/obj/item/weapon/twohanded/spear,/obj/item/weapon/twohanded/spear,/obj/item/weapon/twohanded/spear,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "N" = (/obj/item/weapon/twohanded/spear,/obj/structure/rack,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -34,7 +34,7 @@
 "H" = (/obj/structure/table/optable,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "I" = (/mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "J" = (/obj/item/device/flashlight,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
-"K" = (/obj/structure/closet/crate/necropolis,/obj/item/stack/sheet/mineral/mythril{amount = 50},/obj/item/stack/sheet/mineral/mythril{amount = 50},/obj/item/stack/sheet/mineral/mythril{amount = 50},/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
+"K" = (/obj/structure/closet/crate/necropolis,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "L" = (/obj/structure/closet/crate/miningcar,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
 "M" = (/obj/item/weapon/twohanded/spear,/obj/structure/rack,/obj/item/weapon/twohanded/spear,/obj/item/weapon/twohanded/spear,/obj/item/weapon/twohanded/spear,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "N" = (/obj/item/weapon/twohanded/spear,/obj/structure/rack,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_spiderden.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_spiderden.dmm
@@ -1,0 +1,35 @@
+"a" = (/turf/template_noop,/area/template_noop)
+"d" = (/obj/effect/spider/stickyweb,/mob/living/simple_animal/hostile/asteroid/marrowweaver/den,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"j" = (/obj/effect/spider/stickyweb,/obj/item/stack/sheet/bone{amount = 2},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"z" = (/obj/effect/landmark/weaver_den,/obj/effect/spider/stickyweb,/obj/effect/spider/stickyweb,/obj/item/stack/sheet/animalhide/weaver_chitin{amount = 6},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"D" = (/obj/effect/spider/stickyweb,/obj/effect/spider/stickyweb,/obj/item/stack/sheet/mineral/mythril{amount = 56},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"I" = (/obj/effect/spider/stickyweb,/obj/effect/spider/stickyweb,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"J" = (/obj/effect/spider/stickyweb,/obj/effect/spider/stickyweb,/mob/living/simple_animal/hostile/asteroid/marrowweaver/den,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"N" = (/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"U" = (/obj/effect/spider/stickyweb,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"V" = (/obj/effect/spider/stickyweb,/obj/effect/spider/stickyweb,/obj/item/stack/sheet/mineral/mythril{amount = 42},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"Z" = (/obj/effect/spider/stickyweb,/obj/item/stack/sheet/mineral/mythril{amount = 39},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+
+(1,1,1) = {"
+aaaaaaaaaaaaaNaaaaaa
+aaaaaaaaaaaaaNNaaaaa
+aaaaNNNaaaaaaNNaaaaa
+aaaNNNNNNNNaNNNaaaaa
+aaaUUNNNUNNNNUUNaaaa
+aaaNUNNUUUNNUUNNaaaa
+aaNNUUUUUUUUUUNNaaaa
+aNNNNUjUUUUdjUNNNaaa
+NNNNUUUUIUUUUUNNNaaa
+NNNNUUUdIIDUUUNNNNaa
+NNNNUUUIVzJIjUUUNNNN
+aNNUUUUUIIIUUUNUUNNN
+aNNNUUUjUIZUUUNNNaaa
+aNNNNUUUUdUUUUNNNaaa
+aaNNUUjUUUUUUUNNNaaa
+aaaNNUUNUUUUUZUNNaaa
+aaaNNNUNNUUNNUUNNaaa
+aaaaNNNNNNNNNNNNaaaa
+aaaaaaNNNNNNNNNNaaaa
+aaaaaaaNNNNaaaaaaaaa
+"}
+

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -269,3 +269,11 @@
 	suffix = "lavaland_surface_hermit.dmm"
 	allow_duplicates = FALSE
 	cost = 5
+
+/datum/map_template/ruin/lavaland/spider_den
+	name = "Marrow Weaver Den"
+	id = "spiderden"
+	description = "The massive web of a group of spiders who banded together as the rest of their kin were driven from lavaland."
+	suffix = "lavaland_surface_spiderden.dmm"
+	allow_duplicates = FALSE
+	cost = 5

--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -263,9 +263,8 @@
 
 /turf/open/floor/plating/asteroid/airless/cave/volcanic
 	mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/goldgrub = 10, /mob/living/simple_animal/hostile/asteroid/goliath/beast = 50, /mob/living/simple_animal/hostile/asteroid/basilisk/watcher = 40, \
-		/mob/living/simple_animal/hostile/asteroid/marrowweaver = 35, /mob/living/simple_animal/hostile/asteroid/hivelord/legion = 30, \
-		/mob/living/simple_animal/hostile/spawner/lavaland = 2, /mob/living/simple_animal/hostile/spawner/lavaland/goliath = 3, /mob/living/simple_animal/hostile/spawner/lavaland/legion = 3, \
-		/mob/living/simple_animal/hostile/megafauna/dragon = 2, /mob/living/simple_animal/hostile/megafauna/bubblegum = 2, /mob/living/simple_animal/hostile/megafauna/colossus = 2)
+		/mob/living/simple_animal/hostile/asteroid/hivelord/legion = 30, /mob/living/simple_animal/hostile/spawner/lavaland = 2, /mob/living/simple_animal/hostile/spawner/lavaland/goliath = 3, \
+		/mob/living/simple_animal/hostile/spawner/lavaland/legion = 3, /mob/living/simple_animal/hostile/megafauna/dragon = 2, /mob/living/simple_animal/hostile/megafauna/bubblegum = 2, /mob/living/simple_animal/hostile/megafauna/colossus = 2)
 
 	turf_type = /turf/open/floor/plating/asteroid/basalt/lava_land_surface
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -775,7 +775,7 @@
 	see_in_dark = 10
 	attack_sound = 'sound/weapons/bite.ogg'
 	deathmessage = "the weaver springs over onto its back, its legs curling as its abdomen ruptures open revealing the precious marrow and sinew within"
-	var/poison_type = "venom"
+	var/poison_type = "toxin"
 	var/poison_per_bite = 2
 	var/busy = 0
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -751,7 +751,6 @@
 //Marrow Weaver
 
 #define SPINNING_WEB 1
-#define MOVING_TO_TARGET 2
 
 /mob/living/simple_animal/hostile/asteroid/marrowweaver
 	name = "marrow weaver"
@@ -790,12 +789,16 @@
 /mob/living/simple_animal/hostile/asteroid/marrowweaver/handle_automated_action()
 	if(..())
 		if(!busy && prob(30))	//30% chance to spin webs
-			var/obj/effect/spider/stickyweb/W = locate() in get_turf(src)
-			if(!W)
-				Web()
+			var/turf/T = get_turf(src)
+			if(!istype(T, /turf/open/floor/plating/lava))
+				var/obj/effect/spider/stickyweb/W = locate() in T
+				if(!W)
+					Web()
+		return 1
 	else
 		busy = 0
 		stop_automated_movement = 0
+		return 0
 
 /mob/living/simple_animal/hostile/asteroid/marrowweaver/proc/Web()
 	var/T = loc
@@ -813,8 +816,29 @@
 		busy = 0
 		stop_automated_movement = 0
 
+/mob/living/simple_animal/hostile/asteroid/marrowweaver/den
+	var/max_den_dist = 8
+
+/mob/living/simple_animal/hostile/asteroid/marrowweaver/den/handle_automated_action()
+	if(!..())
+		return 0
+	if(AIStatus == AI_IDLE && !busy)
+		//check if we are too far from the nearest den
+		var/turf/myturf = get_turf(src)
+		var/best_dist = INFINITY
+		var/obj/effect/landmark/weaver_den/best_den = null
+		for(var/obj/effect/landmark/weaver_den/den in landmarks_list)
+			var/turf/T = get_turf(den)
+			if(T.z == myturf.z)
+				var/dist = get_dist(myturf, T)
+				if(dist < best_dist)
+					best_dist = dist
+					best_den = den
+		if(best_den && best_dist > max_den_dist)
+			Goto(best_den, move_to_delay, max_den_dist - rand(1, round(max_den_dist/8 * rand(1, 8)) ) )
+	return 1
+
 #undef SPINNING_WEB
-#undef MOVING_TO_TARGET
 
 
 //Legion

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -107,3 +107,6 @@
 				user << "You need at least ten sheets to finish a golem."
 		else
 			user << "You can't build a golem out of this kind of material."
+
+/obj/effect/landmark/weaver_den
+	name = "Weaver Nest Center"


### PR DESCRIPTION
Possibly fixes #611
:cl:
tweak: marrow weavers are no longer found all over lavaland, only in massive spider nests. The weavers will not wander far from the nest unless they are chasing prey.
tweak: marrow weavers now inject toxin instead of venom.
/:cl:

Since no one likes fighting marrow weavers, they are now found only in a new ruin. The ruin contains a few scattered bones and more than enough mythril to make full sets of weaver chitin armor if you manage to kill all four weavers. The weavers will attempt to return to their nest unless they are chasing something.

<strike>The ash walkers no longer start with mythril since 90% of the time they will not be able to use it.</strike>

![untitled](https://cloud.githubusercontent.com/assets/16478175/18296660/63c56bd8-7468-11e6-9aa8-6bfef2fec85b.png)
