### PR TITLE
Gulag Lockers and Purchasable Prisoner ID's

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -1143,7 +1143,7 @@
 	},
 /area/ai_monitored/security/armory)
 "aco" = (
-/obj/structure/closet/secure_closet/brig,
+/obj/structure/closet/secure_closet/gulag,
 /turf/open/floor/plasteel{
 	icon_state = "dark"
 	},
@@ -7674,6 +7674,7 @@
 	tag = "icon-manifold-b-f (EAST)";
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/gulag,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "anF" = (
@@ -8058,6 +8059,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/closet/secure_closet/gulag,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "aop" = (
@@ -8429,6 +8431,7 @@
 /area/security/processing)
 "aoW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/closet/secure_closet/gulag,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "aoX" = (

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -247,6 +247,7 @@ update_label("John Doe", "Clowny")
 	registered_name = "Scum"
 	var/goal = 0 //How far from freedom?
 	var/points = 0
+	var/savedlocker
 
 /obj/item/weapon/card/id/prisoner/attack_self(mob/user)
 	usr << "<span class='notice'>You have accumulated [points] out of the [goal] points you need for freedom.</span>"
@@ -278,6 +279,25 @@ update_label("John Doe", "Clowny")
 /obj/item/weapon/card/id/prisoner/seven
 	name = "Prisoner #13-007"
 	registered_name = "Prisoner #13-007"
+
+
+/obj/item/weapon/card/id/prisoner/basic
+	name = "Prisoner #13"
+	registered_name
+	var/registered = FALSE
+
+
+/obj/item/weapon/card/id/prisoner/basic/attack_self(mob/user)
+	if(!registered)
+		var/nolongeraman = input(user, "Assign a number?", "Select Prisoner Number") as null|num
+		if(!nolongeraman)
+			return
+
+		name += "-[nolongeraman]"
+		registered_name += "-[nolongeraman]"
+		registered = TRUE
+	else
+		return ..()
 
 /obj/item/weapon/card/id/mining
 	name = "mining ID"

--- a/code/game/objects/items/weapons/storage/boxes.dm
+++ b/code/game/objects/items/weapons/storage/boxes.dm
@@ -387,6 +387,23 @@
 	new /obj/item/weapon/card/id/prisoner/six(src)
 	new /obj/item/weapon/card/id/prisoner/seven(src)
 
+
+/obj/item/weapon/storage/box/bprisoner
+	name = "box of unnumbered prisoner IDs"
+	desc = "These ID's don't have numbers and require you to fill them in yourself."
+	icon_state = "id"
+
+/obj/item/weapon/storage/box/bprisoner/New()
+	..()
+	new /obj/item/weapon/card/id/prisoner/basic(src)
+	new /obj/item/weapon/card/id/prisoner/basic(src)
+	new /obj/item/weapon/card/id/prisoner/basic(src)
+	new /obj/item/weapon/card/id/prisoner/basic(src)
+	new /obj/item/weapon/card/id/prisoner/basic(src)
+	new /obj/item/weapon/card/id/prisoner/basic(src)
+	new /obj/item/weapon/card/id/prisoner/basic(src)
+
+
 /obj/item/weapon/storage/box/seccarts
 	name = "box of PDA security cartridges"
 	desc = "A box full of PDA cartridges used by Security."

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -314,7 +314,7 @@
 /obj/structure/closet/secure_closet/gulag/examine(mob/user)
 	..()
 	if(savedcard)
-		user << "<span class='notice'>The locker is assigned to [P.registered_name].</span>"
+		user << "<span class='notice'>The locker is assigned to [savedcard.registered_name].</span>"
 	else
 		user << "<span class='notice'>The locker hasn't been assigned yet.</span>"
 
@@ -328,7 +328,7 @@
 				user << "<span class='warning'>[W] already has a synced locker!</span>"
 				return
 
-			user << "<span class='notice'>The locker scans and saves the card into it's database. Once the card reaches it's goal, it will open.</span>"
+			user << "<span class='notice'>The locker successfully scans the card. Once the card reaches it's goal, it will open.</span>"
 			savedcard = W
 			P.savedlocker = src
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -348,6 +348,8 @@
 	return ..()
 
 /obj/structure/closet/secure_closet/gulag/ShiftAltClick(mob/user)
+	if(!Adjacent(user))
+		return
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user
 		if(istype(H.get_idcard(), /obj/item/weapon/card/id/prisoner))

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -157,6 +157,13 @@
 					/obj/item/weapon/storage/box/handcuffs)
 	crate_name = "security supply crate"
 
+/datum/supply_pack/security/supplies
+	name = "Prisoner ID Crate"
+	cost = 1000
+	contains = list(/obj/item/weapon/storage/box/bprisoner,
+					/obj/item/weapon/storage/box/bprisoner)
+	crate_name = "prisoner id crate"
+
 /datum/supply_pack/security/helmets
 	name = "Helmets Crate"
 	cost = 1000


### PR DESCRIPTION
### Intent of your Pull Request

NT has developed a prototype gulag locker and has managed to fit it into their tight budget!
Gulag Lockers are exactly what you think.
They're used to store clothing and personal items from a prisoner eligible for a labor sentence.

These lockers start out with a prisoner outfit and orange shoes. Would've debated on legcuffs to be honest with you guys but, not _all_ labor prisoners deserve that treatment.

These lockers will only open for someone with a labor ID if that person has completed his goal and his card was synced earlier to that specific locker.

Of course, if you have security level access you can open up these lockers like normal

To sync ID's with lockers, it requires a person to bump a locker with a prisoner ID.
To clear the memory of a locker, it requires someone to shift+alt. Requires Security Access.

At least 3 lockers will spawn in the gulag transport station.

One other thing, you can now buy 2 whole boxes full of labor ID's for 1000 credits from Cargo.
The only time it'd be a good idea to buy them is if the original box was stolen, blown up, or it's all used up.

These ID's however are special because they don't come with a number. While it's a virgin, the user has an option to choose their own number for that prisoner.
#### Changelog

:cl:
rscadd: NT has shipped in fancy new gulag lockers! To use them properly first, set a card goal on a prisoner ID, second, slap the locker with the ID, third, empty everything the prisoner has into the locker, fourth, process them like usual.
rscadd: Labor ID's are now purchasable within cargo. These are special because you can choose a number for them.
/:cl:

**also can a spriter please help me sprite a cool looking gulag locker. i can't sprite & currently they look like replicas of the security version**
