### PR TITLE
Activates mice eating wires through a baby event

### DIFF
--- a/code/modules/events/mousehunger.dm
+++ b/code/modules/events/mousehunger.dm
@@ -1,18 +1,13 @@
-/datum/round_event_control/mouse_huner
-	name = "Mice hunger for wires"
+/datum/round_event_control/mouse_hunger
+	name = "Mice Hunger For Wires"
 	typepath = /datum/round_event/mouse_hunger
 	min_players = 30
 	max_occurrences = 1
 	weight = 20
-	earliest_start = 10000
+	earliest_start = 10000 //About 16 minutes. Enough time for engi's to start everything up
 
 /datum/round_event/mouse_hunger
-	var/list/mouse_territory = list(/area/maintenance)
 
 /datum/round_event/mouse_hunger/start()
 	for(var/mob/living/simple_animal/mouse/M in mob_list)
 		M.hungry = 1 //Don't need a stat check, mice get replaced with a dead mouse obj anyway.
-
-
-
-

--- a/code/modules/events/mousehunger.dm
+++ b/code/modules/events/mousehunger.dm
@@ -4,6 +4,7 @@
 	min_players = 30
 	max_occurrences = 1
 	weight = 20
+	earliest_start = 10000
 
 /datum/round_event/mouse_hunger
 	var/list/mouse_territory = list(/area/maintenance)
@@ -11,9 +12,7 @@
 /datum/round_event/mouse_hunger/start()
 	for(var/mob/living/simple_animal/mouse/M in mob_list)
 		M.hungry = 1 //Don't need a stat check, mice get replaced with a dead mouse obj anyway.
-		for(var/mob/living/L in mouse_territory)
-			L << "<span class='warning'><b>You hear a distant peeping.</span>" //So everyone in maint knows what's happening, and stuff
-			playsound(M, 'sound/effects/mousesqueek.ogg', 100, 5)
+
 
 
 

--- a/code/modules/events/mousehunger.dm
+++ b/code/modules/events/mousehunger.dm
@@ -1,0 +1,19 @@
+/datum/round_event_control/mouse_huner
+	name = "Mice hunger for wires"
+	typepath = /datum/round_event/mouse_hunger
+	min_players = 30
+	max_occurrences = 1
+	weight = 20
+
+/datum/round_event/mouse_hunger
+	var/list/mouse_territory = list(/area/maintenance)
+
+/datum/round_event/mouse_hunger/start()
+	for(var/mob/living/simple_animal/mouse/M in mob_list)
+		M.hungry = 1 //Don't need a stat check, mice get replaced with a dead mouse obj anyway.
+		for(var/mob/living/L in mouse_territory)
+			L << "<span class='warning'><b>You hear a distant peeping.</span>" //So everyone in maint knows what's happening, and stuff
+			playsound(M, 'sound/effects/mousesqueek.ogg', 100, 5)
+
+
+

--- a/code/modules/mob/living/simple_animal/friendly/mouse.dm
+++ b/code/modules/mob/living/simple_animal/friendly/mouse.dm
@@ -24,6 +24,7 @@
 	var/body_color //brown, gray and white, leave blank for random
 	gold_core_spawnable = 2
 	var/chew_probability = 1
+	var/hungry = 0 //If they're currently trying to eat wires, also acts as a multiplier.
 
 /mob/living/simple_animal/mouse/New()
 	..()
@@ -60,7 +61,7 @@
 	..()
 
 /mob/living/simple_animal/mouse/handle_automated_action()
-	if(prob(chew_probability))
+	if(prob(chew_probability * hungry))
 		var/turf/open/floor/F = get_turf(src)
 		if(istype(F) && !F.intact)
 			var/obj/structure/cable/C = locate() in F

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1116,6 +1116,7 @@
 #include "code\modules\events\mass_hallucination.dm"
 #include "code\modules\events\meateor_wave.dm"
 #include "code\modules\events\meteor_wave.dm"
+#include "code\modules\events\mousehunger.dm"
 #include "code\modules\events\operative.dm"
 #include "code\modules\events\portal_storm.dm"
 #include "code\modules\events\prison_break.dm"


### PR DESCRIPTION
Mice will start eating wires after an event is triggered, the event is common, about almost every round.

Earliest start: 10000 ticks (about 16 minutes))
Minimum pop = 30
max_occurences = 1

I was thinking about mice having a 1 in 100 chance to transform into a special electromouse upon eating a wire. If this gets merged, I'll probably do that.
