### PR TITLE
buffs explosive holo trap

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
@@ -62,32 +62,41 @@
 	anchored = A.anchored
 	density = A.density
 	appearance = A.appearance
-	spawn(1000)
-		stored_obj.loc = get_turf(src.loc)
-		spawner << "<span class='danger'><B>Failure! Your trap didn't catch anyone this time.</span></B>"
-		qdel(src)
+	addtimer(src,"vanish", 1000)
+
+/obj/item/weapon/guardian_bomb/proc/vanish(var/obj/A)
+	stored_obj.loc = get_turf(src.loc)
+	spawner << "<span class='danger'><B>Failure! Your trap didn't catch anyone this time.</span></B>"
+	qdel(src)
 
 /obj/item/weapon/guardian_bomb/proc/detonate(var/mob/living/user)
-	user << "<span class='danger'><B>The [src] was boobytrapped!</span></B>"
+	user << "<span class='danger'><B>[src] was boobytrapped!</span></B>"
 	spawner << "<span class='danger'><B>Success! Your trap caught [user]</span></B>"
 	stored_obj.loc = get_turf(src.loc)
 	playsound(get_turf(src),'sound/effects/Explosion2.ogg', 200, 1)
 	user.ex_act(2)
 	qdel(src)
 
-/obj/item/weapon/guardian_bomb/Bump(atom/A)
-	if(isliving(A) && A != spawner && A != spawner.summoner && !spawner.hasmatchingsummoner(A))
-		detonate(A)
+/obj/item/weapon/guardian_bomb/attackby(obj/item/C, mob/user)
+	if(isliving(user) && user != spawner && user != spawner.summoner && !spawner.hasmatchingsummoner(user))
+		detonate(user)
 	else
-		..()
-
-/obj/item/weapon/guardian_bomb/attackby(mob/living/user)
-	detonate(user)
+		user <<"<span class='danger'>Something forces you to avoid touching [src].</span>"
 	return
 
 /obj/item/weapon/guardian_bomb/pickup(mob/living/user)
 	..()
-	detonate(user)
+	if(isliving(user) && user != spawner && user != spawner.summoner && !spawner.hasmatchingsummoner(user))
+		detonate(user)
+	else
+		user <<"<span class='danger'>Something forces you to avoid touching [src].</span>"
+	return
+
+/obj/item/weapon/guardian_bomb/attack_hand(mob/user)
+	if(isliving(user) && user != spawner && user != spawner.summoner && !spawner.hasmatchingsummoner(user))
+		detonate(user)
+	else
+		user <<"<span class='danger'>Something forces you to avoid touching [src].</span>"
 	return
 
 /obj/item/weapon/guardian_bomb/examine(mob/user)

--- a/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
@@ -30,6 +30,7 @@
 						if(L != src && L != summoner)
 							L.apply_damage(15, BRUTE)
 					PoolOrNew(/obj/effect/overlay/temp/explosion, get_turf(M))
+					playsound(get_turf(M),'sound/effects/Explosion2.ogg', 200, 1)
 
 /mob/living/simple_animal/hostile/guardian/bomb/AltClickOn(atom/movable/A)
 	if(!istype(A))
@@ -41,11 +42,11 @@
 		if(bomb_cooldown <= world.time && !stat)
 			var/obj/item/weapon/guardian_bomb/B = new /obj/item/weapon/guardian_bomb(get_turf(A))
 			src << "<span class='danger'><B>Success! Bomb armed!</span></B>"
-			bomb_cooldown = world.time + 200
+			bomb_cooldown = world.time + 300
 			B.spawner = src
 			B.disguise(A)
 		else
-			src << "<span class='danger'><B>Your powers are on cooldown! You must wait 20 seconds between bombs.</span></B>"
+			src << "<span class='danger'><B>Your powers are on cooldown! You must wait 30 seconds between bombs.</span></B>"
 
 /obj/item/weapon/guardian_bomb
 	name = "bomb"
@@ -61,7 +62,7 @@
 	anchored = A.anchored
 	density = A.density
 	appearance = A.appearance
-	spawn(600)
+	spawn(1000)
 		stored_obj.loc = get_turf(src.loc)
 		spawner << "<span class='danger'><B>Failure! Your trap didn't catch anyone this time.</span></B>"
 		qdel(src)

--- a/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
@@ -77,6 +77,11 @@
 	user.ex_act(2)
 	qdel(src)
 
+/obj/item/weapon/guardian_bomb/Bumped(mob/user)
+	if(isliving(user) && user != spawner && user != spawner.summoner && !spawner.hasmatchingsummoner(user))
+		detonate(user)
+	return
+
 /obj/item/weapon/guardian_bomb/attackby(obj/item/C, mob/user)
 	if(isliving(user) && user != spawner && user != spawner.summoner && !spawner.hasmatchingsummoner(user))
 		detonate(user)

--- a/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/explosive.dm
@@ -80,7 +80,8 @@
 /obj/item/weapon/guardian_bomb/Bumped(mob/user)
 	if(isliving(user) && user != spawner && user != spawner.summoner && !spawner.hasmatchingsummoner(user))
 		detonate(user)
-	return
+	else
+		..()
 
 /obj/item/weapon/guardian_bomb/attackby(obj/item/C, mob/user)
 	if(isliving(user) && user != spawner && user != spawner.summoner && !spawner.hasmatchingsummoner(user))


### PR DESCRIPTION
their traps last longer and they have a longer cooldown in between setting traps

as always vars adjusted are up for debate

:cl: ShadowDeath6
bugfix: Explosive holoparasite's bomb trap now actually works.
tweak: Increases the duration of the explosive holoparasite's bomb trap, as well as the cooldown between bomb traps set.
/:cl:
