### PR TITLE
Minedrone Tweaks

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -376,3 +376,7 @@
 /atom/movable/proc/on_z_level_change()
 	for(var/atom/movable/A in contents)
 		A.on_z_level_change()
+
+/atom/movable/proc/on_pulledby(mob/new_pulledby, supress_message)
+	pulledby = new_pulledby
+	return

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -81,6 +81,12 @@
 		radio.on = 1
 	..()
 
+/mob/living/simple_animal/hostile/mining_drone/Moved(atom/OldLoc, Dir)
+	..()
+	if(ckey || mode == MINEDRONE_COLLECT)
+		for(var/obj/item/weapon/ore/O in src.loc)
+			O.loc = src
+
 /mob/living/simple_animal/hostile/mining_drone/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/weldingtool))
 		var/obj/item/weapon/weldingtool/W = I
@@ -139,6 +145,9 @@
 	ranged = 0
 	minimum_distance = 1
 	retreat_distance = null
+	melee_damage_lower = 15
+	melee_damage_upper = 15
+	a_intent = "harm"
 	icon_state = "mining_drone"
 	src << "<span class='info'>You are set to collect mode. You can now collect loose ore.</span>"
 
@@ -154,6 +163,9 @@
 	ranged = 1
 	retreat_distance = 1
 	minimum_distance = 2
+	melee_damage_lower = 15
+	melee_damage_upper = 15
+	a_intent = "harm"
 	icon_state = "mining_drone_offense"
 	src << "<span class='info'>You are set to attack mode. You can now attack from range.</span>"
 
@@ -169,6 +181,9 @@
 	ranged = 0
 	minimum_distance = 0
 	retreat_distance = null
+	melee_damage_lower = 0
+	melee_damage_upper = 0
+	a_intent = "help"
 	icon_state = "mining_drone_idle"
 	src << "<span class='info'>You are set to idle mode. You can now be repaired.</span>"
 
@@ -183,6 +198,9 @@
 	retreat_distance = 1
 	minimum_distance = 2
 	environment_smash = 1
+	melee_damage_lower = 15
+	melee_damage_upper = 15
+	a_intent = "harm"
 	stop_automated_movement_when_pulled = 0
 	projectiletype = /obj/item/projectile/kinetic/traitor //double the damage. Very lethal in space, mildly lethal otherwise
 	icon_state = "mining_drone_emag"

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -353,7 +353,10 @@
 		OpenFire(A)
 	..()
 
-
+/mob/living/simple_animal/hostile/on_pulledby(mob/new_pulledby, supress_message)
+	..()
+	if(stop_automated_movement_when_pulled)
+		walk_to(src, 0)
 
 ////// AI Status ///////
 /mob/living/simple_animal/hostile/proc/AICanContinue(var/list/possible_targets)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -331,18 +331,18 @@ var/next_mob_id = 0
 		AM.pulledby.stop_pulling() //an object can't be pulled by two mobs at once.
 
 	pulling = AM
-	AM.pulledby = src
+	AM.on_pulledby(src, supress_message)
 	playsound(src.loc, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 	update_pull_hud_icon()
 
-	if(ismob(AM))
-		var/mob/M = AM
-		if(!supress_message)
-			visible_message("<span class='warning'>[src] has grabbed [M] passively!</span>")
-		if(!iscarbon(src))
-			M.LAssailant = null
-		else
-			M.LAssailant = usr
+/mob/on_pulledby(mob/new_pulledby, supress_message)
+	..()
+	if(!supress_message)
+		visible_message("<span class='warning'>[new_pulledby] has grabbed [src] passively!</span>")
+	if(!iscarbon(new_pulledby))
+		LAssailant = null
+	else
+		LAssailant = new_pulledby
 
 /mob/verb/stop_pulling()
 	set name = "Stop Pulling"


### PR DESCRIPTION
:cl:
tweak: Minedrones now immediately pick up ore they move over, stop moving toward their target when you start dragging them, and can be moved through and nuzzle when they are on idle
/:cl:

Also added a generic on_pulledby() proc for when an object starts being pulled.
