### PR TITLE
Normal blob structures will block air

### DIFF
--- a/code/game/gamemodes/blob/blobs/core.dm
+++ b/code/game/gamemodes/blob/blobs/core.dm
@@ -8,6 +8,7 @@
 	explosion_block = 6
 	point_return = -1
 	atmosblock = 1
+	heatblock = 1
 	health_regen = 0 //we regen in Life() instead of when pulsed
 	var/core_regen = 2
 	var/overmind_get_delay = 0 //we don't want to constantly try to find an overmind, this var tracks when we'll try to get an overmind again

--- a/code/game/gamemodes/blob/blobs/node.dm
+++ b/code/game/gamemodes/blob/blobs/node.dm
@@ -8,6 +8,7 @@
 	health_regen = 3
 	point_return = 25
 	atmosblock = 1
+	heatblock = 1
 
 
 /obj/effect/blob/node/New(loc, var/h = 100)

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -9,6 +9,7 @@
 	explosion_block = 3
 	point_return = 4
 	atmosblock = 1
+	heartblock = 1
 
 
 /obj/effect/blob/shield/scannerreport()

--- a/code/game/gamemodes/blob/blobs/shield.dm
+++ b/code/game/gamemodes/blob/blobs/shield.dm
@@ -9,7 +9,7 @@
 	explosion_block = 3
 	point_return = 4
 	atmosblock = 1
-	heartblock = 1
+	heatblock = 1
 
 
 /obj/effect/blob/shield/scannerreport()

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -16,6 +16,7 @@
 	var/brute_resist = 0.5 //multiplies brute damage by this
 	var/fire_resist = 1 //multiplies burn damage by this
 	var/atmosblock = 0 //if the blob blocks atmos and heat spread
+	var/heatblock = 0
 	var/mob/camera/blob/overmind
 
 
@@ -63,7 +64,7 @@
 	return !atmosblock
 
 /obj/effect/blob/BlockSuperconductivity()
-	return atmosblock
+	return heatblock
 
 /obj/effect/blob/CanPass(atom/movable/mover, turf/target, height=0)
 	if(height==0)
@@ -340,6 +341,7 @@
 	maxhealth = 25
 	health_regen = 1
 	brute_resist = 0.25
+	atmosblock = 1
 
 /obj/effect/blob/normal/scannerreport()
 	if(health <= 10)

--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -15,8 +15,8 @@
 	var/pulse_timestamp = 0 //we got pulsed/healed when?
 	var/brute_resist = 0.5 //multiplies brute damage by this
 	var/fire_resist = 1 //multiplies burn damage by this
-	var/atmosblock = 0 //if the blob blocks atmos and heat spread
-	var/heatblock = 0
+	var/atmosblock = 0 //if the blob blocks atmos
+	var/heatblock = 0 // if the blob blocks heatspread
 	var/mob/camera/blob/overmind
 
 
@@ -63,7 +63,7 @@
 /obj/effect/blob/CanAtmosPass(turf/T)
 	return !atmosblock
 
-/obj/effect/blob/BlockSuperconductivity()
+/obj/effect/blob/BlockSuperconductivity() // returns 1 if it does block heat, returns 0 if it doesn't.
 	return heatblock
 
 /obj/effect/blob/CanPass(atom/movable/mover, turf/target, height=0)
@@ -360,3 +360,11 @@
 		name = "blob"
 		desc = "A thick wall of writhing tendrils."
 		brute_resist = 0.25
+
+/obj/effect/blob/temperature_expose(datum/gas_mixture/air, exposed_temperature, exposed_volume)
+	if(heatblock)
+		return ..()
+
+	if(exposed_temperature > T0C + 80)
+		take_damage(round(exposed_volume/1.2), BURN)
+	..()


### PR DESCRIPTION
### Intent of your Pull Request

@AdamElTablawy requested this.
Since blobs spawn in maintenance, and almost always cause un-fightable breaches, forcing crewmembers to either risk their lives and die, or find a space suit, Adam's requesting that blob tiles should prevent block air from flowing in or out.

With this idea, blobs will be more easier to fight, and less people will die.

Though in my opinion, I think that blobs causing breaches is just a factor into the mode and, those who want to fight should do the best they can whether it's in maintenance or not.
#### Changelog

:cl:
tweak: Blob structures now block atmos.
tweak: Plasmafire is once again effective against blobs.
/:cl:
