### PR TITLE
Adam's Drink Nerfs

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -362,12 +362,21 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	id = "beepskysmash"
 	description = "Drink this and prepare for the LAW."
 	color = "#664300" // rgb: 102, 67, 0
-	boozepwr = 90 //THE FIST OF THE LAW IS STRONG AND HARD
+	boozepwr = 95 //THE FIST OF THE LAW IS STRONG AND HARD
 	metabolization_rate = 0.8
+	var/stunning = 0
 
 /datum/reagent/consumable/ethanol/beepsky_smash/on_mob_life(mob/living/M)
-	M.Stun(2, 0)
-	return ..()
+	if(stunning)
+		M.Stun(2, 0)
+	if(istype(M, /mob/living/carbon/human) && M.job in list("Security Officer", "Head of Security", "Detective", "Warden"))
+		M.heal_organ_damage(1,1)
+		. = 1
+	return . || ..()
+
+/datum/reagent/consumable/ethanol/beepsky_smash/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
+	if(method == INGEST)
+		stunning = 1
 
 /datum/reagent/consumable/ethanol/irish_cream
 	name = "Irish Cream"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -300,7 +300,7 @@
 
 /datum/reagent/medicine/mine_salve/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
-		if(method in list(INGEST, VAPOR, INJECT))
+		if(method == INGEST)
 			M.Stun(4)
 			M.Weaken(4)
 			if(show_message)


### PR DESCRIPTION
Closes #767
Closes #768

:cl:
tweak: Miner's salve and Beepsky Smash now only stun if they are drunk.
tweak: Security officers, the detective, the warden, and the HoS are now slightly healed by drinking Beepsky Smash.
/:cl:
