### PR TITLE
Fixes mobs not being able to be thrown

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -236,13 +236,9 @@
 					var/start_T_descriptor = "<font color='#6b5d00'>tile at [start_T.x], [start_T.y], [start_T.z] in area [get_area(start_T)]</font>"
 					var/end_T_descriptor = "<font color='#6b4400'>tile at [end_T.x], [end_T.y], [end_T.z] in area [get_area(end_T)]</font>"
 					add_logs(src, throwable_mob, "thrown", addition="from [start_T_descriptor] with the target [end_T_descriptor]")
-
-	if(I && I.prethrow_at(target))
-		return
-
-	if(!(I && istype(I)))
-		return //Grab processing has a chance of returning null
 	else if(!(I.flags & (NODROP|ABSTRACT)))
+		if(I.prethrow_at(target))
+			return
 		thrown_thing = I
 		unEquip(I)
 


### PR DESCRIPTION
Error caused due to some leftover code from the old grab system (that was an item which was checked for), presumably from when conflicts were resolved during the rebase.

Tested stuff:
- Thrown a mechanical toolbox, works as expected;
- Thrown the fireball spell thing, works as expected;
- Thrown an aggressive grabbed human, now it works as expected;

:cl: Mob Throwing Enthusiast
rscadd: Mobs can now be thrown again, enjoy.
/:cl:
