### PR TITLE
Adjusted blood transfusion chemicals and IV drips.

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -7,6 +7,8 @@
 	var/mob/living/carbon/attached = null
 	var/mode = 1 // 1 is injecting, 0 is taking blood.
 	var/obj/item/weapon/reagent_containers/beaker = null
+	var/transfer_amount = 2.5
+	var/transfers_per_inject = 2 //this is doubled for bloodpacks
 
 
 /obj/machinery/iv_drip/New()
@@ -111,13 +113,13 @@
 		// Give blood
 		if(mode)
 			if(beaker.volume > 0)
-				var/transfer_amount = 5
+				var/transfers = transfers_per_inject
 				if(istype(beaker, /obj/item/weapon/reagent_containers/blood))
 					// speed up transfer on blood packs
-					transfer_amount = 10
-				var/fraction = min(transfer_amount/beaker.volume, 1) //the fraction that is transfered of the total volume
-				beaker.reagents.reaction(attached, INJECT, fraction,0) //make reagents reacts, but don't spam messages
-				beaker.reagents.trans_to(attached, transfer_amount)
+					transfers += transfers_per_inject
+				for(var/i in 1 to transfers)
+					beaker.reagents.reaction(attached, INJECT, transfer_amount, 0) //make reagents reacts, but don't spam messages
+				beaker.reagents.trans_to(attached, transfer_amount * transfers)
 				update_icon()
 
 		// Take blood

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -275,10 +275,12 @@
 	if(ishuman(M) && method == INJECT)
 		var/mob/living/carbon/human/H = M
 		if(H.dna && !(NOBLOOD in H.dna.species.specflags))
-			var/efficiency = (BLOOD_VOLUME_NORMAL-H.blood_volume)/700 + 0.2//The lower the blood of the patient, the better it is as a blood substitute.
-			efficiency = min(0.75,efficiency)
-			//As it's designed for an IV drip, make large injections not as effective as repeated small injections.
-			H.blood_volume += round(efficiency * min(5,reac_volume), 0.1)
+			//The lower the blood of the patient, the better it is as a blood substitute.
+			var/const/hundred_point = BLOOD_VOLUME_NORMAL * 0.5 //100% efficiency at 50% blood level
+			var/const/zero_point = BLOOD_VOLUME_NORMAL * 1.5 //0% efficiency at 150% blood level
+			var/efficiency = 1 - (H.blood_volume - hundred_point) * (1 / (zero_point - hundred_point))
+			efficiency = max(0.25, min(1, efficiency)) //clamp it and change it from a percent to a decimal
+			H.blood_volume += round(efficiency * min(2.5, reac_volume), 0.1)//As it's designed for an IV drip, make large injections not as effective as repeated small injections.
 	..()
 
 /datum/reagent/medicine/mine_salve

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -626,7 +626,7 @@
 	if(iscarbon(M))
 		var/mob/living/carbon/C = M
 		if(C.blood_volume < BLOOD_VOLUME_NORMAL)
-			C.blood_volume += 0.5
+			C.blood_volume += REAGENTS_METABOLISM * 0.5
 	..()
 
 /datum/reagent/iron/reaction_mob(mob/living/M, method=TOUCH, reac_volume)


### PR DESCRIPTION
Tweaked saline glucose to make it less completely useless and iron to make it less overpowered as a free source of effectively O- blood.

:cl:
tweak: Saline glucose's ability to generate blood when injected has been adjusted. At 50% blood level, it now takes 1 unit of salglu to generate one unit of blood, and at 100% blood level it takes 2 units of salglu to generate one unit of blood. Effects are significantly reduced when injecting quantities larger than 2.5 at a time.
tweak: Iron's capacity to regenerate blood has been reduced from 1.25 units of blood per unit iron to 0.5 units of blood per unit iron.
/:cl:

Also adjusted how iv drips work, since they did this weird thing where they would transfer 5-10 units at a time but only have a small fraction of this, based on the total reagents left in the container they were draining from, do the reaction.

The salglu changes were requested by Puremanbird
