### PR TITLE
Possible map generation fix

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_animal_hospital.dmm
@@ -2,20 +2,6 @@
 "aa" = (
 /turf/template_noop,
 /area/template_noop)
-"ab" = (
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"ac" = (
-/turf/open/floor/grass{
-	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
-	},
-/area/lavaland/surface/outdoors)
-"ad" = (
-/obj/structure/flora/ausbushes/brflowers,
-/turf/open/floor/grass{
-	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
-	},
-/area/lavaland/surface/outdoors)
 "ae" = (
 /turf/closed/wall/shuttle/smooth{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
@@ -150,17 +136,6 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
 /area/ruin/powered)
-"ax" = (
-/obj/structure/closet/crate/trashcart,
-/obj/item/weapon/storage/bag/trash,
-/obj/item/trash/cheesie,
-/obj/item/weapon/reagent_containers/syringe/antiviral,
-/obj/item/bodybag,
-/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,
-/turf/open/floor/grass{
-	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
-	},
-/area/lavaland/surface/outdoors)
 "ay" = (
 /obj/structure/sink{
 	icon_state = "sink";
@@ -242,11 +217,6 @@
 "aI" = (
 /turf/closed/wall/shuttle/smooth,
 /area/ruin/powered)
-"aJ" = (
-/turf/open/floor/plasteel/grimy{
-	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
-	},
-/area/lavaland/surface/outdoors)
 "aK" = (
 /turf/open/floor/plasteel{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
@@ -661,20 +631,6 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
 /area/ruin/powered)
-"bL" = (
-/obj/vehicle/scooter/skateboard{
-	dir = 4
-	},
-/turf/open/floor/grass{
-	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
-	},
-/area/lavaland/surface/outdoors)
-"bM" = (
-/obj/structure/flora/ausbushes/sunnybush,
-/turf/open/floor/grass{
-	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
-	},
-/area/lavaland/surface/outdoors)
 "bN" = (
 /obj/effect/mob_spawn/cow{
 	dir = 4;
@@ -685,12 +641,6 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
 /area/ruin/powered)
-"bO" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/turf/open/floor/grass{
-	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
-	},
-/area/lavaland/surface/outdoors)
 "bP" = (
 /obj/structure/chair/office/light{
 	dir = 4
@@ -731,60 +681,6 @@
 	dir = 6
 	},
 /area/ruin/powered)
-"bT" = (
-/obj/item/weapon/pickaxe,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"bU" = (
-/obj/effect/decal/remains/human,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"bV" = (
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/lavaland/surface/outdoors)
-"bW" = (
-/turf/open/floor/grass,
-/area/lavaland/surface/outdoors)
-"bX" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/turf/open/floor/grass{
-	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
-	},
-/area/lavaland/surface/outdoors)
-"bY" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
-/turf/open/floor/grass{
-	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
-	},
-/area/lavaland/surface/outdoors)
-"bZ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/grass{
-	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
-	},
-/area/lavaland/surface/outdoors)
-"ca" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 4
-	},
-/turf/open/floor/grass{
-	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
-	},
-/area/lavaland/surface/outdoors)
-"cb" = (
-/obj/machinery/atmospherics/components/binary/valve,
-/turf/open/floor/grass{
-	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
-	},
-/area/lavaland/surface/outdoors)
 "cc" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/closed/wall/shuttle/smooth{
@@ -815,35 +711,19 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
 /area/ruin/powered)
-"cm" = (
+"cg" = (
 /obj/machinery/door/unpowered/shuttle{
-	name = "Tool Storage"
+	name = "Break Room"
 	},
-/turf/open/floor/plating{
+/turf/open/floor/plasteel/cmo{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
 /area/ruin/powered)
-"cl" = (
+"ch" = (
 /obj/machinery/door/unpowered/shuttle{
-	name = "Safety Supplies"
+	name = "Emergency Care"
 	},
 /turf/open/floor/plasteel/white{
-	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
-	},
-/area/ruin/powered)
-"ck" = (
-/obj/machinery/door/unpowered/shuttle{
-	name = "Medical Supplies"
-	},
-/turf/open/floor/plasteel/white{
-	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
-	},
-/area/ruin/powered)
-"cj" = (
-/obj/machinery/door/unpowered/shuttle{
-	name = "Morgue"
-	},
-/turf/open/floor/plating{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
 /area/ruin/powered)
@@ -856,22 +736,142 @@
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
 /area/ruin/powered)
-"ch" = (
+"cj" = (
 /obj/machinery/door/unpowered/shuttle{
-	name = "Emergency Care"
+	name = "Morgue"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"ck" = (
+/obj/machinery/door/unpowered/shuttle{
+	name = "Medical Supplies"
 	},
 /turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
 /area/ruin/powered)
-"cg" = (
+"cl" = (
 /obj/machinery/door/unpowered/shuttle{
-	name = "Break Room"
+	name = "Safety Supplies"
 	},
-/turf/open/floor/plasteel/cmo{
+/turf/open/floor/plasteel/white{
 	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
 	},
 /area/ruin/powered)
+"cm" = (
+/obj/machinery/door/unpowered/shuttle{
+	name = "Tool Storage"
+	},
+/turf/open/floor/plating{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/ruin/powered)
+"gG" = (
+/obj/vehicle/scooter/skateboard{
+	dir = 4
+	},
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors/mapgen_protected)
+"pi" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors/mapgen_protected)
+"uX" = (
+/obj/structure/closet/crate/trashcart,
+/obj/item/weapon/storage/bag/trash,
+/obj/item/trash/cheesie,
+/obj/item/weapon/reagent_containers/syringe/antiviral,
+/obj/item/bodybag,
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors/mapgen_protected)
+"vC" = (
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/mapgen_protected)
+"wS" = (
+/obj/structure/flora/ausbushes/sunnybush,
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors/mapgen_protected)
+"xL" = (
+/obj/structure/flora/ausbushes/brflowers,
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors/mapgen_protected)
+"zi" = (
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 1
+	},
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors/mapgen_protected)
+"Aw" = (
+/obj/item/weapon/pickaxe,
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/mapgen_protected)
+"Co" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors/mapgen_protected)
+"Cv" = (
+/obj/machinery/atmospherics/components/binary/valve,
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors/mapgen_protected)
+"Fd" = (
+/turf/open/floor/grass,
+/area/lavaland/surface/outdoors/mapgen_protected)
+"Hr" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 4
+	},
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors/mapgen_protected)
+"Hv" = (
+/obj/effect/decal/remains/human,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/mapgen_protected)
+"HT" = (
+/obj/effect/decal/cleanable/blood/old,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors/mapgen_protected)
+"Po" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors/mapgen_protected)
+"PI" = (
+/turf/open/floor/grass{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors/mapgen_protected)
+"UD" = (
+/turf/open/floor/plasteel/grimy{
+	baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface
+	},
+/area/lavaland/surface/outdoors/mapgen_protected)
 
 (1,1,1) = {"
 aa
@@ -882,11 +882,11 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
+vC
+vC
+vC
 aa
-ab
+vC
 aa
 aa
 aa
@@ -911,13 +911,13 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-ab
-ab
-ab
+vC
+vC
+vC
+vC
+vC
+vC
+vC
 aa
 aa
 aa
@@ -927,9 +927,9 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
+vC
+vC
+vC
 aa
 aa
 "}
@@ -939,15 +939,15 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-ab
-aJ
-ab
-ab
-ac
-ab
+vC
+vC
+vC
+vC
+UD
+vC
+vC
+PI
+vC
 aa
 aa
 aa
@@ -955,13 +955,13 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-bU
-bV
-ab
-ab
+vC
+vC
+vC
+Hv
+HT
+vC
+vC
 "}
 (4,1,1) = {"
 aa
@@ -969,12 +969,12 @@ aa
 aa
 aa
 aa
-ab
-ab
-ax
-ac
-aJ
-ac
+vC
+vC
+uX
+PI
+UD
+PI
 ae
 ae
 ae
@@ -984,14 +984,14 @@ aa
 aa
 aa
 aa
-ab
-ab
-ab
-bT
-ab
-ab
-ab
-ab
+vC
+vC
+vC
+Aw
+vC
+vC
+vC
+vC
 "}
 (5,1,1) = {"
 aa
@@ -1015,19 +1015,19 @@ ae
 ae
 ae
 ae
-ac
-ab
-ab
-ab
-ab
-ab
-ab
+PI
+vC
+vC
+vC
+vC
+vC
+vC
 "}
 (6,1,1) = {"
 aa
 aa
 aa
-ab
+vC
 ae
 ag
 ag
@@ -1045,19 +1045,19 @@ bp
 by
 bF
 ae
-ac
-ac
-ab
-ab
-ab
-ab
-ab
+PI
+PI
+vC
+vC
+vC
+vC
+vC
 "}
 (7,1,1) = {"
 aa
-ab
-ab
-ab
+vC
+vC
+vC
 ae
 ah
 ag
@@ -1075,19 +1075,19 @@ bq
 bz
 aP
 af
-ad
-ac
-ac
-ab
-ab
-bW
-bW
+xL
+PI
+PI
+vC
+vC
+Fd
+Fd
 "}
 (8,1,1) = {"
 aa
-ab
-ab
-ac
+vC
+vC
+PI
 ae
 ae
 ae
@@ -1105,19 +1105,19 @@ br
 bA
 aP
 af
-bL
-ac
-ac
-ac
-ab
-ab
-ab
+gG
+PI
+PI
+PI
+vC
+vC
+vC
 "}
 (9,1,1) = {"
-ab
-ab
-ac
-ac
+vC
+vC
+PI
+PI
 ae
 ai
 as
@@ -1135,19 +1135,19 @@ bs
 bB
 aP
 bI
-bM
-ac
-ab
-ab
-ab
-ab
-ab
+wS
+PI
+vC
+vC
+vC
+vC
+vC
 "}
 (10,1,1) = {"
-ab
-ab
-ab
-ac
+vC
+vC
+vC
+PI
 af
 aj
 at
@@ -1165,19 +1165,19 @@ aK
 aK
 aK
 bJ
-aJ
-aJ
-aJ
-ab
-ab
-ab
-ab
+UD
+UD
+UD
+vC
+vC
+vC
+vC
 "}
 (11,1,1) = {"
-ab
-ac
-ac
-ac
+vC
+PI
+PI
+PI
 af
 ak
 as
@@ -1195,19 +1195,19 @@ bt
 aK
 aK
 aK
-aJ
-aJ
-ab
-ab
-bW
-ab
-ab
+UD
+UD
+vC
+vC
+Fd
+vC
+vC
 "}
 (12,1,1) = {"
-ab
-ac
-ac
-ad
+vC
+PI
+PI
+xL
 af
 al
 au
@@ -1225,19 +1225,19 @@ aK
 aK
 aP
 ae
-bM
-ac
-ac
-ab
-ab
-ab
-ab
+wS
+PI
+PI
+vC
+vC
+vC
+vC
 "}
 (13,1,1) = {"
-ab
-ab
-ac
-ac
+vC
+vC
+PI
+PI
 ae
 am
 as
@@ -1255,19 +1255,19 @@ bu
 bu
 bG
 ae
-ac
-bO
-ac
-ab
-ab
-ab
-ab
+PI
+Po
+PI
+vC
+vC
+vC
+vC
 "}
 (14,1,1) = {"
-ab
-ac
-bX
-ca
+vC
+PI
+Co
+Hr
 ae
 ae
 ae
@@ -1288,16 +1288,16 @@ ae
 ae
 ae
 ae
-ab
-ab
+vC
+vC
 aa
 aa
 "}
 (15,1,1) = {"
-ab
-ab
-bY
-ca
+vC
+vC
+zi
+Hr
 ae
 cd
 an
@@ -1318,16 +1318,16 @@ bn
 bN
 bP
 ae
-ab
-ab
+vC
+vC
 aa
 aa
 "}
 (16,1,1) = {"
 aa
-ab
-bZ
-cb
+vC
+pi
+Cv
 cc
 ce
 ao
@@ -1348,16 +1348,16 @@ bK
 ao
 bQ
 ae
-ab
+vC
 aa
 aa
 aa
 "}
 (17,1,1) = {"
 aa
-ab
-ab
-ac
+vC
+vC
+PI
 ae
 ap
 ao
@@ -1386,8 +1386,8 @@ aa
 (18,1,1) = {"
 aa
 aa
-ab
-ac
+vC
+PI
 ae
 aq
 ao
@@ -1416,8 +1416,8 @@ aa
 (19,1,1) = {"
 aa
 aa
-ab
-ab
+vC
+vC
 ae
 ar
 aw
@@ -1447,7 +1447,7 @@ aa
 aa
 aa
 aa
-ab
+vC
 ae
 ae
 ae

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -35,15 +35,16 @@
 "I" = (/mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "J" = (/obj/item/device/flashlight,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "K" = (/obj/structure/closet/crate/necropolis,/obj/item/stack/sheet/mineral/mythril{amount = 50},/obj/item/stack/sheet/mineral/mythril{amount = 50},/obj/item/stack/sheet/mineral/mythril{amount = 50},/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
-"L" = (/obj/structure/closet/crate/miningcar,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
 "M" = (/obj/item/weapon/twohanded/spear,/obj/structure/rack,/obj/item/weapon/twohanded/spear,/obj/item/weapon/twohanded/spear,/obj/item/weapon/twohanded/spear,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "N" = (/obj/item/weapon/twohanded/spear,/obj/structure/rack,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "O" = (/obj/structure/mineral_door/iron,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth; blocks_air = 1},/area/ruin/unpowered)
-"P" = (/turf/closed/wall/mineral/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/lavaland/surface/outdoors)
-"Q" = (/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=13;n2=24;TEMP=300"},/area/lavaland/surface/outdoors)
 "R" = (/obj/item/weapon/twohanded/spear,/obj/structure/table,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
-"S" = (/obj/item/weapon/pickaxe,/obj/item/weapon/shovel,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=13;n2=24;TEMP=300"},/area/lavaland/surface/outdoors)
-"T" = (/obj/structure/ore_box,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"U" = (/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/mapgen_protected)
+"V" = (/obj/structure/ore_box,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/mapgen_protected)
+"W" = (/obj/item/weapon/pickaxe,/obj/item/weapon/shovel,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=13;n2=24;TEMP=300"},/area/lavaland/surface/outdoors/mapgen_protected)
+"X" = (/obj/structure/closet/crate/miningcar,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/mapgen_protected)
+"Y" = (/turf/closed/wall/mineral/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/lavaland/surface/outdoors/mapgen_protected)
+"Z" = (/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=13;n2=24;TEMP=300"},/area/lavaland/surface/outdoors/mapgen_protected)
 
 (1,1,1) = {"
 aabaaaaaaaaabb
@@ -58,10 +59,11 @@ aaccuuvwuucxyc
 aaczABffCDffEc
 aacFfffnGffffc
 aacHIJffffffKc
-bLuMfNuOuuuucc
-PQuRRNuQbQSTaa
-PQuuuuubbbbbaa
-bbbQbbbbQbbQaa
-QbbbbbQbQbbbaa
-abbbbbbbQbbbaa
+UXuMfNuOuuuucc
+YZuRRNuZUZWVaa
+YZuuuuuUUUUUaa
+UUUZUUUUZUUZaa
+ZUUUUUZUZUUUaa
+aUUUUUUUZUUUaa
 "}
+

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_cube.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_cube.dmm
@@ -1,8 +1,8 @@
 "a" = (/turf/closed/mineral/volcanic/lava_land_surface,/area/lavaland/surface/outdoors)
 "b" = (/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
 "c" = (/obj/effect/decal/remains/human,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
-"v" = (/turf/closed/indestructible/riveted,/area/ruin/unpowered)
-"I" = (/obj/machinery/wish_granter,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/ruin/unpowered)
+"X" = (/turf/closed/indestructible/riveted,/area/lavaland/surface/outdoors/mapgen_protected)
+"Z" = (/obj/machinery/wish_granter,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/mapgen_protected)
 
 (1,1,1) = {"
 aaaaabbaaaaaaaaaaaaaaaaaabbbbb
@@ -16,11 +16,11 @@ aaaaaaaaaaabbbbbcbbbbbbbbbaaaa
 aaaaaaaaaaaabcbbbbbcbbbbbbaaaa
 aaaaaaaaaaaabbbcbbbbbbbbbbaaaa
 aaaaaabbbaacbcbbcbbbbabbbcaaaa
-aaaaaabbbaabbvvvvvcbbbbbbbbbba
-aaaaaabbbbabcvvvvvbcbbbbbbcbba
-bbaaabbbbbbbcvvIvvcbcbbbbbbbba
-aabbabbbcbbbbvvvvvcbbbbcbbbbba
-bbababbbbbbbcvvvvvbbbbbbbbabba
+aaaaaabbbaabbXXXXXcbbbbbbbbbba
+aaaaaabbbbabcXXXXXbcbbbbbbcbba
+bbaaabbbbbbbcXXZXXcbcbbbbbbbba
+aabbabbbcbbbbXXXXXcbbbbcbbbbba
+bbababbbbbbbcXXXXXbbbbbbbbabba
 bbbbbbbbbbbccbbbcbcbbbcbaabbba
 bcbabbcbbcbbbbcbccbbbbbbaabbba
 bbbabbbbbbbcbbbaabbabbbbaabbba

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -30,26 +30,28 @@
 "D" = (/obj/item/weapon/storage/firstaid/brute,/obj/structure/table/wood,/obj/item/weapon/storage/firstaid/brute,/obj/item/weapon/disk/design_disk/golem_shell,/turf/open/floor/plasteel/shuttle/purple{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
 "E" = (/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
 "F" = (/obj/structure/ore_box,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/powered/golem_ship)
+"L" = (/turf/template_noop,/area/template_noop/mapgen_protected)
 
 (1,1,1) = {"
-aaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaa
-aaaaabbbbbbbbbbbbbbb
-aaaaabccccccdddefghi
-aaaaabfffffffffffghi
-aabbbbjjbbbbjjbbbbbb
-aabkllllmmbllllllnhi
-aabllllloojlllllllhi
-bbbjjbbbbbblllllpbbb
-bqrllllllljlslllljtj
-bulllllllljlllllljlj
-bbbjjbbbbbbllllvwbbb
-aabllllloojllllllxhi
-aabyllllmmbzllABCDhi
-aabbbbjjbbbbjjbbbbbb
-aaaaabfffffffffffEhi
-aaaaabFFFFFFFefffEhi
-aaaaabbbbbbbbbbbbbbb
-aaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaa
+aaaaabbbbbbbbbbbbbbbLa
+aaaaabccccccdddefghiLL
+aaaaabfffffffffffghiLL
+aabbbbjjbbbbjjbbbbbbLL
+aabkllllmmbllllllnhiLL
+aabllllloojlllllllhiLL
+bbbjjbbbbbblllllpbbbLL
+bqrllllllljlslllljtjLL
+bulllllllljlllllljljLL
+bbbjjbbbbbbllllvwbbbLL
+aabllllloojllllllxhiLL
+aabyllllmmbzllABCDhiLL
+aabbbbjjbbbbjjbbbbbbLL
+aaaaabfffffffffffEhiLL
+aaaaabFFFFFFFefffEhiLL
+aaaaabbbbbbbbbbbbbbbLa
+aaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaa
 "}
+

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_hermit.dmm
@@ -41,22 +41,25 @@
 "O" = (/obj/structure/chair{dir = 4},/turf/open/floor/plasteel/shuttle{baseturf = /turf/open/floor/plating/asteroid/basalt},/area/ruin/powered)
 "P" = (/obj/structure/grille,/obj/structure/window/shuttle,/turf/open/floor/plating{baseturf = /turf/open/floor/plating/asteroid/basalt/lava_land_surface; initial_gas_mix = "o2=14;n2=23;TEMP=300"},/area/ruin/powered)
 "Q" = (/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/turf/closed/wall/shuttle{baseturf = /turf/open/floor/plating/lava/smooth/lava_land_surface; dir = 2; icon_state = "swall_f9"},/area/ruin/powered)
+"R" = (/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/mapgen_protected)
+"Y" = (/turf/closed/mineral/volcanic/lava_land_surface,/area/lavaland/surface/outdoors/mapgen_protected)
 
 (1,1,1) = {"
-aaaaaaaabbcbaaaa
-aaaaaaabbdebbaaa
-aaaaabbbfghfbaaa
-aaaaabijklgmbaaa
-aaaaabncggofbaaa
-aaaabbpffgcbbqaa
-aaaacrssfftuubaa
-aaaabvswsftttbaa
-aaaaxxxssycbbqaa
-aaaaxzAssBcaaaaa
-aaaaxCDExFcaaaaa
-GGaaxHDIxbbaaaaa
-aGaaxxJxxaaaaaaa
-GGGaaaGaaaaKLLMa
+aaaaaaYYbbcbYYaa
+aaaaYYYbbdebbYaa
+aaaaYbbbfghfbYaa
+aaaaYbijklgmbYaa
+aaaYYbncggofbYYa
+aaaYbbpffgcbbqYa
+aaaYcrssfftuubYa
+aaaYbvswsftttbYa
+aaaYxxxssycbbqYa
+aaaYxzAssBcYYYYa
+aaaYxCDExFcYaaaa
+GGaYxHDIxbbYaaaa
+aGaYxxJxxYYYaaaa
+GGGYYYRYYYaKLLMa
 aaGGGGGGGGGNOOPa
 GaGaaaGaaGGKLLQa
 "}
+

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_prisoner_crash.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_prisoner_crash.dmm
@@ -2,11 +2,8 @@
 "b" = (/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
 "c" = (/obj/item/weapon/shard,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
 "d" = (/obj/item/weapon/shard{icon_state = "medium"},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
-"e" = (/turf/closed/indestructible/opshuttle,/area/lavaland/surface/outdoors)
-"f" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion"; dir = 4},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
 "g" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion"; dir = 4},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/ruin/unpowered)
 "h" = (/turf/closed/indestructible/opshuttle,/area/ruin/unpowered)
-"i" = (/turf/open/floor/plasteel/shuttle/red{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=16;n2=23"},/area/lavaland/surface/outdoors)
 "j" = (/obj/item/weapon/pickaxe,/obj/item/weapon/pickaxe,/obj/item/weapon/pickaxe,/obj/item/weapon/pickaxe,/obj/item/device/flashlight/lantern,/obj/structure/closet/crate/engineering{name = "Mining Supplies"},/turf/open/floor/plasteel/shuttle/red{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "k" = (/obj/effect/mob_spawn/human/prisoner_transport,/turf/open/floor/plasteel/shuttle/red{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "l" = (/obj/machinery/suit_storage_unit/ert/security,/turf/open/floor/plasteel/shuttle/red{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
@@ -15,16 +12,23 @@
 "o" = (/obj/item/weapon/gun/projectile/automatic/pistol/m1911,/turf/open/floor/plasteel/shuttle/red{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "p" = (/turf/open/floor/plasteel/shuttle/red{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "q" = (/obj/machinery/door/airlock/shuttle,/turf/open/floor/plasteel/shuttle/red{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
-"r" = (/obj/item/weapon/shard,/turf/open/floor/plasteel/shuttle/red{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=16;n2=23"},/area/lavaland/surface/outdoors)
 "s" = (/obj/machinery/door/airlock/shuttle,/turf/open/floor/plasteel/shuttle/red{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=16;n2=23"},/area/ruin/unpowered)
 "t" = (/obj/effect/mob_spawn/human/nanotrasensoldier,/obj/item/weapon/gun/projectile/automatic/pistol/m1911{desc = "A classic .45 handgun with a small magazine capacity, this one has a name engraved on it that reads 'Samantha'"; name = "Samantha"},/obj/effect/decal/cleanable/blood,/turf/open/floor/plasteel/shuttle/red{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=16;n2=23"},/area/ruin/unpowered)
 "u" = (/obj/structure/closet/crate/internals{desc = "An emergency supply crate with the NT logo attached to it, it has a small reading below which seems to signify that you probably shouldn't open this incase of an emergency. It also says only for security personell"},/obj/item/weapon/storage/toolbox/mechanical,/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/device/flashlight,/obj/item/device/flashlight,/obj/item/device/flashlight,/obj/item/device/flashlight,/obj/item/device/flashlight,/obj/item/weapon/tank/internals/emergency_oxygen,/obj/item/stack/medical/bruise_pack,/obj/item/stack/medical/gauze,/obj/item/stack/medical/ointment,/turf/open/floor/plasteel/shuttle/red{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
-"v" = (/obj/structure/lattice,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
 "w" = (/obj/effect/decal/cleanable/blood,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
-"x" = (/obj/item/weapon/shard{icon_state = "small"},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
-"y" = (/obj/item/weapon/gun/projectile/automatic/pistol/m1911,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
 "z" = (/obj/effect/mob_spawn/human/nanotrasensoldier,/obj/effect/decal/cleanable/blood,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
 "A" = (/obj/effect/decal/cleanable/blood,/obj/item/device/flashlight/seclite,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
+"B" = (/obj/effect/decal/cleanable/blood,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/mapgen_protected)
+"D" = (/obj/item/weapon/shard,/turf/open/floor/plasteel/shuttle/red{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=16;n2=23"},/area/lavaland/surface/outdoors/mapgen_protected)
+"E" = (/obj/item/weapon/shard,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/mapgen_protected)
+"G" = (/obj/item/weapon/gun/projectile/automatic/pistol/m1911,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/mapgen_protected)
+"I" = (/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/mapgen_protected)
+"K" = (/turf/closed/indestructible/opshuttle,/area/lavaland/surface/outdoors/mapgen_protected)
+"N" = (/obj/structure/shuttle/engine/propulsion{icon_state = "propulsion"; dir = 4},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/mapgen_protected)
+"O" = (/turf/closed/mineral/volcanic/lava_land_surface,/area/lavaland/surface/outdoors/mapgen_protected)
+"R" = (/obj/structure/lattice,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/mapgen_protected)
+"V" = (/turf/open/floor/plasteel/shuttle/red{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=16;n2=23"},/area/lavaland/surface/outdoors/mapgen_protected)
+"Y" = (/obj/item/weapon/shard{icon_state = "small"},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/mapgen_protected)
 
 (1,1,1) = {"
 abbbbbbabbaabbbbbbbb
@@ -34,17 +38,18 @@ bbbbaabbdbbbabaaabbb
 bbbbaabbbbbbbbaaabbb
 baabbbbbbbbbbaaaaaaa
 baaabbbbbbbbbaaaaaaa
-bbbbbebaaaabaaaaaaaa
-bbbbbfeaaaabbaaaaaaa
-bbbghhhhhhheiihhhaaa
-bbbhhjkkkkhiiihlmaaa
-bbbghnopppqiristpaaa
-bbbhhukkkkhiiieaaeaa
-bbbghhhhhhhvvieeeabb
-bbbbbfebbbbbbbbbbabb
-bbbbbebbbbbbbbbbbbbb
-bbbbbbbwwbbbbbbbbaab
-bbbxybwwwbbbcbbbbaab
+bbbbIKIOOOOIOOaaaaaa
+bbbbINKOOOOIIOaaaaaa
+bbbghhhhhhhKVVhhhaaa
+bbbhhjkkkkhVVVhlmaaa
+bbbghnopppqVDVstpaaa
+bbbhhukkkkhVVVKOOKaa
+bbbghhhhhhhRRVKKKabb
+bbbbINKIIIIIIIIIbabb
+bbbbIKIIIIIIIIIbbbbb
+bbbbIIIBBIIIIIIbbaab
+bbbYGbwwwbbbEbbbbaab
 babbbzAbbaaaaaaaaaaa
 bbabbbbbbaaaaaaaaaaa
 "}
+

--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -41,6 +41,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 	var/always_unpowered = 0	// This gets overriden to 1 for space in area/New().
 
 	var/outdoors = 0 //For space, the asteroid, lavaland, etc. Used with blueprints to determine if we are adding a new area (vs editing a station room)
+	var/mapgen_protected = 0 //If the area is protected from ruins/lava rivers/etc generating on top of it
 
 	var/power_equip = 1
 	var/power_light = 1
@@ -108,6 +109,9 @@ var/list/teleportlocs = list()
 	outdoors = 1
 	ambientsounds = list('sound/ambience/ambispace.ogg','sound/ambience/title2.ogg',)
 	blob_allowed = 0 //Eating up space doesn't count for victory as a blob.
+
+/area/space/mapgen_protected
+	mapgen_protected = 1
 
 /area/space/nearstation
 	icon_state = "space_near"

--- a/code/game/turfs/simulated/river.dm
+++ b/code/game/turfs/simulated/river.dm
@@ -43,7 +43,7 @@
 
 			cur_turf = get_step(cur_turf, cur_dir)
 			var/area/new_area = get_area(cur_turf)
-			if(!istype(new_area, whitelist_area)) //Rivers will skip ruins
+			if(!istype(new_area, whitelist_area) || new_area.mapgen_protected) //Rivers will skip ruins
 				detouring = 0
 				cur_dir = get_dir(cur_turf, target_turf)
 				cur_turf = get_step(cur_turf, cur_dir)

--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -397,5 +397,9 @@ var/global/dmm_suite/preloader/_preloader = new
 /area/template_noop
 	name = "Area Passthrough"
 
+/area/template_noop/mapgen_protected
+	name = "Area Passthrough"
+	mapgen_protected = 1
+
 /turf/template_noop
 	name = "Turf Passthrough"

--- a/code/modules/awaymissions/zlevel.dm
+++ b/code/modules/awaymissions/zlevel.dm
@@ -86,7 +86,7 @@ var/global/list/potentialRandomZlevels = generateMapList(filename = "config/away
 
 			for(var/turf/check in ruin.get_affected_turfs(T,1))
 				var/area/new_area = get_area(check)
-				if(!(istype(new_area, whitelist)))
+				if(!(istype(new_area, whitelist)) || new_area.mapgen_protected)
 					valid = FALSE
 					break
 

--- a/code/modules/mining/lavaland/lavaland_areas.dm
+++ b/code/modules/mining/lavaland/lavaland_areas.dm
@@ -27,3 +27,6 @@
 /area/lavaland/surface/outdoors
 	name = "Lavaland Wastes"
 	outdoors = 1
+
+/area/lavaland/surface/outdoors/mapgen_protected
+	mapgen_protected = 1


### PR DESCRIPTION
Possibly fixes all those issues where lavaland roles get screwed over by lava rivers and such by adding an area type that lava rivers and ruin generation avoid.

Fixes #1017 (probably)

:cl:
fix: lavaland ruins with ghost roles should no longer ever be blocked off completely by lava. If you ever see this happen, please notify a coder or take a screenshot and post it on discord under coder-public.
/:cl:
