### PR TITLE
Fixed beepsky smash not stunning

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -369,14 +369,18 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/beepsky_smash/on_mob_life(mob/living/M)
 	if(stunning)
 		M.Stun(2, 0)
-	if(istype(M, /mob/living/carbon/human) && M.job in list("Security Officer", "Head of Security", "Detective", "Warden"))
+	if(istype(M, /mob/living/carbon/human) && (M.job in list("Security Officer", "Head of Security", "Detective", "Warden")))
 		M.heal_organ_damage(1,1)
 		. = 1
 	return . || ..()
 
 /datum/reagent/consumable/ethanol/beepsky_smash/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
-	if(method == INGEST)
-		stunning = 1
+	if(method == INGEST && M.reagents)
+		src = null
+		spawn(0)
+			var/datum/reagent/consumable/ethanol/beepsky_smash/BS = M.reagents.get_reagent(/datum/reagent/consumable/ethanol/beepsky_smash)
+			if(BS)
+				BS.stunning = 1
 
 /datum/reagent/consumable/ethanol/irish_cream
 	name = "Irish Cream"


### PR DESCRIPTION
People were so passionate about this change and yet no one noticed that it did not stun at all.

:cl:
fix: Beepsky smash now stuns you when you drink it.
/:cl:
