### PR TITLE
Fixes cult walls of all kinds

### DIFF
--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -75,6 +75,21 @@
 			alpha = initial(src.alpha)
 			density = 1
 			opacity = 1
+	else if(istype(W,/obj/item/weapon/weldingtool) && iscultist(user))
+		var/obj/item/weapon/weldingtool/WT = I
+		if(!WT.remove_fuel(0,user))
+			return 0
+		playsound(src, 'sound/items/Welder.ogg', 100, 1)
+		user.visible_message("<span class='notice'>[user] begins channeling energy into [src]...</span>", "<span class='notice'>You begin undoing the magics protecting [src]...</span>")
+		if(!do_after(user, 60 / WT.toolspeed, target = src))
+			return 0
+		if(!WT.remove_fuel(1, user))
+			return 0
+		user.visible_message("<span class='notice'>[user] breaks apart [src]!</span>", "<span class='notice'>You break apart [src]!</span>")
+		dismantle_wall()
+		return 1
+	else
+		..()//Let the parent do the heavy lifting.
 	return
 
 /turf/closed/wall/mineral/cult/artificer
@@ -126,13 +141,26 @@
 	return ..()
 
 /turf/closed/wall/clockwork/attackby(obj/item/I, mob/living/user, params)
-	if(istype(I, /obj/item/weapon/weldingtool))
+	if(istype(I, /obj/item/weapon/weldingtool) && user.IsAdvancedToolUser() && is_servant_of_ratvar(user)) //Clock cultists get superfast dismantle
+		var/obj/item/weapon/weldingtool/WT = I
+		if(!WT.remove_fuel(0,user))
+			return 0
+		playsound(src, 'sound/items/Welder.ogg', 100, 1)
+		user.visible_message("<span class='notice'>[user] quickly begins adjusting [src]...</span>", "<span class='notice'>You begin preparing [src] for reallocation.</span>")
+		if(!do_after(user, 60 / WT.toolspeed, target = src))
+			return 0
+		if(!WT.remove_fuel(1, user))
+			return 0
+		user.visible_message("<span class='notice'>[user] breaks apart [src]!</span>", "<span class='notice'>You break apart [src]!</span>")
+		dismantle_wall()
+		return 1
+	if(istype(I, /obj/item/weapon/weldingtool) && user.IsAdvancedToolUser() && (!is_servant_of_ratvar(user))) //Meanwhile, noncultists take a while
 		var/obj/item/weapon/weldingtool/WT = I
 		if(!WT.remove_fuel(0,user))
 			return 0
 		playsound(src, 'sound/items/Welder.ogg', 100, 1)
 		user.visible_message("<span class='notice'>[user] begins slowly breaking down [src]...</span>", "<span class='notice'>You begin painstakingly destroying [src]...</span>")
-		if(!do_after(user, 120 / WT.toolspeed, target = src))
+		if(!do_after(user, 240 / WT.toolspeed, target = src))
 			return 0
 		if(!WT.remove_fuel(1, user))
 			return 0

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -76,7 +76,7 @@
 			density = 1
 			opacity = 1
 	else if(istype(W,/obj/item/weapon/weldingtool) && iscultist(user))
-		var/obj/item/weapon/weldingtool/WT = I
+		var/obj/item/weapon/weldingtool/WT = W
 		if(!WT.remove_fuel(0,user))
 			return 0
 		playsound(src, 'sound/items/Welder.ogg', 100, 1)


### PR DESCRIPTION
This PR tweaks the functionality of both blood and clockwork cult walls, because constructs spamming unremovable walls was getting annoying.
# NEW (and old) SHIT:
### Blood Cult

Blood Cult walls can now be removed with a standard welder.  Cultists do this twice as fast as a normal wall.  Girders can be sliced apart with a welder to drop runed metal.  As usual, cult walls can be hit with a tome to make them see-through and walk-through.
### Clock Cult

Clock Cult walls can be removed with a standard welder.  Clock cultists do this in half the time of a regular metal wall.  Non cultists take twice as much time.  Clockwork cultist girders can be unsecured and moved around, or smashed until they yield alloy fragments to remove them.
## WHAT THIS MEANS

You can now get rid of cult walls without blowing them up.  Without this, culties can just have the artyfacers wall off their summoning position and kill toxins, and you're forced to welderbomb in.  Also, flavortext.

:cl:
tweak: Cultists now remove cult walls faster.
tweak: Clockwork cultists now remove clockwork cult walls faster.
tweak: Non-cultists now take noticeably longer removing clockwork cult walls.
bugfix: Cult walls of all types can now be destroyed by anyone with a welder, although effectiveness varies based on cult membership.
/:cl:
