### PR TITLE
Readds the jet-pack to the engineering hardsuit.

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -118,7 +118,10 @@
 	item_state = "eng_hardsuit"
 	armor = list(melee = 30, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 75)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine
-	var/obj/item/weapon/tank/jetpack/suit/jetpack = 1
+
+/obj/item/clothing/suit/space/hardsuit/engine/New()
+	jetpack = new /obj/item/weapon/tank/jetpack/suit(src)
+	..()
 
 	//Atmospherics
 /obj/item/clothing/head/helmet/space/hardsuit/engine/atmos
@@ -163,7 +166,7 @@
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS					//Uncomment to enable firesuit protection
 	max_heat_protection_temperature = FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine/elite
-	var/obj/item/weapon/tank/jetpack/suit/jetpack = 1
+	
 
 
 	//Mining hardsuit

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -166,6 +166,10 @@
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS					//Uncomment to enable firesuit protection
 	max_heat_protection_temperature = FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine/elite
+	
+/obj/item/clothing/suit/space/hardsuit/engine/New()
+ +	jetpack = new /obj/item/weapon/tank/jetpack/suit(src)
+ +	..()
 
 
 	//Mining hardsuit
@@ -463,6 +467,10 @@
 	desc = "A special bulky suit that protects against hazardous, low pressure environments. Has an additional layer of armor."
 	armor = list(melee = 45, bullet = 25, laser = 30, energy = 10, bomb = 25, bio = 100, rad = 50)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/security/hos
+	
+/obj/item/clothing/suit/space/hardsuit/engine/New()
+ +	jetpack = new /obj/item/weapon/tank/jetpack/suit(src)
+ +	..()
 
 
 
@@ -606,6 +614,10 @@
 	item_state = "syndie_helm"
 	item_color = "syndi"
 	armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 50)
+
+/obj/item/clothing/suit/space/hardsuit/engine/New()
+ +	jetpack = new /obj/item/weapon/tank/jetpack/suit(src)
+ +	..()
 
 
 ////mining medic///

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -615,9 +615,6 @@
 	item_color = "syndi"
 	armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 50)
 
-/obj/item/clothing/suit/space/hardsuit/engine/New()
- +	jetpack = new /obj/item/weapon/tank/jetpack/suit(src)
- +	..()
 
 
 ////mining medic///

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -167,7 +167,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine/elite
 	
-/obj/item/clothing/suit/space/hardsuit/engine/New()
+/obj/item/clothing/suit/space/hardsuit/engine/elite/New()
  +	jetpack = new /obj/item/weapon/tank/jetpack/suit(src)
  +	..()
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -449,8 +449,8 @@
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals, /obj/item/weapon/gun/energy,/obj/item/weapon/reagent_containers/spray/pepper,/obj/item/weapon/gun/projectile,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/restraints/handcuffs)
 	armor = list(melee = 30, bullet = 15, laser = 30, energy = 10, bomb = 10, bio = 100, rad = 50)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/security
-	
-/obj/item/clothing/suit/space/space/hardsuit/security/New()
+
+/obj/item/clothing/suit/space/hardsuit/security/New()
  	jetpack = new /obj/item/weapon/tank/jetpack/suit(src)
  	..()
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -168,7 +168,6 @@
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine/elite
 	
 
-
 	//Mining hardsuit
 /obj/item/clothing/head/helmet/space/hardsuit/mining
 	name = "mining hardsuit helmet"

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -449,6 +449,10 @@
 	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals, /obj/item/weapon/gun/energy,/obj/item/weapon/reagent_containers/spray/pepper,/obj/item/weapon/gun/projectile,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/weapon/melee/baton,/obj/item/weapon/restraints/handcuffs)
 	armor = list(melee = 30, bullet = 15, laser = 30, energy = 10, bomb = 10, bio = 100, rad = 50)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/security
+	
+/obj/item/clothing/suit/space/space/hardsuit/security/New()
+ 	jetpack = new /obj/item/weapon/tank/jetpack/suit(src)
+ 	..()
 
 /obj/item/clothing/head/helmet/space/hardsuit/security/hos
 	name = "head of security's hardsuit helmet"

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -470,7 +470,6 @@
 
 
 
-
 /////////////SHIELDED//////////////////////////////////
 
 /obj/item/clothing/suit/space/hardsuit/shielded

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -118,10 +118,7 @@
 	item_state = "eng_hardsuit"
 	armor = list(melee = 30, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 75)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine
-	
-/obj/item/clothing/suit/space/hardsuit/engine/New()
-	jetpack = new /obj/item/weapon/tank/jetpack/suit(src)
-	..()
+	var/obj/item/weapon/tank/jetpack/suit/jetpack = 1
 
 	//Atmospherics
 /obj/item/clothing/head/helmet/space/hardsuit/engine/atmos
@@ -166,10 +163,7 @@
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS					//Uncomment to enable firesuit protection
 	max_heat_protection_temperature = FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine/elite
-	
-/obj/item/clothing/suit/space/hardsuit/engine/elite/New()
- +	jetpack = new /obj/item/weapon/tank/jetpack/suit(src)
- +	..()
+	var/obj/item/weapon/tank/jetpack/suit/jetpack = 1
 
 
 	//Mining hardsuit

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -616,7 +616,6 @@
 	armor = list(melee = 40, bullet = 50, laser = 30, energy = 15, bomb = 35, bio = 100, rad = 50)
 
 
-
 ////mining medic///
 
 /obj/item/clothing/suit/space/hardsuit/mining/mmedic

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -467,10 +467,7 @@
 	desc = "A special bulky suit that protects against hazardous, low pressure environments. Has an additional layer of armor."
 	armor = list(melee = 45, bullet = 25, laser = 30, energy = 10, bomb = 25, bio = 100, rad = 50)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/security/hos
-	
-/obj/item/clothing/suit/space/hardsuit/engine/New()
- +	jetpack = new /obj/item/weapon/tank/jetpack/suit(src)
- +	..()
+
 
 
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -118,6 +118,10 @@
 	item_state = "eng_hardsuit"
 	armor = list(melee = 30, bullet = 5, laser = 10, energy = 5, bomb = 10, bio = 100, rad = 75)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine
+	
+/obj/item/clothing/suit/space/hardsuit/engine/New()
+	jetpack = new /obj/item/weapon/tank/jetpack/suit(src)
+	..()
 
 	//Atmospherics
 /obj/item/clothing/head/helmet/space/hardsuit/engine/atmos

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -855,10 +855,6 @@
 		user.visible_message("<span class='notice'>[user] digs out the plants in [src]!</span>", "<span class='notice'>You dig out all of [src]'s plants!</span>")
 		playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1)
 		if(myseed) //Could be that they're just using it as a de-weeder
-			age = 0
-			health = 0
- 			if(harvest)
- 				harvest = FALSE //To make sure they can't just put in another seed and insta-harvest it
 			qdel(myseed)
 			myseed = null
 		weedlevel = 0 //Side-effect of cleaning up those nasty weeds

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -855,6 +855,10 @@
 		user.visible_message("<span class='notice'>[user] digs out the plants in [src]!</span>", "<span class='notice'>You dig out all of [src]'s plants!</span>")
 		playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1)
 		if(myseed) //Could be that they're just using it as a de-weeder
+			age = 0
+			health = 0
+ 			if(harvest)
+ 				harvest = FALSE //To make sure they can't just put in another seed and insta-harvest it
 			qdel(myseed)
 			myseed = null
 		weedlevel = 0 //Side-effect of cleaning up those nasty weeds


### PR DESCRIPTION
Readds the jetpack to the engi harsuits. Gives sec inbuilt jetpacks(if it turns out to fuck with gameplay revert it.)
🆑 (Zostroll)
tweak:The jet-pack was readded to the engineering hardsuits.
tweak:Security was given a inbuilt jetpack to chase spaceborn scum. 
/🆑

The jet-pack was lost in the rebase. I see no reason for it to have been removed as it was quick useful for wiring solars and not getting lost in space.
