### PR TITLE
Removes a sleep from kinetic_acclerator/dropped()

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -148,10 +148,12 @@
 	. = ..()
 	if(!holds_charge)
 		// Put it on a delay because moving item from slot to hand
-		// calls dropped().
-		sleep(1)
-		if(!ismob(loc))
-			empty()
+		// calls dropped()
+		addtimer(src, "empty_if_not_held", 2)
+
+/obj/item/weapon/gun/energy/kinetic_accelerator/proc/empty_if_not_held()
+	if(!ismob(loc))
+		empty()
 
 /obj/item/weapon/gun/energy/kinetic_accelerator/proc/empty()
 	power_supply.use(500)


### PR DESCRIPTION
This is why KAs appear on the ground for a moment when you put them in your backpack.
