### PR TITLE
Shaft Miners & Cargo Techs can no longer get QM during skeleton crew situations

### DIFF
--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -44,7 +44,7 @@ Cargo Technician
 
 	outfit = /datum/outfit/job/cargo_tech
 
-	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station, access_mineral_storeroom)
+	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mining, access_mining_station, access_mineral_storeroom)
 	minimal_access = list(access_maint_tunnels, access_cargo, access_cargo_bot, access_mailsorting, access_mineral_storeroom)
 
 /datum/outfit/job/cargo_tech
@@ -72,7 +72,7 @@ Shaft Miner
 
 	outfit = /datum/outfit/job/miner
 
-	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station, access_mineral_storeroom)
+	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_mining, access_mining_station, access_mineral_storeroom)
 	minimal_access = list(access_mining, access_mining_station, access_mailsorting, access_mineral_storeroom)
 
 /datum/outfit/job/miner


### PR DESCRIPTION
Refer to issue https://github.com/yogstation13/yogstation/issues/909.
### Intent of your Pull Request

They might need it on /tg/, but we don't need it on Yogs.

Cargo Techs don't need the cargos door remote just like how Medical Doctors don't need medbays door remote.

If it doesn't matter, than don't bother saying anything.

As I said in the previous issue, I'm still skeptical of revoking Cargo Technician's access truthfully. But don't bother defending Shaft Miners.
#### Changelog

:cl:
rscdel: Shaft Miners and Cargo Techs can no longer obtain QM access when there's a skeleton crew situation.
/:cl:
