### PR TITLE
Hostile Mobs now break down girders

### DIFF
--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -261,7 +261,7 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	user.do_attack_animation(src)
 	visible_message("[user] swings at [src]!")
-	var/dmg = health - melee_damage_upper
+	var/dmg = health - user.melee_damage_upper
 	health = dmg
 
 	if(health <= 0)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -255,6 +255,16 @@
 		else
 			return 0
 
+
+/obj/structure/girder/attack_animal(mob/living/simple_animal/user)
+	user.changeNext_move(CLICK_CD_MELEE)
+	user.do_attack_animation(src)
+	visible_message("[user] swings at [src]!")
+	take_damage(user.melee_damage_upper, user.melee_damage_type, 1)
+
+	if(user.environment_smash)
+		playsound(src.loc, 'sound/weapons/Genhit.ogg', 50, 1)
+
 /obj/structure/girder/CanAStarPass(ID, dir, caller)
 	. = !density
 	if(ismovableatom(caller))

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -13,6 +13,7 @@
 	var/state = GIRDER_NORMAL
 	var/girderpasschance = 20 // percentage chance that a projectile passes through the girder.
 	var/can_displace = TRUE //If the girder can be moved around by wrenching it
+	var/health = 100
 
 /obj/structure/girder/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)
@@ -260,7 +261,12 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	user.do_attack_animation(src)
 	visible_message("[user] swings at [src]!")
-	take_damage(user.melee_damage_upper, user.melee_damage_type, 1)
+	var/dmg = health - user.meele_damage_type
+	health = dmg
+
+	if(health <= 0)
+		var/obj/item/stack/sheet/metal/M = new (loc, 2)
+		qdel(src)
 
 	if(user.environment_smash)
 		playsound(src.loc, 'sound/weapons/Genhit.ogg', 50, 1)
@@ -307,6 +313,7 @@
 	icon_state = "reinforced"
 	state = GIRDER_REINF
 	girderpasschance = 0
+	health = 200
 
 /obj/structure/girder/reinforced/ex_act(severity, target)
 	switch(severity)

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -261,11 +261,12 @@
 	user.changeNext_move(CLICK_CD_MELEE)
 	user.do_attack_animation(src)
 	visible_message("[user] swings at [src]!")
-	var/dmg = health - user.meele_damage_type
+	var/dmg = health - melee_damage_upper
 	health = dmg
 
 	if(health <= 0)
 		var/obj/item/stack/sheet/metal/M = new (loc, 2)
+		M.visible_message("[src] shatters into [M]!")
 		qdel(src)
 
 	if(user.environment_smash)

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -320,7 +320,7 @@
 				var/atom/A = a
 				if(!A.Adjacent(targets_from))
 					continue
-				if(istype(A, /obj/structure/window) || istype(A, /obj/structure/closet) || istype(A, /obj/structure/table) || istype(A, /obj/structure/grille) || istype(A, /obj/structure/rack))
+				if(istype(A, /obj/structure/window) || istype(A, /obj/structure/closet) || istype(A, /obj/structure/table) || istype(A, /obj/structure/grille) || istype(A, /obj/structure/rack) || istype(A, /obj/structure/girder))
 					A.attack_animal(src)
 
 /mob/living/simple_animal/hostile/proc/EscapeConfinement()


### PR DESCRIPTION
Fixes https://github.com/yogstation13/yogstation/issues/948.

I'm going to be handling a pretty interesting lavaland project, aside with another project I'm working on. So my priorities really aren't straight, and simple mob handling has something to do with that lavaland one.

So might as well fix some bugs while I'm at it

:cl:
fix: Hostile Mobs (like Goliaths) can now break down girders.
/:cl:
