### PR TITLE
various holoparasite tweaks + simplemob dismember

### DIFF
--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -30,6 +30,7 @@
 	environment_smash = 1
 	melee_damage_lower = 30
 	melee_damage_upper = 30
+	candismember = TRUE
 	see_in_dark = 8
 	var/boost = 0
 	bloodcrawl = BLOODCRAWL_EAT

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -125,7 +125,8 @@
 	var/f_loss = null
 	var/bomb_armor = getarmor(null, "bomb")
 
-	for(var/mob/living/simple_animal/hostile/guardian/protector/G in src)//if they've got a protector holo inside them
+	if(locate(/mob/living/simple_animal/hostile/guardian/protector) in src)//if they've got a protector holo inside them
+		var/mob/living/simple_animal/hostile/guardian/protector/G = locate(/mob/living/simple_animal/hostile/guardian/protector)
 		if(severity == 1 && G.toggle)//can't think of a better way to do this since ex_act only works if the holo is actually hit with the explosion, which it isn't
 			apply_damage(20,BRUTE)
 		else

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -125,6 +125,22 @@
 	var/f_loss = null
 	var/bomb_armor = getarmor(null, "bomb")
 
+	for(var/mob/living/simple_animal/hostile/guardian/protector/G in src)//if they've got a protector holo inside them
+		if(severity == 1 && G.toggle)//can't think of a better way to do this since ex_act only works if the holo is actually hit with the explosion, which it isn't
+			apply_damage(20,BRUTE)
+		else
+			if(G.toggle && severity > 1)
+				visible_message("<span class='notice'><i>[src] glows in a <font color=\"[G.namedatum.colour]\">strange light </font>and is protected from the explosion!<i></span>")
+				return
+			else
+				if(severity == 1)
+					apply_damage(200,BRUTE)
+				if(severity == 2)
+					apply_damage(60,BRUTE)
+				if(severity == 3)
+					apply_damage(30,BRUTE)
+		visible_message("<span class='notice'><i>[src] glows in a <font color=\"[G.namedatum.colour]\">strange light </font>and is protected from the explosion!<i></span>")
+		return
 	switch (severity)
 		if (1)
 			b_loss += 500

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -278,9 +278,13 @@
 		apply_damage(damage, M.melee_damage_type, affecting, armor, "", "", M.armour_penetration)
 		if(affecting)
 			if(M.melee_damage_type == BRUTE && M.candismember == TRUE && dam_zone != "chest")
-				if(damage >= 25)
-					if(prob(damage)) //higher damage means higher chance of dismember
-						affecting.dismember()
+				if(damage >= 25 || M.forcedismember == TRUE)//for stuff that does low damage to still have a chance of dismember, like viscerators
+					if(damage >= 25)
+						if(prob(damage)) //higher damage means higher chance of dismember
+							affecting.dismember()
+					else
+						if(prob(15)) //for forcedismember we just use a flat 15% for your 1 damage dismember needs
+							affecting.dismember()
 		updatehealth()
 
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -276,6 +276,10 @@
 		var/obj/item/bodypart/affecting = get_bodypart(ran_zone(dam_zone))
 		var/armor = run_armor_check(affecting, "melee")
 		apply_damage(damage, M.melee_damage_type, affecting, armor, "", "", M.armour_penetration)
+		if(M.melee_damage_type == BRUTE && M.candismember == TRUE && dam_zone != "chest")
+			if(damage >= 25)
+				if(prob(damage)) //higher damage means higher chance of dismember
+					affecting.dismember()
 		updatehealth()
 
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -278,13 +278,12 @@
 		apply_damage(damage, M.melee_damage_type, affecting, armor, "", "", M.armour_penetration)
 		if(affecting)
 			if(M.melee_damage_type == BRUTE && M.candismember == TRUE && dam_zone != "chest")
-				if(damage >= 25 || M.forcedismember == TRUE)//for stuff that does low damage to still have a chance of dismember, like viscerators
-					if(damage >= 25)
-						if(prob(damage)) //higher damage means higher chance of dismember
-							affecting.dismember()
-					else
-						if(prob(15)) //for forcedismember we just use a flat 15% for your 1 damage dismember needs
-							affecting.dismember()
+				if(damage >= 25)
+					if(prob(damage)) //higher damage means higher chance of dismember
+						affecting.dismember()
+				else
+					if(prob(15)) //if it's below 25 just use a flat 15% for your 1 damage dismember needs
+						affecting.dismember()
 		updatehealth()
 
 

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -276,10 +276,11 @@
 		var/obj/item/bodypart/affecting = get_bodypart(ran_zone(dam_zone))
 		var/armor = run_armor_check(affecting, "melee")
 		apply_damage(damage, M.melee_damage_type, affecting, armor, "", "", M.armour_penetration)
-		if(M.melee_damage_type == BRUTE && M.candismember == TRUE && dam_zone != "chest")
-			if(damage >= 25)
-				if(prob(damage)) //higher damage means higher chance of dismember
-					affecting.dismember()
+		if(affecting)
+			if(M.melee_damage_type == BRUTE && M.candismember == TRUE && dam_zone != "chest")
+				if(damage >= 25)
+					if(prob(damage)) //higher damage means higher chance of dismember
+						affecting.dismember()
 		updatehealth()
 
 

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -321,10 +321,6 @@ var/global/list/parasites = list() //all currently existing/living guardians
 	set desc = "Re-rolls which ghost will control your Guardian."
 
 	var/list/guardians = hasparasites()
-	for(var/para in guardians)
-		var/mob/living/simple_animal/hostile/guardian/P = para
-		if(P.reset)
-			guardians -= P //clear out guardians that are already reset
 	if(guardians.len)
 		var/mob/living/simple_animal/hostile/guardian/G = input(src, "Pick the guardian you wish to reset", "Guardian Reset") as null|anything in guardians
 		if(G)

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -172,6 +172,8 @@ var/global/list/parasites = list() //all currently existing/living guardians
 	if(src.loc == summoner)
 		src << "<span class='danger'><B>You must be manifested to attack!</span></B>"
 		return 0
+	if(target == summoner && !(istype(src,/mob/living/simple_animal/hostile/guardian/healer)))
+		return 0
 	else
 		..()
 		return 1
@@ -314,9 +316,9 @@ var/global/list/parasites = list() //all currently existing/living guardians
 		G.Recall()
 
 /mob/living/proc/guardian_reset()
-	set name = "Reset Guardian Player (One Use)"
+	set name = "Reset Guardian Player"
 	set category = "Guardian"
-	set desc = "Re-rolls which ghost will control your Guardian. One use per Guardian."
+	set desc = "Re-rolls which ghost will control your Guardian."
 
 	var/list/guardians = hasparasites()
 	for(var/para in guardians)
@@ -344,14 +346,10 @@ var/global/list/parasites = list() //all currently existing/living guardians
 					if("magic")
 						src << "<span class='holoparasite'><font color=\"[G.namedatum.colour]\"><b>[G.real_name]</b></font> has been summoned!</span>"
 				guardians -= G
-				if(!guardians.len)
-					verbs -= /mob/living/proc/guardian_reset
 			else
 				src << "<span class='holoparasite'>There were no ghosts willing to take control of <font color=\"[G.namedatum.colour]\"><b>[G.real_name]</b></font>. Looks like you're stuck with it for now.</span>"
 		else
 			src << "<span class='holoparasite'>You decide not to reset [guardians.len > 1 ? "any of your guardians":"your guardian"].</span>"
-	else
-		verbs -= /mob/living/proc/guardian_reset
 
 ////////parasite tracking/finding procs
 
@@ -501,7 +499,7 @@ var/global/list/parasites = list() //all currently existing/living guardians
  <br>
  <b>Assassin</b>: Does medium damage and takes full damage, but can enter stealth, causing its next attack to do massive damage and ignore armor. However, it becomes briefly unable to recall after attacking from stealth.<br>
  <br>
- <b>Chaos</b>: Ignites enemies on touch and causes them to hallucinate all nearby people as the parasite. Automatically extinguishes the user if they catch on fire.<br>
+ <b>Chaos</b>: Ignites enemies on attack. Bumping humans causes them to hallucinate all nearby humans as the parasite. Automatically extinguishes the user if they catch on fire.<br>
  <br>
  <b>Charger</b>: Moves extremely fast, does medium damage on attack, and can charge at targets, damaging the first target hit and forcing them to drop any items they are holding.<br>
  <br>

--- a/code/modules/mob/living/simple_animal/guardian/types/assassin.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/assassin.dm
@@ -2,6 +2,7 @@
 /mob/living/simple_animal/hostile/guardian/assassin
 	melee_damage_lower = 15
 	melee_damage_upper = 15
+	candismember = TRUE
 	attacktext = "slashes"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)

--- a/code/modules/mob/living/simple_animal/guardian/types/fire.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/fire.dm
@@ -4,7 +4,7 @@
 	melee_damage_lower = 7
 	melee_damage_upper = 7
 	attack_sound = 'sound/items/Welder.ogg'
-	attacktext = "sears"
+	attacktext = "ignites"
 	damage_coeff = list(BRUTE = 0.8, BURN = 0.8, TOX = 0.8, CLONE = 0.8, STAMINA = 0, OXY = 0.8)
 	range = 7
 	playstyle_string = "<span class='holoparasite'>As a <b>chaos</b> type, you have only light damage resistance, but will ignite any enemy you bump into. In addition, your melee attacks will cause human targets to see everyone as you.</span>"
@@ -20,25 +20,25 @@
 
 /mob/living/simple_animal/hostile/guardian/fire/AttackingTarget()
 	if(..())
-		if(ishuman(target) && target != summoner)
-			spawn(0)
-				new /obj/effect/hallucination/delusion(target.loc,target,force_kind="custom",duration=200,skip_nearby=0, custom_icon = src.icon_state, custom_icon_file = src.icon)
+		if(isliving(target))
+			var/mob/living/M = target
+			if(!hasmatchingsummoner(M) && M != summoner && M.fire_stacks < 7)
+				M.fire_stacks = 7
+				M.IgniteMob()
 
-/mob/living/simple_animal/hostile/guardian/fire/Crossed(AM as mob|obj)
+/mob/living/simple_animal/hostile/guardian/fire/Crossed(atom/movable/AM)
 	..()
-	collision_ignite(AM)
+	collision_hallucination(AM)
 
-/mob/living/simple_animal/hostile/guardian/fire/Bumped(AM as mob|obj)
+/mob/living/simple_animal/hostile/guardian/fire/Bumped(atom/movable/AM)
 	..()
-	collision_ignite(AM)
+	collision_hallucination(AM)
 
-/mob/living/simple_animal/hostile/guardian/fire/Bump(AM as mob|obj)
+/mob/living/simple_animal/hostile/guardian/fire/Bump(atom/movable/AM)
 	..()
-	collision_ignite(AM)
+	collision_hallucination(AM)
 
-/mob/living/simple_animal/hostile/guardian/fire/proc/collision_ignite(AM as mob|obj)
-	if(isliving(AM))
-		var/mob/living/M = AM
-		if(!hasmatchingsummoner(M) && M != summoner && M.fire_stacks < 7)
-			M.fire_stacks = 7
-			M.IgniteMob()
+/mob/living/simple_animal/hostile/guardian/fire/proc/collision_hallucination(atom/movable/AM)
+	if(ishuman(AM) && AM != summoner)
+		spawn(0)
+			new /obj/effect/hallucination/delusion(AM.loc,AM,force_kind="custom",duration=200,skip_nearby=0, custom_icon = src.icon_state, custom_icon_file = src.icon)

--- a/code/modules/mob/living/simple_animal/guardian/types/lightning.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/lightning.dm
@@ -22,6 +22,11 @@
 /mob/living/simple_animal/hostile/guardian/beam/AttackingTarget()
 	if(..())
 		if(isliving(target) && target != src && target != summoner)
+			if(ishuman(target))
+				var/mob/living/carbon/human/H = target
+				if(prob(50))
+					H.drop_item()
+					H <<"<span class='warning'>[src]'s shock causes your hand to spasm, disarming you!</span>"
 			for(var/chain in enemychains)
 				var/datum/beam/B = chain
 				if(B.target == target)

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -154,6 +154,8 @@
 	maxHealth = 15
 	melee_damage_lower = 15
 	melee_damage_upper = 15
+	candismember = TRUE
+	forcedismember = TRUE
 	attacktext = "cuts"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	faction = list("syndicate")

--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -155,7 +155,6 @@
 	melee_damage_lower = 15
 	melee_damage_upper = 15
 	candismember = TRUE
-	forcedismember = TRUE
 	attacktext = "cuts"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	faction = list("syndicate")

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -46,6 +46,7 @@
 	var/armour_penetration = 0 //How much armour they ignore, as a flat reduction from the targets armour value
 	var/melee_damage_type = BRUTE //Damage type of a simple mob's melee attack, should it do damage.
 	var/candismember = FALSE //if the animal can chop off limbs on hit, they still need >25 damage to delimb
+	var/forcedismember = FALSE //if you want the mob to dismember regardless of damage
 	var/list/damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1) // 1 for full damage , 0 for none , -1 for 1:1 heal from that source
 	var/attacktext = "attacks"
 	var/attack_sound = null

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -45,6 +45,7 @@
 	var/melee_damage_upper = 0
 	var/armour_penetration = 0 //How much armour they ignore, as a flat reduction from the targets armour value
 	var/melee_damage_type = BRUTE //Damage type of a simple mob's melee attack, should it do damage.
+	var/candismember = FALSE //if the animal can chop off limbs on hit, they still need >25 damage to delimb
 	var/list/damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1) // 1 for full damage , 0 for none , -1 for 1:1 heal from that source
 	var/attacktext = "attacks"
 	var/attack_sound = null

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -45,8 +45,7 @@
 	var/melee_damage_upper = 0
 	var/armour_penetration = 0 //How much armour they ignore, as a flat reduction from the targets armour value
 	var/melee_damage_type = BRUTE //Damage type of a simple mob's melee attack, should it do damage.
-	var/candismember = FALSE //if the animal can chop off limbs on hit, they still need >25 damage to delimb
-	var/forcedismember = FALSE //if you want the mob to dismember regardless of damage
+	var/candismember = FALSE //if the animal can chop off limbs on hit, see human_defense for the dismemberment stuff
 	var/list/damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1) // 1 for full damage , 0 for none , -1 for 1:1 heal from that source
 	var/attacktext = "attacks"
 	var/attack_sound = null

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -187,7 +187,7 @@
 		)
 	blocked |= typesof(/obj/item/weapon/reagent_containers/food/snacks/customizable)
 
-	var/list/borks = typesof(/obj/item/weapon/reagent_containers/food/snacks) - blocked += /obj/item/weapon/guardiancreator/carp //holo fishsticks are food too ;^)
+	var/list/borks = typesof(/obj/item/weapon/reagent_containers/food/snacks) - blocked + /obj/item/weapon/guardiancreator/carp //holo fishsticks are food too ;^)
 	// BORK BORK BORK
 
 	playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -187,7 +187,7 @@
 		)
 	blocked |= typesof(/obj/item/weapon/reagent_containers/food/snacks/customizable)
 
-	var/list/borks = typesof(/obj/item/weapon/reagent_containers/food/snacks) - blocked
+	var/list/borks = typesof(/obj/item/weapon/reagent_containers/food/snacks) - blocked += /obj/item/weapon/guardiancreator/carp //holo fishsticks are food too ;^)
 	// BORK BORK BORK
 
 	playsound(get_turf(holder.my_atom), 'sound/effects/phasein.ogg', 100, 1)


### PR DESCRIPTION
Refer to issue https://github.com/yogstation13/yogstation/issues/742

Lightning holo now disarms on-hit because you're being shocked and also it wasn't really threatening one on one

Protector holo now protects its host from explosions while inside their host

Chaos holo now ignites on hit and hallucinates on bump, from https://github.com/tgstation/tgstation/pull/19514 by ChangelingRain 

you can now use the holo reset infinitely because why could you not in the first place

also also- adds holocarp fishsticks to silver slime extract list because it's food and also for memes

also pt.3- added simplemob dismemberment with a shitty var

this took a lot less time than I thought it would

:cl: Hirohiko Araki
rscadd: Protector holoparasites protect their host from explosions while inside them.
rscadd: Lightning holoparasites now disarm people they attack.
rscadd: Assassin holoparasites can dismember, provided they are stealthed.
rscadd: Viscerators can now dismember.
tweak: Chaos holoparasites ignite on-hit, rather than on-bump. They now hallucinate on-bump.
tweak: Increased silver slime extract's reaction food list.
/:cl:
