### PR TITLE
Further minor pAI fixes and tweaks

### DIFF
--- a/code/controllers/subsystem/pai.dm
+++ b/code/controllers/subsystem/pai.dm
@@ -25,6 +25,7 @@ var/datum/subsystem/pai/SSpai
 				pai.name = pick(ninja_names)
 			else
 				pai.name = candidate.name
+			pai.description = candidate.description
 			pai.real_name = pai.name
 			pai.key = candidate.key
 
@@ -35,13 +36,13 @@ var/datum/subsystem/pai/SSpai
 			ticker.mode.update_rev_icons_removed(card.pai.mind)
 
 			candidates -= candidate
-			
+
 			if(availableRecruitsCount() == 0)
 				for(var/obj/item/device/paicard/p in world)
 					if(p.looking_for_personality == 1)
 						p.overlays.Cut()
 						p.overlays += "pai-off"
-			
+
 			usr << browse(null, "window=findPai")
 
 	if(href_list["new"])

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -431,6 +431,10 @@
 	if(stat || sleeping || paralysis || weakened)
 		return
 
+	if (wiped)
+		src << "\red Your holographic control processes were the first to be deleted! You can't move!"
+		return
+
 	if (!canholo)
 		src << "\red Your master has not enabled your external holographic emitters! Ask nicely!"
 		return

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -253,6 +253,7 @@
 		if (W.force)
 			user.visible_message("<span class='warning'>[user.name] slams [W] into [src]'s card, damaging it severely!</span>")
 			src.adjustBruteLoss(20)
+			src.adjustFireLoss(20)
 		else
 			user.visible_message("<span class='info'>[user.name] taps [W] against [src]'s screen.</span>")
 		..()

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -192,11 +192,12 @@
 				adjustFireLoss(100)
 		if(2.0)
 			if (src.stat != 2)
-				adjustBruteLoss(30)
+				adjustBruteLoss(60)
 				adjustFireLoss(30)
 		if(3.0)
 			if (src.stat != 2)
-				adjustBruteLoss(15)
+				adjustBruteLoss(30)
+				adjustFireLoss(15)
 	src << "<span class='danger'><b>A warning chime fires at the back of your consciousness process, heralding the unexpected shutdown of your holographic emitter. You're defenseless!</b></span>"
 	close_up()
 	return

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -248,7 +248,7 @@
 	return
 
 /mob/living/silicon/pai/attackby(obj/item/weapon/W as obj, mob/user as mob, params)
-	if (!canmove) //card has been hit
+	if (loc == card) //card has been hit
 		if (W.force)
 			user.visible_message("<span class='warning'>[user.name] slams [W] into [src]'s card, damaging it severely!</span>")
 			src.adjustBruteLoss(20)
@@ -258,7 +258,9 @@
 		return
 	if (cooldown >= cooldowncap)
 		return
+
 	user.do_attack_animation(src)
+
 	if(!W.force)
 		visible_message("<span class='info'>[user.name] strikes [src] harmlessly with [W], passing clean through its holographic projection.</span>")
 	else

--- a/code/modules/mob/living/silicon/pai/pai_software.dm
+++ b/code/modules/mob/living/silicon/pai/pai_software.dm
@@ -252,7 +252,8 @@
 		if (S in pai_software) //software with "0" ram is innate or otherwise hidden and doesn't need to be shown, same with stuff we've already purchased
 			continue
 
-		dat += "<a href='byond://?src=\ref[src];software=buy;sub=1;buy=[S.sid]'>[S.name]</a> ([S.ram])<br>"
+		dat += "<b><a href='byond://?src=\ref[src];software=buy;sub=1;buy=[S.sid]'>[S.name]</a></b> ([S.ram])<br>"
+		dat += "<i><small>[S.description]</small></i><br><br>"
 
 	dat += "</p>"
 	return dat

--- a/code/modules/tgui/states/default.dm
+++ b/code/modules/tgui/states/default.dm
@@ -54,7 +54,7 @@
 
 /mob/living/silicon/pai/default_can_use_topic(src_object)
 	// pAIs can only use themselves and the owner's radio.
-	if((src_object == src || src_object == radio) && !stat)
+	if(src_object == src && !stat)
 		return UI_INTERACTIVE
 	else
 		return ..()


### PR DESCRIPTION
Fixes a couple of minor issues relating to display and general interaction with pAIs in the world.

The damage tweaks specifically address issues regarding pAIs in holoform being able to sustain too much damage given what they're supposed to be.

Descriptions are also shown on pAI examining again.

A bug currently exists where dragging a pAI can sometimes force its canmove to be set to 0. Still can't figure out how to replicate it.
#### Changelog

:cl:
bugfix: pAI descriptions are now visible on both the card and in their holographic forms once more. When making your personality, remember that the "Description" column is shown for the world to see!
tweak: pAI are now generally more vulnerable in holographic form to all types of damage, and especially explosions.
/:cl:
