### PR TITLE
Prevents Gold Core mobs from attacking sentiented things

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -179,7 +179,7 @@
 		SM.key = theghost.key
 		SM.languages_spoken |= HUMAN
 		SM.languages_understood |= HUMAN
-		SM.faction = user.faction
+		SM.faction = user.faction | "chemicalsummon" //To prevent plasma spawned mobs from attacking this guy
 		SM.sentience_act()
 		SM << "<span class='warning'>All at once it makes sense: you know what you are and who you are! Self awareness is yours!</span>"
 		SM << "<span class='userdanger'>You are grateful to be self aware and owe [user] a great debt. Serve [user], and assist them in completing their goals at any cost.</span>"

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -179,7 +179,7 @@
 		SM.key = theghost.key
 		SM.languages_spoken |= HUMAN
 		SM.languages_understood |= HUMAN
-		SM.faction = user.faction | "chemicalsummon" //To prevent plasma spawned mobs from attacking this guy
+		SM.faction |= user.faction
 		SM.sentience_act()
 		SM << "<span class='warning'>All at once it makes sense: you know what you are and who you are! Self awareness is yours!</span>"
 		SM << "<span class='userdanger'>You are grateful to be self aware and owe [user] a great debt. Serve [user], and assist them in completing their goals at any cost.</span>"


### PR DESCRIPTION
fixes #noissuefound

Prevents Plasma Reaction mobs from killing whatever you sentiented. Not sure if a fix or a feature.

Not sure if clever and simple fix or shitcode.
### Tests performed
- **BEFORE** : Spawned gold core mobs from plasma reaction + Sentienced one of them = instantly dead sentienced mob
- **AFTER** : Spawned gold core mobs from plasma reaction + Sentienced one of them = sentienced mob not attacked
