### PR TITLE
Arcanes explain how to toggle rune wall phasbility

### DIFF
--- a/code/game/gamemodes/cult/ritual.dm
+++ b/code/game/gamemodes/cult/ritual.dm
@@ -20,6 +20,7 @@ This file contains the arcane tome files.
 		user << "<span class='cult'>Striking a cult structure will unanchor or reanchor it.</span>"
 		user << "<span class='cult'>Striking another cultist with it will purge holy water from them.</span>"
 		user << "<span class='cult'>Striking a noncultist, however, will sear their flesh.</span>"
+		user << "<span class='cult'>Striking a runed wall will make it intangible or tangible.</span>"
 
 /obj/item/weapon/tome/attack(mob/living/M, mob/living/user)
 	if(!istype(M))


### PR DESCRIPTION
Refer to issue https://github.com/yogstation13/yogstation/pull/460.
### Intent of your Pull Request

Examining an arcane tome will contain some information on toggling runed wall phasability.
#### Changelog

:cl:
tweak: Arcane tomes now explain how to toggle the phasability of runed walls... it's as easy as smashing a book against a wall.
/:cl:
