### PR TITLE
brings back limited ammo for secborgs

### DIFF
--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -35,11 +35,11 @@
 
 /obj/item/weapon/gun/energy/gun/advtaser/cyborg/New()
 	..()
-	SSobj.processing |= src
+	START_PROCESSING(SSobj, src)
 
 
 /obj/item/weapon/gun/energy/gun/advtaser/cyborg/Destroy()
-	SSobj.processing.Remove(src)
+	STOP_PROCESSING(SSobj, src)
 	..()
 
 /obj/item/weapon/gun/energy/gun/advtaser/cyborg/process() //Every [recharge_time] ticks, recharge a shot for the cyborg
@@ -69,11 +69,11 @@
 
 /obj/item/weapon/gun/energy/disabler/cyborg/New()
 	..()
-	SSobj.processing |= src
+	START_PROCESSING(SSobj, src)
 
 
 /obj/item/weapon/gun/energy/disabler/cyborg/Destroy()
-	SSobj.processing.Remove(src)
+	STOP_PROCESSING(SSobj, src)
 	..()
 
 /obj/item/weapon/gun/energy/disabler/cyborg/process() //Every [recharge_time] ticks, recharge a shot for the cyborg

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -31,10 +31,26 @@
 	desc = "An integrated hybrid taser that draws directly from a cyborg's power cell. The weapon contains a limiter to prevent the cyborg's power cell from overheating."
 	can_flashlight = 0
 	can_charge = 0
+	var/recharge_time = 10
 
-/obj/item/weapon/gun/energy/gun/advtaser/cyborg/newshot()
+/obj/item/weapon/gun/energy/gun/advtaser/cyborg/New()
 	..()
+	SSobj.processing |= src
+
+
+/obj/item/weapon/gun/energy/gun/advtaser/cyborg/Destroy()
+	SSobj.processing.Remove(src)
+	..()
+
+/obj/item/weapon/gun/energy/gun/advtaser/cyborg/process() //Every [recharge_time] ticks, recharge a shot for the cyborg
+	charge_tick++
+	if(charge_tick < recharge_time) return 0
+	charge_tick = 0
+
+	if(!power_supply) return 0 //sanity
 	robocharge()
+
+	update_icon()
 
 /obj/item/weapon/gun/energy/disabler
 	name = "disabler"
@@ -48,7 +64,25 @@
 	name = "cyborg disabler"
 	desc = "An integrated disabler that draws from a cyborg's power cell. This weapon contains a limiter to prevent the cyborg's power cell from overheating."
 	can_charge = 0
+	var/recharge_time = 4
 
-/obj/item/weapon/gun/energy/disabler/cyborg/newshot()
+
+/obj/item/weapon/gun/energy/disabler/cyborg/New()
 	..()
+	SSobj.processing |= src
+
+
+/obj/item/weapon/gun/energy/disabler/cyborg/Destroy()
+	SSobj.processing.Remove(src)
+	..()
+
+/obj/item/weapon/gun/energy/disabler/cyborg/process() //Every [recharge_time] ticks, recharge a shot for the cyborg
+	charge_tick++
+	if(charge_tick < recharge_time) return 0
+	charge_tick = 0
+
+	if(!power_supply) return 0 //sanity
 	robocharge()
+
+	update_icon()
+


### PR DESCRIPTION
https://github.com/yogstation13/yogstation/issues/833
disable my ass daddy

:cl: ShadowDeath6
rscadd: Due to loud outcry from Grayshirts Organized, NanoTrasen has reverted the upgrade providing their security cyborgs with unlimited disabler beams.
/:cl:
