### PR TITLE
Slightly changed how plant reagents work

### DIFF
--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -16,6 +16,7 @@
 	// If you don't want a plant to be driable (watermelons) set this to null in the time definition.
 	burn_state = FLAMMABLE
 	origin_tech = "biotech=1"
+	volume = 50
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/New(newloc, var/obj/item/seeds/new_seed = null)
 	..()

--- a/code/modules/hydroponics/grown/ambrosia.dm
+++ b/code/modules/hydroponics/grown/ambrosia.dm
@@ -22,7 +22,7 @@
 	potency = 5
 	icon_dead = "ambrosia-dead"
 	mutatelist = list(/obj/item/seeds/ambrosia/deus)
-	reagents_add = list("space_drugs" = 0.15, "bicaridine" = 0.1, "kelotane" = 0.1, "vitamin" = 0.04, "nutriment" = 0.05, "toxin" = 0.1)
+	reagents_add = list("space_drugs" = 0.30, "bicaridine" = 0.2, "kelotane" = 0.2, "vitamin" = 0.08, "nutriment" = 0.1, "toxin" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosia/vulgaris
 	seed = /obj/item/seeds/ambrosia
@@ -39,7 +39,7 @@
 	plantname = "Ambrosia Deus"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosia/deus
 	mutatelist = list(/obj/item/seeds/ambrosia/gaia)
-	reagents_add = list("omnizine" = 0.15, "synaptizine" = 0.15, "space_drugs" = 0.1, "vitamin" = 0.04, "nutriment" = 0.05)
+	reagents_add = list("omnizine" = 0.3, "synaptizine" = 0.3, "space_drugs" = 0.2, "vitamin" = 0.08, "nutriment" = 0.1)
 	rarity = 40
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosia/deus
@@ -59,7 +59,7 @@
 	plantname = "Ambrosia Gaia"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/ambrosia/gaia
 	mutatelist = list()
-	reagents_add = list("earthsblood" = 0.4, "nutriment" = 0.2, "vitamin" = 0.1)
+	reagents_add = list("earthsblood" = 0.8, "nutriment" = 0.4, "vitamin" = 0.2)
 	rarity = 100 //These are some pretty good plants right here
 	oneharvest = TRUE
 

--- a/code/modules/hydroponics/grown/apple.dm
+++ b/code/modules/hydroponics/grown/apple.dm
@@ -13,7 +13,7 @@
 	icon_grow = "apple-grow"
 	icon_dead = "apple-dead"
 	mutatelist = list(/obj/item/seeds/apple/gold)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("vitamin" = 0.08, "nutriment" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/apple
 	seed = /obj/item/seeds/apple
@@ -27,7 +27,7 @@
 /obj/item/seeds/apple/poisoned
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/apple/poisoned
 	mutatelist = list()
-	reagents_add = list("zombiepowder" = 0.5, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("zombiepowder" = 0.9, "vitamin" = 0.08, "nutriment" = 0.2)
 	rarity = 50 // Source of cyanide, and hard (almost impossible) to obtain normally.
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/apple/poisoned
@@ -44,7 +44,7 @@
 	maturation = 10
 	production = 10
 	mutatelist = list()
-	reagents_add = list("gold" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("gold" = 0.4, "vitamin" = 0.08, "nutriment" = 0.2)
 	rarity = 40 // Alchemy!
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/apple/gold

--- a/code/modules/hydroponics/grown/banana.dm
+++ b/code/modules/hydroponics/grown/banana.dm
@@ -12,7 +12,7 @@
 	icon_dead = "banana-dead"
 	genes = list(/datum/plant_gene/trait/slip)
 	mutatelist = list(/obj/item/seeds/banana/mime, /obj/item/seeds/banana/bluespace)
-	reagents_add = list("banana" = 0.1, "potassium" = 0.1, "vitamin" = 0.04, "nutriment" = 0.02)
+	reagents_add = list("banana" = 0.2, "potassium" = 0.2, "vitamin" = 0.08, "nutriment" = 0.04)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/banana
 	seed = /obj/item/seeds/banana
@@ -64,7 +64,7 @@
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/banana/mime
 	growthstages = 4
 	mutatelist = list()
-	reagents_add = list("nothing" = 0.1, "mutetoxin" = 0.1, "nutriment" = 0.02)
+	reagents_add = list("nothing" = 0.2, "mutetoxin" = 0.2, "nutriment" = 0.04)
 	rarity = 15
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/banana/mime
@@ -92,7 +92,7 @@
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/banana/bluespace
 	mutatelist = list()
 	genes = list(/datum/plant_gene/trait/slip, /datum/plant_gene/trait/teleport)
-	reagents_add = list("singulo" = 0.2, "banana" = 0.1, "vitamin" = 0.04, "nutriment" = 0.02)
+	reagents_add = list("singulo" = 0.4, "banana" = 0.2, "vitamin" = 0.08, "nutriment" = 0.04)
 	rarity = 30
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/banana/bluespace

--- a/code/modules/hydroponics/grown/beans.dm
+++ b/code/modules/hydroponics/grown/beans.dm
@@ -14,7 +14,7 @@
 	icon_grow = "soybean-grow"
 	icon_dead = "soybean-dead"
 	mutatelist = list(/obj/item/seeds/soya/koi)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.05)
+	reagents_add = list("vitamin" = 0.08, "nutriment" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/soybeans
 	seed = /obj/item/seeds/soya
@@ -35,7 +35,7 @@
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/koibeans
 	potency = 10
 	mutatelist = list()
-	reagents_add = list("carpotoxin" = 0.1, "vitamin" = 0.04, "nutriment" = 0.05)
+	reagents_add = list("carpotoxin" = 0.2, "vitamin" = 0.08, "nutriment" = 0.1)
 	rarity = 20
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/koibeans

--- a/code/modules/hydroponics/grown/berries.dm
+++ b/code/modules/hydroponics/grown/berries.dm
@@ -14,7 +14,7 @@
 	icon_grow = "berry-grow" // Uses one growth icons set for all the subtypes
 	icon_dead = "berry-dead" // Same for the dead icon
 	mutatelist = list(/obj/item/seeds/berry/glow, /obj/item/seeds/berry/poison)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("vitamin" = 0.08, "nutriment" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/berries
 	seed = /obj/item/seeds/berry
@@ -34,7 +34,7 @@
 	plantname = "Poison-Berry Bush"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/berries/poison
 	mutatelist = list(/obj/item/seeds/berry/death)
-	reagents_add = list("cyanide" = 0.15, "tirizene" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("cyanide" = 0.3, "tirizene" = 0.4, "vitamin" = 0.08, "nutriment" = 0.2)
 	rarity = 10 // Mildly poisonous berries are common in reality
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/berries/poison
@@ -55,7 +55,7 @@
 	lifespan = 30
 	potency = 50
 	mutatelist = list()
-	reagents_add = list("coniine" = 0.08, "tirizene" = 0.1, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("coniine" = 0.16, "tirizene" = 0.2, "vitamin" = 0.08, "nutriment" = 0.2)
 	rarity = 30
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/berries/death
@@ -77,7 +77,7 @@
 	endurance = 25
 	mutatelist = list()
 	genes = list(/datum/plant_gene/trait/glow/berry)
-	reagents_add = list("uranium" = 0.25, "iodine" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("uranium" = 0.4, "iodine" = 0.3, "vitamin" = 0.08, "nutriment" = 0.2)
 	rarity = 20
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/berries/glow
@@ -105,7 +105,7 @@
 	icon_grow = "cherry-grow"
 	icon_dead = "cherry-dead"
 	mutatelist = list(/obj/item/seeds/cherry/blue)
-	reagents_add = list("nutriment" = 0.07, "sugar" = 0.07)
+	reagents_add = list("nutriment" = 0.14, "sugar" = 0.14)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/cherries
 	seed = /obj/item/seeds/cherry
@@ -125,7 +125,7 @@
 	plantname = "Blue Cherry Tree"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/bluecherries
 	mutatelist = list(/obj/item/seeds/cherry/bomb)
-	reagents_add = list("nutriment" = 0.07, "sugar" = 0.07)
+	reagents_add = list("nutriment" = 0.14, "sugar" = 0.14)
 	rarity = 10
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/bluecherries
@@ -145,7 +145,7 @@
 	plantname = "Cherry Bomb Tree"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/cherry_bomb
 	mutatelist = list()
-	reagents_add = list("nutriment" = 0.1, "sugar" = 0.1, "blackpowder" = 0.1)
+	reagents_add = list("nutriment" = 0.2, "sugar" = 0.2, "blackpowder" = 0.2)
 	rarity = 25
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/cherry_bomb
@@ -198,7 +198,7 @@
 	icon_grow = "grape-grow"
 	icon_dead = "grape-dead"
 	mutatelist = list(/obj/item/seeds/grape/green)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1, "sugar" = 0.1)
+	reagents_add = list("vitamin" = 0.08, "nutriment" = 0.2, "sugar" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/grapes
 	seed = /obj/item/seeds/grape
@@ -217,7 +217,7 @@
 	species = "greengrape"
 	plantname = "Green-Grape Vine"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/grapes/green
-	reagents_add = list("kelotane" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1, "sugar" = 0.1)
+	reagents_add = list("kelotane" = 0.4, "vitamin" = 0.08, "nutriment" = 0.2, "sugar" = 0.2)
 	// No rarity: technically it's a beneficial mutant, but it's not exactly "new"...
 	mutatelist = list()
 

--- a/code/modules/hydroponics/grown/cannabis.dm
+++ b/code/modules/hydroponics/grown/cannabis.dm
@@ -17,7 +17,7 @@
 						/obj/item/seeds/cannabis/death,
 						/obj/item/seeds/cannabis/white,
 						/obj/item/seeds/cannabis/ultimate)
-	reagents_add = list("space_drugs" = 0.15, "lipolicide" = 0.35) // gives u the munchies
+	reagents_add = list("space_drugs" = 0.3, "lipolicide" = 0.7) // gives u the munchies
 
 
 /obj/item/seeds/cannabis/rainbow
@@ -28,7 +28,7 @@
 	plantname = "Rainbow Weed"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/cannabis/rainbow
 	mutatelist = list()
-	reagents_add = list("mindbreaker" = 0.15, "lipolicide" = 0.35)
+	reagents_add = list("mindbreaker" = 0.3, "lipolicide" = 0.7)
 	rarity = 40
 
 /obj/item/seeds/cannabis/death
@@ -39,7 +39,7 @@
 	plantname = "Deathweed"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/cannabis/death
 	mutatelist = list()
-	reagents_add = list("cyanide" = 0.35, "space_drugs" = 0.15, "lipolicide" = 0.15)
+	reagents_add = list("cyanide" = 0.6, "space_drugs" = 0.2, "lipolicide" = 0.2)
 	rarity = 40
 
 /obj/item/seeds/cannabis/white
@@ -50,7 +50,7 @@
 	plantname = "Lifeweed"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/cannabis/white
 	mutatelist = list()
-	reagents_add = list("omnizine" = 0.35, "space_drugs" = 0.15, "lipolicide" = 0.15)
+	reagents_add = list("omnizine" = 0.6, "space_drugs" = 0.2, "lipolicide" = 0.2)
 	rarity = 40
 
 
@@ -62,21 +62,21 @@
 	plantname = "Omega Weed"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/cannabis/ultimate
 	mutatelist = list()
-	reagents_add = list("space_drugs" = 0.3,
-						"mindbreaker" = 0.3,
-						"mercury" = 0.15,
-						"lithium" = 0.15,
-						"atropine" = 0.15,
-						"haloperidol" = 0.15,
-						"methamphetamine" = 0.15,
-						"capsaicin" = 0.15,
-						"barbers_aid" = 0.15,
-						"bath_salts" = 0.15,
-						"itching_powder" = 0.15,
-						"crank" = 0.15,
-						"krokodil" = 0.15,
-						"histamine" = 0.15,
-						"lipolicide" = 0.15)
+	reagents_add = list("space_drugs" = 0.1,
+						"mindbreaker" = 0.1,
+						"mercury" = 0.05,
+						"lithium" = 0.05,
+						"atropine" = 0.05,
+						"haloperidol" = 0.05,
+						"methamphetamine" = 0.05,
+						"capsaicin" = 0.05,
+						"barbers_aid" = 0.05,
+						"bath_salts" = 0.05,
+						"itching_powder" = 0.05,
+						"crank" = 0.05,
+						"krokodil" = 0.05,
+						"histamine" = 0.05,
+						"lipolicide" = 0.05)
 	rarity = 69
 
 

--- a/code/modules/hydroponics/grown/cereals.dm
+++ b/code/modules/hydroponics/grown/cereals.dm
@@ -12,7 +12,7 @@
 	oneharvest = 1
 	icon_dead = "wheat-dead"
 	mutatelist = list(/obj/item/seeds/wheat/oat, /obj/item/seeds/wheat/meat)
-	reagents_add = list("nutriment" = 0.04)
+	reagents_add = list("nutriment" = 0.08)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/wheat
 	seed = /obj/item/seeds/wheat

--- a/code/modules/hydroponics/grown/chili.dm
+++ b/code/modules/hydroponics/grown/chili.dm
@@ -15,7 +15,7 @@
 	icon_grow = "chili-grow" // Uses one growth icons set for all the subtypes
 	icon_dead = "chili-dead" // Same for the dead icon
 	mutatelist = list(/obj/item/seeds/chili/ice, /obj/item/seeds/chili/ghost)
-	reagents_add = list("capsaicin" = 0.25, "vitamin" = 0.04, "nutriment" = 0.04)
+	reagents_add = list("capsaicin" = 0.5, "vitamin" = 0.08, "nutriment" = 0.08)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/chili
 	seed = /obj/item/seeds/chili
@@ -38,7 +38,7 @@
 	production = 4
 	rarity = 20
 	mutatelist = list()
-	reagents_add = list("frostoil" = 0.25, "vitamin" = 0.02, "nutriment" = 0.02)
+	reagents_add = list("frostoil" = 0.5, "vitamin" = 0.04, "nutriment" = 0.04)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/icepepper
 	seed = /obj/item/seeds/chili/ice
@@ -63,7 +63,7 @@
 	yield = 3
 	rarity = 20
 	mutatelist = list()
-	reagents_add = list("condensedcapsaicin" = 0.3, "capsaicin" = 0.55, "nutriment" = 0.04)
+	reagents_add = list("condensedcapsaicin" = 0.3, "capsaicin" = 0.6, "nutriment" = 0.08)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/ghost_chili
 	seed = /obj/item/seeds/chili/ghost

--- a/code/modules/hydroponics/grown/citrus.dm
+++ b/code/modules/hydroponics/grown/citrus.dm
@@ -20,7 +20,7 @@
 	potency = 15
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	mutatelist = list(/obj/item/seeds/orange)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.05)
+	reagents_add = list("vitamin" = 0.08, "nutriment" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/citrus/lime
 	seed = /obj/item/seeds/lime
@@ -45,7 +45,7 @@
 	icon_grow = "lime-grow"
 	icon_dead = "lime-dead"
 	mutatelist = list(/obj/item/seeds/lime)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.05)
+	reagents_add = list("vitamin" = 0.08, "nutriment" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/citrus/orange
 	seed = /obj/item/seeds/orange
@@ -69,7 +69,7 @@
 	icon_grow = "lime-grow"
 	icon_dead = "lime-dead"
 	mutatelist = list(/obj/item/seeds/cash)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.05)
+	reagents_add = list("vitamin" = 0.08, "nutriment" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/citrus/lemon
 	seed = /obj/item/seeds/lemon
@@ -92,7 +92,7 @@
 	lifespan = 55
 	endurance = 45
 	yield = 4
-	reagents_add = list("nutriment" = 0.05)
+	reagents_add = list("nutriment" = 0.1)
 	rarity = 50  // Nanotrasen approves...
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/shell/moneyfruit

--- a/code/modules/hydroponics/grown/cocoa_vanilla.dm
+++ b/code/modules/hydroponics/grown/cocoa_vanilla.dm
@@ -15,7 +15,7 @@
 	icon_grow = "cocoapod-grow"
 	icon_dead = "cocoapod-dead"
 	mutatelist = list(/obj/item/seeds/cocoapod/vanillapod)
-	reagents_add = list("cocoa" = 0.25, "nutriment" = 0.1)
+	reagents_add = list("cocoa" = 0.5, "nutriment" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/cocoapod
 	seed = /obj/item/seeds/cocoapod
@@ -34,7 +34,7 @@
 	plantname = "Vanilla Tree"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/vanillapod
 	mutatelist = list()
-	reagents_add = list("vanilla" = 0.25, "nutriment" = 0.1)
+	reagents_add = list("vanilla" = 0.5, "nutriment" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/vanillapod
 	seed = /obj/item/seeds/cocoapod/vanillapod

--- a/code/modules/hydroponics/grown/corn.dm
+++ b/code/modules/hydroponics/grown/corn.dm
@@ -14,7 +14,7 @@
 	icon_grow = "corn-grow" // Uses one growth icons set for all the subtypes
 	icon_dead = "corn-dead" // Same for the dead icon
 	mutatelist = list(/obj/item/seeds/corn/snapcorn)
-	reagents_add = list("cornoil" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("cornoil" = 0.4, "vitamin" = 0.08, "nutriment" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/corn
 	seed = /obj/item/seeds/corn

--- a/code/modules/hydroponics/grown/eggplant.dm
+++ b/code/modules/hydroponics/grown/eggplant.dm
@@ -12,7 +12,7 @@
 	icon_grow = "eggplant-grow"
 	icon_dead = "eggplant-dead"
 	mutatelist = list(/obj/item/seeds/eggplant/eggy)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("vitamin" = 0.08, "nutriment" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/eggplant
 	seed = /obj/item/seeds/eggplant
@@ -31,7 +31,7 @@
 	lifespan = 75
 	production = 12
 	mutatelist = list()
-	reagents_add = list("nutriment" = 0.1)
+	reagents_add = list("nutriment" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/shell/eggy
 	seed = /obj/item/seeds/eggplant/eggy

--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -16,7 +16,7 @@
 	icon_grow = "poppy-grow"
 	icon_dead = "poppy-dead"
 	mutatelist = list(/obj/item/seeds/poppy/geranium, /obj/item/seeds/poppy/lily)
-	reagents_add = list("bicaridine" = 0.2, "nutriment" = 0.05)
+	reagents_add = list("bicaridine" = 0.4, "nutriment" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/poppy
 	seed = /obj/item/seeds/poppy
@@ -80,7 +80,7 @@
 	growthstages = 4
 	plant_type = PLANT_WEED
 	growing_icon = 'icons/obj/hydroponics/growing_flowers.dmi'
-	reagents_add = list("nutriment" = 0.04)
+	reagents_add = list("nutriment" = 0.08)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/harebell
 	seed = /obj/item/seeds/harebell
@@ -109,7 +109,7 @@
 	icon_grow = "sunflower-grow"
 	icon_dead = "sunflower-dead"
 	mutatelist = list(/obj/item/seeds/sunflower/moonflower, /obj/item/seeds/sunflower/novaflower)
-	reagents_add = list("cornoil" = 0.08, "nutriment" = 0.04)
+	reagents_add = list("cornoil" = 0.16, "nutriment" = 0.08)
 
 /obj/item/weapon/grown/sunflower // FLOWER POWER!
 	seed = /obj/item/seeds/sunflower
@@ -137,7 +137,7 @@
 	plantname = "Moonflowers"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/moonflower
 	mutatelist = list()
-	reagents_add = list("moonshine" = 0.2, "vitamin" = 0.02, "nutriment" = 0.02)
+	reagents_add = list("moonshine" = 0.4, "vitamin" = 0.04, "nutriment" = 0.04)
 	rarity = 15
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/moonflower
@@ -158,7 +158,7 @@
 	plantname = "Novaflowers"
 	product = /obj/item/weapon/grown/novaflower
 	mutatelist = list()
-	reagents_add = list("condensedcapsaicin" = 0.25, "capsaicin" = 0.3, "nutriment" = 0)
+	reagents_add = list("condensedcapsaicin" = 0.5, "capsaicin" = 0.5)
 	rarity = 20
 
 /obj/item/weapon/grown/novaflower

--- a/code/modules/hydroponics/grown/grass_carpet.dm
+++ b/code/modules/hydroponics/grown/grass_carpet.dm
@@ -15,7 +15,7 @@
 	icon_grow = "grass-grow"
 	icon_dead = "grass-dead"
 	mutatelist = list(/obj/item/seeds/grass/carpet)
-	reagents_add = list("nutriment" = 0.02, "hydrogen" = 0.05)
+	reagents_add = list("nutriment" = 0.04, "hydrogen" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/grass
 	seed = /obj/item/seeds/grass

--- a/code/modules/hydroponics/grown/kudzu.dm
+++ b/code/modules/hydroponics/grown/kudzu.dm
@@ -14,7 +14,7 @@
 	plant_type = PLANT_WEED
 	rarity = 30
 	var/list/mutations = list()
-	reagents_add = list("charcoal" = 0.04, "nutriment" = 0.02)
+	reagents_add = list("charcoal" = 0.08, "nutriment" = 0.04)
 
 /obj/item/seeds/kudzu/Copy()
 	var/obj/item/seeds/kudzu/S = ..()

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -11,7 +11,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
 	icon_dead = "watermelon-dead"
 	mutatelist = list(/obj/item/seeds/watermelon/holy)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.2)
+	reagents_add = list("vitamin" = 0.08, "nutriment" = 0.4)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/watermelon
 	seed = /obj/item/seeds/watermelon
@@ -34,7 +34,7 @@
 	plantname = "Holy Melon Vines"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/holymelon
 	mutatelist = list()
-	reagents_add = list("holywater" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("holywater" = 0.4, "vitamin" = 0.08, "nutriment" = 0.2)
 	rarity = 20
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/holymelon

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -33,7 +33,7 @@
 	growthstages = 1
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
 	mutatelist = list(/obj/item/seeds/replicapod)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("vitamin" = 0.08, "nutriment" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/cabbage
 	seed = /obj/item/seeds/cabbage
@@ -57,7 +57,7 @@
 	maturation = 3
 	yield = 4
 	growthstages = 3
-	reagents_add = list("sugar" = 0.25)
+	reagents_add = list("sugar" = 0.5)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/sugarcane
 	seed = /obj/item/seeds/sugarcane
@@ -85,7 +85,7 @@
 	growthstages = 2
 	rarity = 60 // Obtainable only with xenobio+superluck.
 	growing_icon = 'icons/obj/hydroponics/growing_fruits.dmi'
-	reagents_add = list("sulfur" = 0.1, "carbon" = 0.1, "nitrogen" = 0.07, "potassium" = 0.05)
+	reagents_add = list("sulfur" = 0.2, "carbon" = 0.2, "nitrogen" = 0.14, "potassium" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/shell/gatfruit
 	seed = /obj/item/seeds/gatfruit

--- a/code/modules/hydroponics/grown/mushrooms.dm
+++ b/code/modules/hydroponics/grown/mushrooms.dm
@@ -21,7 +21,7 @@
 	growthstages = 4
 	plant_type = PLANT_MUSHROOM
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
-	reagents_add = list("morphine" = 0.35, "charcoal" = 0.35, "nutriment" = 0)
+	reagents_add = list("morphine" = 0.5, "charcoal" = 0.5)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/reishi
 	seed = /obj/item/seeds/reishi
@@ -49,7 +49,7 @@
 	plant_type = PLANT_MUSHROOM
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	mutatelist = list(/obj/item/seeds/angel)
-	reagents_add = list("mushroomhallucinogen" = 0.04, "amatoxin" = 0.35, "nutriment" = 0)
+	reagents_add = list("mushroomhallucinogen" = 0.08, "amatoxin" = 0.7)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/amanita
 	seed = /obj/item/seeds/amanita
@@ -77,7 +77,7 @@
 	growthstages = 3
 	plant_type = PLANT_MUSHROOM
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
-	reagents_add = list("mushroomhallucinogen" = 0.04, "amatoxin" = 0.1, "nutriment" = 0, "amanitin" = 0.2)
+	reagents_add = list("mushroomhallucinogen" = 0.08, "amatoxin" = 0.2, "amanitin" = 0.4)
 	rarity = 30
 	origin_tech = "biotech=5"
 
@@ -105,7 +105,7 @@
 	growthstages = 3
 	plant_type = PLANT_MUSHROOM
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
-	reagents_add = list("mushroomhallucinogen" = 0.25, "nutriment" = 0.02)
+	reagents_add = list("mushroomhallucinogen" = 0.5, "nutriment" = 0.04)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/libertycap
 	seed = /obj/item/seeds/liberty
@@ -132,7 +132,7 @@
 	plant_type = PLANT_MUSHROOM
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	mutatelist = list(/obj/item/seeds/plump/walkingmushroom)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("vitamin" = 0.08, "nutriment" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/plumphelmet
 	seed = /obj/item/seeds/plump
@@ -156,7 +156,7 @@
 	yield = 1
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	mutatelist = list()
-	reagents_add = list("vitamin" = 0.05, "nutriment" = 0.15)
+	reagents_add = list("vitamin" = 0.1, "nutriment" = 0.3)
 	rarity = 30
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/walkingmushroom
@@ -198,7 +198,7 @@
 	growthstages = 3
 	plant_type = PLANT_MUSHROOM
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
-	reagents_add = list("nutriment" = 0.1)
+	reagents_add = list("nutriment" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/chanterelle
 	seed = /obj/item/seeds/chanter
@@ -229,7 +229,7 @@
 	genes = list(/datum/plant_gene/trait/glow)
 	growing_icon = 'icons/obj/hydroponics/growing_mushrooms.dmi'
 	mutatelist = list(/obj/item/seeds/glowshroom/glowcap)
-	reagents_add = list("radium" = 0.1, "phosphorus" = 0.1, "nutriment" = 0.04)
+	reagents_add = list("radium" = 0.2, "phosphorus" = 0.2, "nutriment" = 0.08)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom
 	seed = /obj/item/seeds/glowshroom
@@ -265,7 +265,7 @@
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom/glowcap
 	genes = list(/datum/plant_gene/trait/glow, /datum/plant_gene/trait/cell_charge)
 	mutatelist = list()
-	reagents_add = list("teslium" = 0.1, "nutriment" = 0.04)
+	reagents_add = list("teslium" = 0.2, "nutriment" = 0.08)
 	rarity = 30
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/mushroom/glowshroom/glowcap

--- a/code/modules/hydroponics/grown/nettle.dm
+++ b/code/modules/hydroponics/grown/nettle.dm
@@ -11,7 +11,7 @@
 	growthstages = 5
 	plant_type = PLANT_WEED
 	mutatelist = list(/obj/item/seeds/nettle/death)
-	reagents_add = list("sacid" = 0.5)
+	reagents_add = list("sacid" = 1)
 
 /obj/item/seeds/nettle/death
 	name = "pack of death-nettle seeds"

--- a/code/modules/hydroponics/grown/potato.dm
+++ b/code/modules/hydroponics/grown/potato.dm
@@ -16,7 +16,7 @@
 	icon_grow = "potato-grow"
 	icon_dead = "potato-dead"
 	mutatelist = list(/obj/item/seeds/potato/sweet)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("vitamin" = 0.08, "nutriment" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/potato
 	seed = /obj/item/seeds/potato
@@ -60,7 +60,7 @@
 	plantname = "Sweet Potato Plants"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/potato/sweet
 	mutatelist = list()
-	reagents_add = list("vitamin" = 0.1, "sugar" = 0.1, "nutriment" = 0.1)
+	reagents_add = list("vitamin" = 0.2, "sugar" = 0.2, "nutriment" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/potato/sweet
 	seed = /obj/item/seeds/potato/sweet

--- a/code/modules/hydroponics/grown/pumpkin.dm
+++ b/code/modules/hydroponics/grown/pumpkin.dm
@@ -13,7 +13,7 @@
 	icon_grow = "pumpkin-grow"
 	icon_dead = "pumpkin-dead"
 	mutatelist = list(/obj/item/seeds/pumpkin/blumpkin)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.2)
+	reagents_add = list("vitamin" = 0.08, "nutriment" = 0.4)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/pumpkin
 	seed = /obj/item/seeds/pumpkin
@@ -40,7 +40,7 @@
 	plantname = "Blumpkin Vines"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/blumpkin
 	mutatelist = list()
-	reagents_add = list("ammonia" = 0.2, "chlorine" = 0.2, "nutriment" = 0.2)
+	reagents_add = list("ammonia" = 0.4, "chlorine" = 0.4, "nutriment" = 0.4)
 	rarity = 20
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/blumpkin

--- a/code/modules/hydroponics/grown/root.dm
+++ b/code/modules/hydroponics/grown/root.dm
@@ -13,7 +13,7 @@
 	growthstages = 3
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
 	mutatelist = list(/obj/item/seeds/carrot/parsnip)
-	reagents_add = list("oculine" = 0.25, "vitamin" = 0.04, "nutriment" = 0.05)
+	reagents_add = list("oculine" = 0.5, "vitamin" = 0.08, "nutriment" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/carrot
 	seed = /obj/item/seeds/carrot
@@ -44,7 +44,7 @@
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/parsnip
 	icon_dead = "carrot-dead"
 	mutatelist = list()
-	reagents_add = list("vitamin" = 0.05, "nutriment" = 0.05)
+	reagents_add = list("vitamin" = 0.1, "nutriment" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/parsnip
 	seed = /obj/item/seeds/carrot/parsnip
@@ -69,7 +69,7 @@
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
 	icon_dead = "whitebeet-dead"
 	mutatelist = list(/obj/item/seeds/redbeet)
-	reagents_add = list("vitamin" = 0.04, "sugar" = 0.2, "nutriment" = 0.05)
+	reagents_add = list("vitamin" = 0.08, "sugar" = 0.4, "nutriment" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/whitebeet
 	seed = /obj/item/seeds/whitebeet
@@ -93,7 +93,7 @@
 	oneharvest = 1
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'
 	icon_dead = "whitebeet-dead"
-	reagents_add = list("vitamin" = 0.05, "nutriment" = 0.05)
+	reagents_add = list("vitamin" = 0.1, "nutriment" = 0.1)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/redbeet
 	seed = /obj/item/seeds/redbeet

--- a/code/modules/hydroponics/grown/tea_coffee.dm
+++ b/code/modules/hydroponics/grown/tea_coffee.dm
@@ -13,7 +13,7 @@
 	growthstages = 5
 	icon_dead = "tea-dead"
 	mutatelist = list(/obj/item/seeds/tea/astra)
-	reagents_add = list("vitamin" = 0.04, "teapowder" = 0.1)
+	reagents_add = list("vitamin" = 0.08, "teapowder" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tea
 	seed = /obj/item/seeds/tea
@@ -30,7 +30,7 @@
 	plantname = "Tea Astra Plant"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/tea/astra
 	mutatelist = list()
-	reagents_add = list("synaptizine" = 0.1, "vitamin" = 0.04, "teapowder" = 0.1)
+	reagents_add = list("synaptizine" = 0.2, "vitamin" = 0.08, "teapowder" = 0.2)
 	rarity = 20
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tea/astra
@@ -56,7 +56,7 @@
 	growthstages = 5
 	icon_dead = "coffee-dead"
 	mutatelist = list(/obj/item/seeds/coffee/robusta)
-	reagents_add = list("vitamin" = 0.04, "coffeepowder" = 0.1)
+	reagents_add = list("vitamin" = 0.08, "coffeepowder" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/coffee
 	seed = /obj/item/seeds/coffee
@@ -75,7 +75,7 @@
 	plantname = "Coffee Robusta Bush"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/coffee/robusta
 	mutatelist = list()
-	reagents_add = list("ephedrine" = 0.1, "vitamin" = 0.04, "coffeepowder" = 0.1)
+	reagents_add = list("ephedrine" = 0.2, "vitamin" = 0.08, "coffeepowder" = 0.2)
 	rarity = 20
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/coffee/robusta

--- a/code/modules/hydroponics/grown/tobacco.dm
+++ b/code/modules/hydroponics/grown/tobacco.dm
@@ -14,7 +14,7 @@
 	growthstages = 3
 	icon_dead = "tobacco-dead"
 	mutatelist = list(/obj/item/seeds/tobacco/space)
-	reagents_add = list("nicotine" = 0.03, "nutriment" = 0.03)
+	reagents_add = list("nicotine" = 0.06, "nutriment" = 0.06)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tobacco
 	seed = /obj/item/seeds/tobacco
@@ -32,7 +32,7 @@
 	plantname = "Space Tobacco Plant"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/tobacco/space
 	mutatelist = list()
-	reagents_add = list("salbutamol" = 0.05, "nicotine" = 0.08, "nutriment" = 0.03)
+	reagents_add = list("salbutamol" = 0.1, "nicotine" = 0.16, "nutriment" = 0.06)
 	rarity = 20
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tobacco/space

--- a/code/modules/hydroponics/grown/tomato.dm
+++ b/code/modules/hydroponics/grown/tomato.dm
@@ -12,7 +12,7 @@
 	icon_dead = "tomato-dead"
 	genes = list(/datum/plant_gene/trait/squash)
 	mutatelist = list(/obj/item/seeds/tomato/blue, /obj/item/seeds/tomato/blood, /obj/item/seeds/tomato/killer)
-	reagents_add = list("vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("vitamin" = 0.08, "nutriment" = 0.2)
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tomato
 	seed = /obj/item/seeds/tomato
@@ -32,7 +32,7 @@
 	plantname = "Blood-Tomato Plants"
 	product = /obj/item/weapon/reagent_containers/food/snacks/grown/tomato/blood
 	mutatelist = list()
-	reagents_add = list("blood" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("blood" = 0.4, "vitamin" = 0.08, "nutriment" = 0.2)
 	rarity = 20
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tomato/blood
@@ -57,7 +57,7 @@
 	icon_grow = "bluetomato-grow"
 	mutatelist = list(/obj/item/seeds/tomato/blue/bluespace)
 	genes = list(/datum/plant_gene/trait/slip)
-	reagents_add = list("lube" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("lube" = 0.4, "vitamin" = 0.08, "nutriment" = 0.2)
 	rarity = 20
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tomato/blue
@@ -80,7 +80,7 @@
 	yield = 2
 	mutatelist = list()
 	genes = list(/datum/plant_gene/trait/squash, /datum/plant_gene/trait/slip, /datum/plant_gene/trait/teleport)
-	reagents_add = list("lube" = 0.2, "singulo" = 0.2, "vitamin" = 0.04, "nutriment" = 0.1)
+	reagents_add = list("lube" = 0.4, "singulo" = 0.4, "vitamin" = 0.08, "nutriment" = 0.2)
 	rarity = 50
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/tomato/blue/bluespace

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -679,15 +679,7 @@
 		if(myseed || weedlevel)
 			user << "<span class='warning'>[src] needs to be clear of plants and weeds!</span>"
 			return
-		if(alert(user, "This will make [src] self-sustaining but consume [O] forever. Are you sure?", "[name]", "I'm Sure", "Abort") == "Abort" || !user)
-			return
 		if(!Adjacent(user))
-			return
-		if(self_sustaining)
-			user << "<span class='warning'>This [name] is already self-sustaining!</span>"
-			return
-		if(myseed || weedlevel)
-			user << "<span class='warning'>[src] needs to be clear of plants and weeds!</span>"
 			return
 		user.visible_message("<span class='notice'>[user] gently pulls open the soil for [O] and places it inside.</span>", "<span class='notice'>You tenderly root [O] into [src].</span>")
 		user.drop_item()
@@ -855,6 +847,9 @@
 		user.visible_message("<span class='notice'>[user] digs out the plants in [src]!</span>", "<span class='notice'>You dig out all of [src]'s plants!</span>")
 		playsound(src, 'sound/effects/shovel_dig.ogg', 50, 1)
 		if(myseed) //Could be that they're just using it as a de-weeder
+			age = 0
+			health = 0
+			harvest = FALSE
 			qdel(myseed)
 			myseed = null
 		weedlevel = 0 //Side-effect of cleaning up those nasty weeds

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -154,7 +154,7 @@
 	var/total_volume = 0
 	for(var/reagent_id in reagents_add)
 		total_volume += max(1, reagents_add[reagent_id] * potency)
-	var/sanity_multiplier = min(1, T.reagents.maximum_volume / total_volume)
+	var/sanity_multiplier = total_volume ? min(1, T.reagents.maximum_volume / total_volume) : 1
 
 	for(var/reagent_id in reagents_add)
 		var/add_amount = sanity_multiplier * max(1, reagents_add[reagent_id] * potency )

--- a/code/modules/hydroponics/seeds.dm
+++ b/code/modules/hydroponics/seeds.dm
@@ -148,15 +148,23 @@
 
 	return result
 
-/obj/item/seeds/proc/prepare_result(var/obj/item/weapon/reagent_containers/food/snacks/grown/T)
-	if(T.reagents)
-		for(var/reagent_id in reagents_add)
-			if(reagent_id == "blood") // Hack to make blood in plants always O-
-				T.reagents.add_reagent(reagent_id, 1 + round(potency * reagents_add[reagent_id], 1), list("blood_type"="O-"))
-				continue
+/obj/item/seeds/proc/prepare_result(obj/item/weapon/reagent_containers/food/snacks/grown/T)
+	if(!T.reagents)
+		return 0
+	var/total_volume = 0
+	for(var/reagent_id in reagents_add)
+		total_volume += max(1, reagents_add[reagent_id] * potency)
+	var/sanity_multiplier = min(1, T.reagents.maximum_volume / total_volume)
 
-			T.reagents.add_reagent(reagent_id, 1 + round(potency * reagents_add[reagent_id]), 1)
-		return 1
+	for(var/reagent_id in reagents_add)
+		var/add_amount = sanity_multiplier * max(1, reagents_add[reagent_id] * potency )
+		if(reagent_id == "blood") // Hack to make blood in plants always O-
+			T.reagents.add_reagent(reagent_id, add_amount, list("blood_type"="O-"), no_react = TRUE)
+			continue
+
+		T.reagents.add_reagent(reagent_id, add_amount, 1, no_react = TRUE)
+	T.reagents.handle_reactions()
+	return 1
 
 
 /// Setters procs ///


### PR DESCRIPTION
Changed plant reagents so the number times the potency of the plant is a percent of the total volume of reagents in the resulting reagent container rather than a flat reagent amount. Because all plant reagent containers have a max volume of 50, I doubled all the reagent amounts so the amount of reagents in plants should be the same as it always was, except for some that held more than the plant could actually hold, which resulted in some of the reagents not actually appearing in the plant. If a plants genes add up to more than the capacity of the reagent holder, all reagent amounts will be scaled down so they fit.

tl;dr: omega weed now actually produces all the reagents its genes say it should.

Also when reagents are added to plants, they don't react until they have all been added, to prevent strange situations dependent on the order of genes.

Also removed the prompt from placing ambrosia gaia into a hydro tray, since no one particularly likes it and it was letting you use the same leaf for multiple trays.

:cl:
tweak: Ambrosia Gaia no longer prompts if you are sure that you want to add it to a hydroponics tray
tweak: The way reagents are added to plants on harvest has been slightly changed. All reagent gene values have been doubled, but the amount of reagents per plant should be the same as it used to be. Omega weed and plants with many reagent genes spliced in will now always produce all the reagents they should.
/:cl:

Removed the prompt from adding ambrosia gaia to hydro trays
