### PR TITLE
Replaces alien brain in necropolis drop table with greentext

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -33,7 +33,7 @@
 			new /obj/item/clothing/suit/magusred(src)
 			new /obj/item/clothing/head/magus(src)
 		if(9)
-			new /obj/item/weapon/spellbook/oneuse/barnyard(src)
+			new /obj/item/weapon/greentext(src)
 		if(10)
 			new /obj/item/weapon/implant/sad_trombone(src)
 		if(11)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -33,7 +33,7 @@
 			new /obj/item/clothing/suit/magusred(src)
 			new /obj/item/clothing/head/magus(src)
 		if(9)
-			new /obj/item/organ/brain/alien(src)
+			new /obj/item/weapon/spellbook/oneuse/barnyard(src)
 		if(10)
 			new /obj/item/weapon/implant/sad_trombone(src)
 		if(11)


### PR DESCRIPTION
# WHAT WAS CHANGED:
- In the tendril drop crates' drop table, the alien brain's position has been replaced by that of the the greentext

_Purpose: Antags and powergamers alike love to dig into tendril crates anyway. One may as well add an on-the-nose reference to this fact._
#### Changelog

:cl:
tweak: Necropolis chests have had one of their lamer loot options replaced with something more... desirable.
/:cl:
