### PR TITLE
Fixed the xenobio secure pen's disposal outlet not working.

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -46493,12 +46493,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/toxins/xenobiology)
-"bNT" = (
-/obj/structure/disposaloutlet{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/toxins/xenobiology)
 "bNU" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/plasteel{
@@ -69120,6 +69114,13 @@
 	icon_state = "white"
 	},
 /area/medical/sleeper)
+"YoX" = (
+/obj/structure/disposaloutlet{
+	dir = 1
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/engine,
+/area/toxins/xenobiology)
 
 (1,1,1) = {"
 aaa
@@ -112447,7 +112448,7 @@ bHV
 bJt
 bJt
 bJt
-bNT
+YoX
 bPn
 bQA
 bRF


### PR DESCRIPTION
Fixes #723

:cl:
fix: the disposal bin to the secure pen in xenobio now works properly.
/:cl:
