### PR TITLE
Adds rpds to the atmos wintercoat

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -477,7 +477,7 @@
 	name = "engineering winter coat"
 	icon_state = "coatengineer"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 20)
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/device/t_scanner, /obj/item/weapon/rcd)
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/device/t_scanner,/obj/item/weapon/rcd,/obj/item/weapon/Rapid_Engineering_Device,/obj/item/device/geiger_counter)
 	hoodtype = /obj/item/clothing/head/winterhood/engineering
 
 /obj/item/clothing/head/winterhood/engineering
@@ -486,6 +486,7 @@
 /obj/item/clothing/suit/hooded/wintercoat/engineering/atmos
 	name = "atmospherics winter coat"
 	icon_state = "coatatmos"
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/device/t_scanner,/obj/item/weapon/rpd,/obj/item/device/analyzer,/obj/item/device/geiger_counter)
 	hoodtype = /obj/item/clothing/head/winterhood/engineering/atmos
 
 /obj/item/clothing/head/winterhood/engineering/atmos

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -477,7 +477,7 @@
 	name = "engineering winter coat"
 	icon_state = "coatengineer"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 20)
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/device/t_scanner,/obj/item/weapon/rcd,/obj/item/weapon/Rapid_Engineering_Device,/obj/item/device/geiger_counter)
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/device/t_scanner,/obj/item/weapon/rcd,/obj/item/weapon/rapid_engineering_device,/obj/item/device/geiger_counter)
 	hoodtype = /obj/item/clothing/head/winterhood/engineering
 
 /obj/item/clothing/head/winterhood/engineering

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -486,7 +486,7 @@
 /obj/item/clothing/suit/hooded/wintercoat/engineering/atmos
 	name = "atmospherics winter coat"
 	icon_state = "coatatmos"
-	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/device/t_scanner,/obj/item/weapon/rpd,/obj/item/device/analyzer,/obj/item/device/geiger_counter)
+	allowed = list(/obj/item/device/flashlight,/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/device/t_scanner,/obj/item/weapon/pipe_dispenser,/obj/item/device/analyzer,/obj/item/device/geiger_counter)
 	hoodtype = /obj/item/clothing/head/winterhood/engineering/atmos
 
 /obj/item/clothing/head/winterhood/engineering/atmos


### PR DESCRIPTION
Fixes #842.

Lets the atmos winter coat store a rpd

:cl:(Zostroll)
tweak:Added a pocket for the rpd on the atmos wintercoat
/:cl:
