### PR TITLE
Stops mice from eating through wires

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -23,7 +23,7 @@
 	mob_size = MOB_SIZE_TINY
 	var/body_color //brown, gray and white, leave blank for random
 	gold_core_spawnable = 2
-	var/chew_probability = 0
+//	var/chew_probability = 0
 
 /mob/living/simple_animal/mouse/New()
 	..()
@@ -59,6 +59,7 @@
 			playsound(src, 'sound/effects/mousesqueek.ogg', 100, 1)
 	..()
 
+/*
 /mob/living/simple_animal/mouse/handle_automated_action()
 	if(prob(chew_probability))
 		var/turf/open/floor/F = get_turf(src)
@@ -73,10 +74,11 @@
 				else
 					C.Deconstruct()
 					visible_message("<span class='warning'>[src] chews through the [C].</span>")
+*/
 
-/*
- * Mouse types
- */
+
+//Mouse types
+
 
 /mob/living/simple_animal/mouse/white
 	body_color = "white"

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -23,7 +23,7 @@
 	mob_size = MOB_SIZE_TINY
 	var/body_color //brown, gray and white, leave blank for random
 	gold_core_spawnable = 2
-	var/chew_probability = 1
+	var/chew_probability = 0
 
 /mob/living/simple_animal/mouse/New()
 	..()


### PR DESCRIPTION
Stops mice from eating through wires, because most of the time engineering is incompetent and the mice cause a shuttle call cuz no powr.
:cl:
tweak: After years of roasting mice, central command has trained their mice not to bite through wires. Rumours say they trained their mice into sleeper agents, ready to attack at a moments notice. There is a current lawsuit about the matter since 7 assistants have dissapeared in maintenance, which is 2 above average. Due to the training the engineering staff wont have to worry about mice causing a shuttle call, at least not by power outtage. Do you know what the plural of mouse is? It's mice. It's commonly confused with mouses, wich will make you seem retarted. It has been scientifically proven to cause severe brain damage, aswell as triggering the sleeper agent mouses. Anyway, central com-  OH GOD HELP ME HELP THEY G- _distant peeping_
/:cl:
