### PR TITLE
megafauna can attack through walls + bubblegum buffs

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -16,6 +16,7 @@
 	var/ranged_message = "fires" //Fluff text for ranged mobs
 	var/ranged_cooldown = 0 //What the current cooldown on ranged attacks is, generally world.time + ranged_cooldown_time
 	var/ranged_cooldown_time = 30 //How long, in deciseconds, the cooldown of ranged attacks is
+	var/ranged_ignores_vision = FALSE //if it'll fire ranged attacks even if it lacks vision on its target, only works with environment smash
 	var/check_friendly_fire = 0 // Should the ranged mob check for friendlies when shooting
 	var/retreat_distance = null //If our mob runs from players when they're too close, set in tile distance. By default, mobs do not retreat.
 	var/minimum_distance = 1 //Minimum approach distance, so ranged mobs chase targets down, but still keep their distance set in tiles to the target, set higher to make mobs keep distance
@@ -200,6 +201,8 @@
 		return 0
 	if(environment_smash && !(stop_automated_movement_when_pulled && pulledby))
 		if(target.loc != null && get_dist(targets_from, target.loc) <= vision_range)//We can't see our target, but he's in our vision range still
+			if(ranged_ignores_vision && ranged_cooldown <= world.time) //we can't see our target... but we can fire at them!
+				OpenFire(target)
 			if(environment_smash >= 2)//If we're capable of smashing through walls, forget about vision completely after finding our target
 				Goto(target,move_to_delay,minimum_distance)
 				FindHidden()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -29,6 +29,7 @@
 	var/charging = 0
 	deathmessage = "sinks into a pool of blood, fleeing the battle. You've won, for now... "
 	death_sound = 'sound/magic/enter_blood.ogg'
+	bloodcrawl = BLOODCRAWL_EAT
 
 /obj/item/device/gps/internal/lavaland/bubblegum
 	icon_state = null
@@ -38,7 +39,7 @@
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Life()
 	..()
-	move_to_delay = Clamp(round((health/maxHealth) * 10), 5, 10)
+	move_to_delay = Clamp(round((health/maxHealth) * 6), 5, 10)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/OpenFire()
 	var/anger_modifier = Clamp(((maxHealth - health)/50),0,20)
@@ -69,10 +70,10 @@
 		if(B != src)
 			qdel(src) //There can be only one
 			break
-	var/obj/effect/proc_holder/spell/bloodcrawl/bloodspell = new
+	/*var/obj/effect/proc_holder/spell/bloodcrawl/bloodspell = new // commented out because we use ctrl+click rather than the spell
 	AddSpell(bloodspell)
 	if(istype(loc, /obj/effect/dummy/slaughter))
-		bloodspell.phased = 1
+		bloodspell.phased = 1*/
 	new/obj/item/device/gps/internal/lavaland/bubblegum(src)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/do_attack_animation(atom/A)
@@ -159,7 +160,7 @@
 	visible_message("<span class='danger'>[src] sprays a stream of gore!</span>")
 	spawn(0)
 		var/turf/E = get_edge_target_turf(src, src.dir)
-		var/range = 10
+		var/range = 25
 		for(var/turf/open/J in getline(src,E))
 			if(!range)
 				break

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -183,7 +183,8 @@
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/blast()
 	spawn()
-		for(var/turf/turf in range(1, target))
+		var/turf/T = get_turf(target)
+		for(var/turf/turf in range(1, T))
 			shoot_projectile(turf)
 
 /mob/living/simple_animal/hostile/megafauna/colossus/proc/dir_shots(list/dirs)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/dragon.dm
@@ -225,6 +225,7 @@
 	name = "lesser ash drake"
 	maxHealth = 300
 	health = 300
+	faction = list("neutral")
 	melee_damage_upper = 30
 	melee_damage_lower = 30
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -9,6 +9,7 @@
 	luminosity = 3
 	weather_immunities = list("lava","ash")
 	robust_searching = 1
+	ranged_ignores_vision = TRUE
 	stat_attack = 1
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0


### PR DESCRIPTION
Buffs Bubblegum's speed by a substantial amount as well as giving him a vastly increased range of his blood spray

Ports https://github.com/tgstation/tgstation/pull/20443 , giving megafauna the ability to fire through walls by @ChangelingRain 

:cl: ShadowDeath6
rscadd: Megafauna can now attack you through walls, provided you're close enough. By ChangelingRain.
tweak: Increased Bubblegum's bloodspray range.
tweak: Increased Bubblegum's speed.
/:cl:
