### PR TITLE
Nerfs Virus Stimulant

### DIFF
--- a/code/datums/diseases/advance/symptoms/stimulant.dm
+++ b/code/datums/diseases/advance/symptoms/stimulant.dm
@@ -17,7 +17,7 @@ Bonus
 
 /datum/symptom/stimulant
 
-	name = "Stimulant"
+	name = "Artificial Stimulant"
 	stealth = -1
 	resistance = -3
 	stage_speed = -2
@@ -30,9 +30,10 @@ Bonus
 		var/mob/living/M = A.affected_mob
 		switch(A.stage)
 			if(5)
-				if (M.reagents.get_reagent_amount("ephedrine") < 10)
-					M.reagents.add_reagent("ephedrine", 10)
+				if(!M.stunned && !M.weakened)
+					if (M.reagents.get_reagent_amount("lesserephedrine") < 10)
+						M.reagents.add_reagent("lesserephedrine", 10)
 			else
 				if(prob(SYMPTOM_ACTIVATION_PROB * 5))
-					M << "<span class='notice'>[pick("You feel restless.", "You feel like running laps around the station.")]</span>"
+					M << "<span class='notice'>[pick("You feel restless.", "You feel like running laps around the station.", "You feel like you could dodge a bullet", "You feel like taking a run outside the skirts of the station.", "You feel like time is moving slowly every time you take a step.")]</span>"
 	return

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -533,6 +533,21 @@
 		. = 1
 	..()
 
+
+/datum/reagent/medicine/lesserephedrine
+	name = "Lesser Ephedrine"
+	id = "lesserephedrine"
+	description = "Increases movement speed."
+	reagent_state = LIQUID
+	color = "#D2FFFA"
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
+
+
+/datum/reagent/medicine/lesserephedrine/on_mob_life(mob/living/M)
+	M.status_flags |= GOTTAGOFAST
+	..()
+	. = 1
+
 /datum/reagent/medicine/diphenhydramine
 	name = "Diphenhydramine"
 	id = "diphenhydramine"


### PR DESCRIPTION
Alternative to https://github.com/yogstation13/yogstation/pull/820.
### Intent of your Pull Request
- Nerfs the stimulant virus, also includes a new chemical known as "Lesser Ephedrine".
  - Lesser Ephedrine is subjected the same way Ephedrine was
  - The virus will not inject Lesser Ephedrine into the user's bloodstream if he/she is stunned or weakened.
  - Lesser Ephedrine **ONLY** makes you faster.
- A few more messages were added for the stimulant virus, other than "You feel restless", or "You feel like running laps around the station."
#### Changelog

:cl:
rscadd: Stimulant Virus Nerf
rscdel: Stimulant Virus no longer uses ephedrine
tweak: Stimulant Virus now uses lesser ephedrine, which only makes you run faster.
tweak: The virus will not subject lesser ephedrine to users that are stunned or weakened.
/:cl:
