### PR TITLE
Fixed being unable to toggle the lock on a locker with your PDA

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -252,7 +252,7 @@
 							"<span class='notice'>You [welded ? "weld" : "unwelded"] \the [src] with \the [WT].</span>",
 							"<span class='italics'>You hear welding.</span>")
 			update_icon()
-	else if(user.a_intent != "harm" && !(W.flags & NOBLUDGEON))
+	else if(user.a_intent != "harm")
 		if(W.GetID() || !toggle(user))
 			togglelock(user)
 		return 1


### PR DESCRIPTION
Fixes #894
:cl:
fix: You can now toggle the lock on a locker by hitting it with your PDA if your PDA has an ID in it.
/:cl:
