### PR TITLE
Fix mech dominate href.

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -455,6 +455,10 @@ var/list/ai_list = list()
 		return
 
 	if (href_list["ai_take_control"]) //Mech domination
+		var/mob/living/silicon/ai/user = usr
+		if(!user || !user.can_dominate_mechs)
+			message_admins("EXPLOIT: [usr] attempted to dominate a mech without being able to dominate mechs.")
+			return
 		var/obj/mecha/M = locate(href_list["ai_take_control"])
 		if(controlled_mech)
 			src << "You are already loaded into an onboard computer!"


### PR DESCRIPTION
Fixes AIs' ability to dominate mechs via an href exploit without being malf or having the right module ordered.
