### PR TITLE
buffs assassin holos again

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -172,6 +172,8 @@ var/global/list/parasites = list() //all currently existing/living guardians
 	if(src.loc == summoner)
 		src << "<span class='danger'><B>You must be manifested to attack!</span></B>"
 		return 0
+	if(target == src)//stop hitting yourself, please
+		return
 	if(target == summoner && !(istype(src,/mob/living/simple_animal/hostile/guardian/healer)))
 		return 0
 	else

--- a/code/modules/mob/living/simple_animal/guardian/types/assassin.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/assassin.dm
@@ -9,7 +9,6 @@
 	range = 21 //gives it some freedom to scout while invisible
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	see_in_dark = 8
-	sight = SEE_MOBS
 	playstyle_string = "<span class='holoparasite'>As an <b>assassin</b> type you do medium damage and have no damage resistance, but can enter stealth, massively increasing the damage of your next attack and causing it to ignore armor. Stealth is broken when you attack or take damage.</span>"
 	magic_fluff_string = "<span class='holoparasite'>..And draw the Space Ninja, a lethal, invisible assassin.</span>"
 	tech_fluff_string = "<span class='holoparasite'>Boot sequence complete. Assassin modules loaded. Holoparasite swarm online.</span>"

--- a/code/modules/mob/living/simple_animal/guardian/types/assassin.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/assassin.dm
@@ -6,6 +6,10 @@
 	attacktext = "slashes"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
+	range = 21 //gives it some freedom to scout while invisible
+	see_invisible = SEE_INVISIBLE_MINIMUM
+	see_in_dark = 8
+	sight = SEE_MOBS
 	playstyle_string = "<span class='holoparasite'>As an <b>assassin</b> type you do medium damage and have no damage resistance, but can enter stealth, massively increasing the damage of your next attack and causing it to ignore armor. Stealth is broken when you attack or take damage.</span>"
 	magic_fluff_string = "<span class='holoparasite'>..And draw the Space Ninja, a lethal, invisible assassin.</span>"
 	tech_fluff_string = "<span class='holoparasite'>Boot sequence complete. Assassin modules loaded. Holoparasite swarm online.</span>"
@@ -36,6 +40,9 @@
 /mob/living/simple_animal/hostile/guardian/assassin/AttackingTarget()
 	if(..())
 		if(toggle && (isliving(target) || istype(target, /obj/structure/window) || istype(target, /obj/structure/grille)))
+			if(ishuman(target))
+				var/mob/living/carbon/human/H = target
+				H.Weaken(3)//so the assassin can actually secure kills on people it sneak attacks
 			ToggleMode(1)
 
 /mob/living/simple_animal/hostile/guardian/assassin/adjustHealth(amount)
@@ -53,6 +60,8 @@
 		melee_damage_upper = initial(melee_damage_upper)
 		armour_penetration = initial(armour_penetration)
 		environment_smash = initial(environment_smash)
+		pass_flags &= ~PASSMOB
+		pass_flags &= ~PASSTABLE
 		alpha = initial(alpha)
 		if(!forced)
 			src << "<span class='danger'><B>You exit stealth.</span></B>"
@@ -72,6 +81,7 @@
 		environment_smash = 0
 		PoolOrNew(/obj/effect/overlay/temp/guardian/phase/out, get_turf(src))
 		alpha = 15
+		pass_flags = PASSTABLE | PASSMOB
 		if(!forced)
 			src << "<span class='danger'><B>You enter stealth, empowering your next attack.</span></B>"
 		updatestealthalert()

--- a/code/modules/mob/living/simple_animal/guardian/types/assassin.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/assassin.dm
@@ -42,7 +42,7 @@
 		if(toggle && (isliving(target) || istype(target, /obj/structure/window) || istype(target, /obj/structure/grille)))
 			if(ishuman(target))
 				var/mob/living/carbon/human/H = target
-				H.Weaken(3)//so the assassin can actually secure kills on people it sneak attacks
+				H.adjustStaminaLoss(35)//so the assassin can actually secure kills on people it sneak attacks
 			ToggleMode(1)
 
 /mob/living/simple_animal/hostile/guardian/assassin/adjustHealth(amount)


### PR DESCRIPTION
fuck yourself chaos holo

Assassin holos now have a vastly increased range to encourage actual usage of their stealth other than killing people

They also have full darkvision and thermals for sneaking purposes

they also have passmob while stealthed so they don't bump people while invisible

also they have passtable as a direct buff, it'd be a nice feature and I doubt it would really change much
# big shit

assassin holos also do a fuckton of stamina after stealth hitting, which slows their targets a lot

:cl: ShadowDeath6
rscadd: Assassin holoparasites now deal stamina damage upon stealth attacking, so they better secure kills.
rscadd: Assassin holoparasites now have thermal vision.
rscadd: Assassin holoparasites now pass through people while under stealth.
tweak: Increased Assassin holoparasite range has been increased.
/:cl:
