### PR TITLE
Adds a 10 second cooldown between mining shuttle calls

### DIFF
--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -383,7 +383,7 @@
 /obj/item/weapon/circuitboard/computer/ferry/request
 	name = "circuit board (Transport Ferry Console)"
 	build_path = /obj/machinery/computer/shuttle/ferry/request
-/obj/item/weapon/circuitboard/computer/mining_shuttle
+/obj/item/weapon/circuitboard/computer/cooldown_holder/mining_shuttle
 	name = "circuit board (Mining Shuttle)"
 	build_path = /obj/machinery/computer/shuttle/mining
 /obj/item/weapon/circuitboard/computer/white_ship

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -53,10 +53,11 @@
 /obj/machinery/computer/shuttle/mining
 	name = "Mining Shuttle Console"
 	desc = "Used to call and send the mining shuttle."
-	circuit = /obj/item/weapon/circuitboard/computer/mining_shuttle
+	circuit = /obj/item/weapon/circuitboard/computer/cooldown_holder/mining_shuttle
 	shuttleId = "mining"
 	possible_destinations = "mining_home;mining_away"
 	no_destination_swap = 1
+	call_cooldown = 100
 
 /*********************Pickaxe & Drills**************************/
 


### PR DESCRIPTION
fixes #nothing
As requested by @AdamElTablawy 

Prevents mining shuttle call spam to permastun/roadkill miners. Also prevents miners from spacing themselves all the time.

Total waiting time between calls is 15 seconds : 5 second transit time + 10 second cooldown
Map doesn't have the circuit anywhere in it placed and it can't be built, so I don't think I broke anything.
### Tests
- Moved shuttle, then tried moving it again instantly - needs to wait;
- Tried deconstructing/reconstructing the console - you'll just have to wait, powergamer-san;

:cl: X-TheDark
tweak: Mining Shuttle can now has a cooldown of 10 seconds between being moved using the Console.
tweak: No, disconnecting and reconnecting the Console's monitor or otherwise meddling with the machine will not help you.
/:cl:
