### PR TITLE
removes cruix's exploding memeana from xeno

### DIFF
--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -186,6 +186,7 @@
 		/obj/item/weapon/reagent_containers/food/snacks/grown/mushroom,
 		)
 	blocked |= typesof(/obj/item/weapon/reagent_containers/food/snacks/customizable)
+	blocked |= /obj/item/weapon/reagent_containers/food/snacks/grown/banana/bombanana
 
 	var/list/borks = typesof(/obj/item/weapon/reagent_containers/food/snacks) - blocked + /obj/item/weapon/guardiancreator/carp //holo fishsticks are food too ;^)
 	// BORK BORK BORK


### PR DESCRIPTION
> be xenobio
> spam silver slime extracts to get [redacted]
> step on banana that has no teller of whether or not it's a bomb
> you immediately die from a syndie minibomb

don't even try to justify this one, this was not intended

:cl: pseudo
rscdel: Removed bomb bananas from xenobio silver slime pool
/:cl:
