### PR TITLE
Makes macro-bomb implants available for traitors.

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1022,7 +1022,6 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			Upon death, releases a massive explosion that will wipe out everything nearby."
 	item = /obj/item/weapon/storage/box/syndie_kit/imp_macrobomb
 	cost = 20
-	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/implants/mindslave
 	name = "Mindslave Implant"


### PR DESCRIPTION
The macro bomb implant can now be purchased for 20tc by every traitor.

Honestly, if you have a "Die a glorious death" objective, this is one funky way to do it.

I did not include the micro bomb implant because it would be too easy of a get-away.

:cl:
rscadd: After multiple protests for equal rights, the syndicate agents can now purchase a macro bomb implant.
/:cl:
