### PR TITLE
Fix holodeck safeties href exploit.

### DIFF
--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -164,6 +164,9 @@
 		if(area == offline_program || (area in program_cache) || (emagged && (area in emag_programs)))
 			load_program(area)
 	else if("safety" in href_list)
+		if(!issilicon(usr))
+			message_admins("EXPLOIT: [usr] attempted to override [src]'s safeties without being a silicon.")
+			return
 		var/safe = text2num(href_list["safety"])
 		emagged = !safe
 		if(!program)


### PR DESCRIPTION
The holodeck safeties did not have a check if the src is a silicon, so anyone could disable the safeties with an href.
This includes any random griefing assistant.
