### PR TITLE
Fixed being unable to print the telecommunications traffic console

### DIFF
--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -228,14 +228,11 @@
 	build_path = /obj/item/weapon/circuitboard/computer/comm_server
 	category = list("Computer Boards")
 
-/datum/design/comm_traffic
+/datum/design/board/comm_traffic
 	name = "Computer Design (Telecommunications Traffic Control Console)"
 	desc = "Allows for the construction of circuit boards used to build a telecommunications traffic control console."
 	id = "comm_traffic"
 	req_tech = list("programming" = 3)
-	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000)
-	reagents = list("sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/telecomms/comm_traffic
 	category = list("Computer Boards")
 

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -234,7 +234,8 @@
 	id = "comm_traffic"
 	req_tech = list("programming" = 3)
 	build_type = IMPRINTER
-	materials = list(MAT_GLASS = 1000, "sacid" = 20)
+	materials = list(MAT_GLASS = 1000)
+	reagents = list("sacid" = 20)
 	build_path = /obj/item/weapon/circuitboard/computer/telecomms/comm_traffic
 	category = list("Computer Boards")
 


### PR DESCRIPTION
Fixes #757
:cl:
fix: RnD can now print telecommunications traffic console boards.
/:cl:
