### PR TITLE
Chasms no longer swallow dim light tiles.

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -575,6 +575,8 @@
 /turf/open/chasm/Entered(atom/movable/AM)
 	if(istype(AM, /obj/singularity) || istype(AM, /obj/item/projectile))
 		return
+	if(istype(AM, /atom/movable/light/dim))
+		return
 	if(istype(AM, /obj/effect/portal))
 		// Portals aren't affected by gravity. Probably.
 		return


### PR DESCRIPTION
:cl:
fix: Chasms no longer swallow dim light tiles.
/:cl:
