### PR TITLE
Cult walls that open up near space are reported to admins.

### DIFF
--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -6,6 +6,7 @@
 	walltype = "cult"
 	builtin_sheet = null
 	canSmoothWith = null
+	var/alertthreshold
 
 /turf/closed/wall/mineral/cult/New()
 	PoolOrNew(/obj/effect/overlay/temp/cult/turf, src)
@@ -27,6 +28,11 @@
 		var/previouscolor = color
 		color = "#FAE48C"
 		animate(src, color = previouscolor, time = 8)
+
+/turf/closed/wall/mineral/cult/process()
+	..()
+	if(alertthreshold)
+		alertthreshold--
 
 /turf/closed/wall/mineral/cult/Bumped(atom/movable/C as mob)
 	var/phasable=0
@@ -52,14 +58,23 @@
 	if(istype(W, /obj/item/weapon/tome) && iscultist(user))
 		if(src.density == 1)
 			user <<"<span class='notice'>Your tome passes through the wall as if it's thin air.</span>"
-			src.alpha = 60
-			src.density = 0
-			src.opacity = 0
+			alpha = 60
+			density = 0
+			opacity = 0
+			var/messaged_admins
+			for(var/turf/open/ST in orange(1, src))
+				if(messaged_admins || alertthreshold)
+					break
+				if(istype(ST, /turf/open/space/))
+					messaged_admins = TRUE
+					message_admins("[src] <A href='?_src_=holder;jumpto=\ref[src]'>([x], [y], [z])</A> has been opened by [user]/[user.ckey] near a space vacuum.")
+					log_game("[user]/[user.ckey] used their arcane tome to open a runed wall, which was adjacent to a space tile.")
+					alertthreshold += 500
 		else
 			user <<"<span class='notice'>Your tome solidly connects with the wall.</span>"
-			src.alpha = initial(src.alpha)
-			src.density = 1
-			src.opacity = 1
+			alpha = initial(src.alpha)
+			density = 1
+			opacity = 1
 	return
 
 /turf/closed/wall/mineral/cult/artificer


### PR DESCRIPTION
Refer to issue https://github.com/yogstation13/yogstation/pull/460
### Intent of your Pull Request

Makes the opening of cult walls a little more admin-freindly.

This PR simply sends a message to the admins when someone opens a cult wall, that is adjacent to a space tile, with an arcane tome. Also logs it within the game.

Additionally, there is an alertthreshold so admins aren't spammed.
#### Changelog

:cl:
administration: Cult walls that are adjacent to a space tile are reported to admins, with the person that opened it and the coordinates. Same with game logging.
/:cl:
