### PR TITLE
Fixed being unable to emag lockers on non-harm intent and being unable to wrap lockers.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -252,8 +252,8 @@
 							"<span class='notice'>You [welded ? "weld" : "unwelded"] \the [src] with \the [WT].</span>",
 							"<span class='italics'>You hear welding.</span>")
 			update_icon()
-	else if(user.a_intent != "harm")
-		if(W.GetID() || !toggle(user))
+	else if(user.a_intent != "harm" && W.GetID())
+		if(secure && !opened)
 			togglelock(user)
 		return 1
 	else


### PR DESCRIPTION
Fixes #905
Fixes #908
:cl:
fix: Fixed being unable to emag lockers except on harm intent.
fix: Fixed being unable to wrap lockers.
/:cl:
