### PR TITLE
Made universal recorders remember languages and spans.

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -393,3 +393,7 @@
 
 //Picks from the list, with some safeties, and returns the "default" arg if it fails
 #define DEFAULTPICK(L, default) ((istype(L, /list) && L:len) ? pick(L) : default)
+
+/proc/add_list_to_list(list/L, list/E)
+	L += null
+	L[L.len] = E

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -225,9 +225,6 @@
 		msg = AM.compose_message(src, ALL, msg, , get_spans()) //everyone gets the numbers for free (because math is the universal language)
 		AM.Hear(msg, src, ALL, msg, , spans)
 
-/obj/item/device/taperecorder/proc/timestamp_to_header(time)
-	return
-
 /obj/item/device/taperecorder/attack_self(mob/user)
 	if(!mytape || mytape.ruined)
 		return
@@ -266,8 +263,9 @@
 
 //empty tape recorders
 /obj/item/device/taperecorder/empty/New()
-	return
-
+	..()
+	qdel(mytape)
+	mytape = null
 
 /obj/item/device/tape
 	name = "tape"

--- a/code/game/objects/items/devices/taperecorder.dm
+++ b/code/game/objects/items/devices/taperecorder.dm
@@ -104,7 +104,11 @@
 /obj/item/device/taperecorder/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, spans)
 	if(mytape && recording)
 		mytape.timestamp += mytape.used_capacity
-		mytape.storedinfo += "\[[time2text(mytape.used_capacity * 10,"mm:ss")]\] [message]"
+		mytape.storedinfo += raw_message
+		add_list_to_list(mytape.storedspans, spans)
+		var/atom/movable/virtualspeaker/virt = get_virtual_speaker_for(speaker)
+		virt.languages_spoken = message_langs
+		mytape.stored_speakers += virt
 
 /obj/item/device/taperecorder/verb/record()
 	set name = "Start Recording"
@@ -124,7 +128,9 @@
 		recording = 1
 		update_icon()
 		mytape.timestamp += mytape.used_capacity
-		mytape.storedinfo += "\[[time2text(mytape.used_capacity * 10,"mm:ss")]\] Recording started."
+		mytape.storedinfo += "Recording started."
+		add_list_to_list(mytape.storedspans, get_spans())
+		mytape.stored_speakers += get_virtual_speaker_for(src)
 		var/used = mytape.used_capacity	//to stop runtimes when you eject the tape
 		var/max = mytape.max_capacity
 		for(used, used < max)
@@ -149,7 +155,9 @@
 	if(recording)
 		recording = 0
 		mytape.timestamp += mytape.used_capacity
-		mytape.storedinfo += "\[[time2text(mytape.used_capacity * 10,"mm:ss")]\] Recording stopped."
+		mytape.storedinfo += "Recording stopped."
+		add_list_to_list(mytape.storedspans, get_spans())
+		mytape.stored_speakers += get_virtual_speaker_for(src)
 		usr << "<span class='notice'>Recording stopped.</span>"
 		return
 	else if(playing)
@@ -184,7 +192,8 @@
 			break
 		if(mytape.storedinfo.len < i)
 			break
-		say(mytape.storedinfo[i])
+		//if we speak any of the languages the speaker spoke, translate to all languages we know
+		sayRecorded(i)
 		if(mytape.storedinfo.len < i + 1)
 			playsleepseconds = 1
 			sleep(10)
@@ -200,6 +209,24 @@
 	playing = 0
 	update_icon()
 
+/obj/item/device/taperecorder/proc/sayRecorded(index)
+	var/list/spans = get_spans()
+	for(var/atom/movable/AM in get_hearers_in_view(7, src))
+		var/msg
+		var/langs
+		var/atom/movable/virtualspeaker/virt = mytape.stored_speakers[index]
+		langs = virt.languages_spoken
+		//if we understand any of the languages, translate to all languages we can speak
+		if(languages_understood & langs)
+			langs |= languages_spoken
+		msg = AM.compose_message(virt, langs, mytape.storedinfo[index], , mytape.storedspans[index])
+		langs = ALL
+		msg = "\[" + time2text(mytape.timestamp[index] * 10,"mm:ss") + "\] " + msg
+		msg = AM.compose_message(src, ALL, msg, , get_spans()) //everyone gets the numbers for free (because math is the universal language)
+		AM.Hear(msg, src, ALL, msg, , spans)
+
+/obj/item/device/taperecorder/proc/timestamp_to_header(time)
+	return
 
 /obj/item/device/taperecorder/attack_self(mob/user)
 	if(!mytape || mytape.ruined)
@@ -255,6 +282,8 @@
 	var/used_capacity = 0
 	var/list/storedinfo = list()
 	var/list/timestamp = list()
+	var/list/stored_speakers = list()
+	var/list/storedspans = list()
 	var/ruined = 0
 
 /obj/item/device/tape/fire_act()

--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -16,13 +16,13 @@ var/list/freqtospan = list(
 	"1337" = "centcomradio"
 	)
 
-/atom/movable/proc/say(message)
+/atom/movable/proc/say(message, languages = src.languages_spoken) //if you change src.languages_spoken to languages_spoken the proc will runtime due to an obscure byond bug
 	if(!can_speak())
 		return
 	if(message == "" || !message)
 		return
 	var/list/spans = get_spans()
-	send_speech(message, 7, src, , spans)
+	send_speech(message, 7, src, , spans, languages)
 
 /atom/movable/proc/Hear(message, atom/movable/speaker, message_langs, raw_message, radio_freq, list/spans)
 	return
@@ -30,10 +30,10 @@ var/list/freqtospan = list(
 /atom/movable/proc/can_speak()
 	return 1
 
-/atom/movable/proc/send_speech(message, range = 7, obj/source = src, bubble_type, list/spans)
-	var/rendered = compose_message(src, languages_spoken, message, , spans)
+/atom/movable/proc/send_speech(message, range = 7, obj/source = src, bubble_type, list/spans, languages = src.languages_spoken) //if you change src.languages_spoken to languages_spoken the proc will runtime due to an obscure byond bug
+	var/rendered = compose_message(src, languages, message, , spans)
 	for(var/atom/movable/AM in get_hearers_in_view(range, src))
-		AM.Hear(rendered, src, languages_spoken, message, , spans)
+		AM.Hear(rendered, src, languages, message, , spans)
 
 //To get robot span classes, stuff like that.
 /atom/movable/proc/get_spans()
@@ -62,30 +62,33 @@ var/list/freqtospan = list(
 /atom/movable/proc/compose_job(atom/movable/speaker, message_langs, raw_message, radio_freq)
 	return ""
 
-/atom/movable/proc/say_quote(input, list/spans=list())
+/atom/movable/proc/say_quote(input, list/spans=list(), languages)
 	if(!input)
 		return "says, \"...\""	//not the best solution, but it will stop a large number of runtimes. The cause is somewhere in the Tcomms code
+	var/extra = ""
+	if(languages == ROBOT) //only if we are speaking only in robot
+		extra = " in binary"
 	var/ending = copytext(input, length(input))
 	if(copytext(input, length(input) - 1) == "!!")
 		spans |= SPAN_YELL
-		return "[verb_yell], \"[attach_spans(input, spans)]\""
+		return "[verb_yell][extra], \"[attach_spans(input, spans)]\""
 	input = attach_spans(input, spans)
 	if(ending == "?")
-		return "[verb_ask], \"[input]\""
+		return "[verb_ask][extra], \"[input]\""
 	if(ending == "!")
-		return "[verb_exclaim], \"[input]\""
+		return "[verb_exclaim][extra], \"[input]\""
 
-	return "[verb_say], \"[input]\""
+	return "[verb_say][extra], \"[input]\""
 
 /atom/movable/proc/lang_treat(atom/movable/speaker, message_langs, raw_message, list/spans)
 	if(languages_understood & message_langs)
 		var/atom/movable/AM = speaker.GetSource()
 		if(AM) //Basically means "if the speaker is virtual"
 			if(AM.verb_say != speaker.verb_say || AM.verb_ask != speaker.verb_ask || AM.verb_exclaim != speaker.verb_exclaim || AM.verb_yell != speaker.verb_yell) //If the saymod was changed
-				return speaker.say_quote(raw_message, spans)
-			return AM.say_quote(raw_message, spans)
+				return speaker.say_quote(raw_message, spans, message_langs)
+			return AM.say_quote(raw_message, spans, message_langs)
 		else
-			return speaker.say_quote(raw_message, spans)
+			return speaker.say_quote(raw_message, spans, message_langs)
 	else if((message_langs & HUMAN) || (message_langs & RATVAR)) //it's human or ratvar language
 		var/atom/movable/AM = speaker.GetSource()
 		if(message_langs & HUMAN)
@@ -93,9 +96,9 @@ var/list/freqtospan = list(
 		if(message_langs & RATVAR)
 			raw_message = text2ratvar(raw_message)
 		if(AM)
-			return AM.say_quote(raw_message, spans)
+			return AM.say_quote(raw_message, spans, message_langs)
 		else
-			return speaker.say_quote(raw_message, spans)
+			return speaker.say_quote(raw_message, spans, message_langs)
 	else if(message_langs & MONKEY)
 		return "chimpers."
 	else if(message_langs & ALIEN)
@@ -174,3 +177,22 @@ var/list/freqtospan = list(
 /atom/movable/virtualspeaker/Destroy()
 	..()
 	return QDEL_HINT_PUTINPOOL
+
+/proc/get_virtual_speaker_for(atom/movable/AM, obj/item/device/radio/radio)
+	if(!AM)
+		return null
+	var/atom/movable/virtualspeaker/virt = PoolOrNew(/atom/movable/virtualspeaker, null)
+	virt.name = AM.name
+	virt.languages_spoken = AM.languages_spoken
+	virt.languages_understood = AM.languages_understood
+	virt.identifier = AM.identifier
+	virt.source = AM
+	virt.radio = radio
+	virt.verb_say = AM.verb_say
+	virt.verb_ask = AM.verb_ask
+	virt.verb_exclaim = AM.verb_exclaim
+	virt.verb_yell = AM.verb_yell
+	if(ismob(AM))
+		var/mob/M = AM
+		virt.job = M.job
+	return virt


### PR DESCRIPTION
I was working on some language stuff and decided to refactor universal recorders. At the moment all the language remembering they do should have no significant effect, since they understand, speak, and translate all languages, but it opens up interesting possibilities like ruins that have recorded messages in a particular language.

:cl:
rscadd: Tape recorders now remember the font (but not the font size) of messages they record.
/:cl:
