### PR TITLE
"Beacon" pAI software

### DIFF
--- a/code/modules/mob/living/silicon/pai/death.dm
+++ b/code/modules/mob/living/silicon/pai/death.dm
@@ -19,13 +19,17 @@
 		//pai died via wiping
 		T.visible_message("<span class='danger'>A shrill electronic screeching emanates from [src], moments before its screen falls inexplicably dark.</span>",
 		"<span class='danger'>A terrible electronic-sounding shriek echoes in the air from nearby.</span>")
-
+	else if (emitter_OD)
+		//died while emitters are overloaded from beacon software
+		T.visible_message("<span class='danger'>With a terrible squealing whine, [src]'s holographic emitters suddenly and catastrophically fail in a surprisingly large fireball, immediately turning the card into a plume of ash.</span>")
+		new /obj/effect/decal/cleanable/ash(loc)
 
 	card.overlays.Cut()
 	card.overlays += "pai-off"
 	canmove = 0
 	did_suicide = 0
 	wiped = 0
+	emitter_OD = 0
 	stat = DEAD
 
 	update_sight()

--- a/code/modules/mob/living/silicon/pai/life.dm
+++ b/code/modules/mob/living/silicon/pai/life.dm
@@ -18,6 +18,23 @@
 		if(world.timeofday >= silence_time)
 			silence_time = null
 			src << "<font color=green>Communication circuit reinitialized. Speech and messaging functionality restored.</font>"
+	if(emitter_OD) //beacon overcharge software emitter stuff (/datum/pai/software/beacon_overcharge [beacon_overcharge.dm])
+		if (src.getFireLoss() >= 75)
+			var/datum/pai/software/beacon_overcharge/S = new /datum/pai/software/beacon_overcharge
+			S.take_overload_damage(src)
+		if (luminosity && luminosity < 6)
+			if (prob(12))
+				AddLuminosity(1)
+				if (prob(50))
+					adjustFireLoss(rand(6, 8))
+					src << "<span class='warning'>Your circuits sizzle and whine under the increased heat produced by your overloaded holographic emitters.</span>"
+			if (luminosity && luminosity > 1 && prob(3))
+				AddLuminosity(-1)
+		else if (luminosity && luminosity == 6)
+			if (prob(50))
+				adjustFireLoss(rand(2, 4))
+				src << "<span class='warning'>Your circuits sizzle and whine under the increased heat produced by your overloaded holographic emitters.</span>"
+				src << "<span class='warning><b>/mnt/holo_em:</b> PROTOCOL WARNING: VOLTAGE MAXED</span>"
 
 /mob/living/silicon/pai/updatehealth()
 	if(GODMODE in status_flags)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -331,7 +331,7 @@
 	spawn(dur)
 		visible_message("<span class='danger'>[src]'s holographic field flickers out of existence!</span>")
 		src.emittersFailing = 0
-		close_up()
+		close_up(1)
 
 /mob/living/silicon/pai/Bump(AM as mob|obj) //can open doors on touch but doesn't affect anything else
 	if (istype(AM, /obj/machinery/door))
@@ -480,9 +480,9 @@
 	icon_state = "[chassis]"
 	if(istype(T)) T.visible_message("With a faint hum, <b>[src]</b> levitates briefly on the spot before adopting its holographic form in a flash of green light.")
 
-/mob/living/silicon/pai/proc/close_up()
+/mob/living/silicon/pai/proc/close_up(var/force = 0)
 
-	if (health < 5)
+	if (health < 5 && !force)
 		src << "<span class='warning'><b>Your holographic emitters are too damaged to function!</b></span>"
 		return
 

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -83,9 +83,10 @@
 	var/cooldown = 0
 	var/emittersFailing = 0
 
-	//REPAIR SOFTWARE VARS
+	//SOFTWARE VARS
 	var/selfrepair = 0
 	var/updating = 0
+	var/emitter_OD = 0
 
 /mob/living/silicon/pai/New(var/obj/item/device/paicard/P)
 	make_laws()
@@ -524,6 +525,10 @@
 	if(world.time <= last_special)
 		src << "\red You must wait before returning to your card form!"
 		return
+
+	if (emitter_OD)
+		var/datum/pai/software/beacon_overcharge/S = new /datum/pai/software/beacon_overcharge
+		S.take_overload_damage(src)
 
 	close_up()
 

--- a/code/modules/mob/living/silicon/pai/software/beacon_overcharge.dm
+++ b/code/modules/mob/living/silicon/pai/software/beacon_overcharge.dm
@@ -14,7 +14,7 @@
 	var/dat = ""
 	dat += {"
 		<h3>Lumix 'Beacon' Overcharge Suite</h3>
-		When activated, holographic core emitters will be erratically overclocked to a maximum of 900% of normal operating efficiency.<br>
+		When activated, holographic core emitters will be erratically overclocked to a maximum of 700% of normal operating efficiency.<br>
 		This will massively tax internal containment fields and may result in permanent damage to the card unit.<br><br>
 
 		<b>WARNING:</b> There have been reports of this software causing catastrophic emitter failure. Use only in emergencies.<br><br>

--- a/code/modules/mob/living/silicon/pai/software/beacon_overcharge.dm
+++ b/code/modules/mob/living/silicon/pai/software/beacon_overcharge.dm
@@ -1,0 +1,59 @@
+/datum/pai/software/beacon_overcharge
+	name = "LDT Lumix 'Beacon' Overcharge Uninhibitor"
+	description = {"Allows temporary overclocking of holographic core emitters to produce near-blinding levels of illumination.
+					<b>WARNING: May cause irreversible damage to card unit.</b>"}
+	category = "Blackware"
+	sid = "beaconOC"
+	ram = 25
+
+/datum/pai/software/beacon_overcharge/action_use(mob/living/silicon/pai/user, var/args)
+	if (args["toggle"] && (user.loc != user.card))
+		toggleOC(user)
+
+/datum/pai/software/beacon_overcharge/action_menu(mob/living/silicon/pai/user)
+	var/dat = ""
+	dat += {"
+		<h3>Lumix 'Beacon' Overcharge Suite</h3>
+		When activated, holographic core emitters will be erratically overclocked to a maximum of 900% of normal operating efficiency.<br>
+		This will massively tax internal containment fields and may result in permanent damage to the card unit.<br><br>
+
+		<b>WARNING:</b> There have been reports of this software causing catastrophic emitter failure. Use only in emergencies.<br><br>
+	"}
+
+	if (user.loc != user.card)
+		dat += "<a href='byond://?src=\ref[user];software=[sid];toggle=1'>[user.emitter_OD ? "Enabled" : "Disabled"]</a>"
+
+	if (user.emitter_OD)
+		dat += "<br><br><b>Emitters currently overloaded by [user.luminosity * 100]%</b>"
+
+	return dat
+
+/datum/pai/software/beacon_overcharge/proc/toggleOC(mob/living/silicon/pai/user)
+	var/turf/T = get_turf(user.loc)
+	if (!user.emitter_OD)
+		//toggle the overcharge on. the ramping happens in the life tick
+		user.emitter_OD = 1
+		user.AddLuminosity(2) //add some luminosity straight away for obvious benefit
+		T.visible_message("<span class='notice'>A blinding pulse of light emanates briefly from within [user]'s holographic core, slowly fading until its field is nearly twice as bright as before.</span>")
+	else
+		user.emitter_OD = 0
+		T.visible_message("<span class='notice'>Winking down abruptly to a dull ebb, [user]'s holographic form becomes almost spectral for a moment, nearly flickering out of existence entirely.</span>")
+		//take damage based on max luminosity reached
+		take_overload_damage(user)
+
+
+/datum/pai/software/beacon_overcharge/proc/take_overload_damage(mob/living/silicon/pai/user)
+	//check for the really big fat unlucky insta-death proc
+	if (prob(3))
+		//oooooh shit you're fucked
+		user.emitter_OD = 1 //just to be sure
+		user.death(0)
+	else
+		//just take nominal damage based on total luminosity
+		if (user.luminosity > 1) //stops people from spam enabling the software to kill themselves noisily
+			var/turf/T = get_turf(user.loc)
+			user.adjustFireLoss(rand(6,18) * user.luminosity + 1)
+			user.close_up(1)
+			T.visible_message("<span class='danger'>Smoke rises from within the interior [user]'s of card, its casing hissing loudly.</span>")
+			user.emitter_OD = 0
+

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1442,6 +1442,7 @@
 #include "code\modules\mob\living\silicon\pai\personality.dm"
 #include "code\modules\mob\living\silicon\pai\say.dm"
 #include "code\modules\mob\living\silicon\pai\software\atmospherics_scanner.dm"
+#include "code\modules\mob\living\silicon\pai\software\beacon_overcharge.dm"
 #include "code\modules\mob\living\silicon\pai\software\camera_jack.dm"
 #include "code\modules\mob\living\silicon\pai\software\crew_manifest.dm"
 #include "code\modules\mob\living\silicon\pai\software\doorjack.dm"


### PR DESCRIPTION
Adds a program that provides temporary holographic field luminosity boosts (for lighting up very dark areas or briefly countering shadowlings). Gradually ramps up to 7 luminosity (normal is 1) while dealing scaling fire damage to the pAI (can't be repaired by normal means). Has a chance to instantly kill the pAI on tick at max luminosity if they leave it active for too long.

Showcases the features of the new pAI refactor and should hopefully give people interested in making new software a platform to launch from.
#### Changelog

:cl:
rscadd: The pAI software network has been hacked by intrepid personality cores, and a new variety of software titled "blackware" are now available. Highly dangerous, these software suites provide improved functionality at a potentially lethal cost.
rscadd: The "BEACON" class blackware is now available to all pAI units.
/:cl:
