### PR TITLE
Re-upload and tweaking of space bar buff

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacebar.dmm
@@ -87,8 +87,10 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/item/stack/sheet/glass/fifty,
 /obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/wood,
 /area/ruin/powered{
 	name = "Space Bar"

--- a/_maps/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacebar.dmm
@@ -64,14 +64,20 @@
 /area/ruin/powered)
 "ao" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer,
+/obj/machinery/chem_dispenser/drinks/beer{
+	emagged = 1;
+	name = "\"exotic\"booze dispenser"
+	},
 /turf/open/floor/wood,
 /area/ruin/powered{
 	name = "Space Bar"
 	})
 "ap" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks,
+/obj/machinery/chem_dispenser/drinks{
+	emagged = 1;
+	name = "\"exotic\" soda dispenser"
+	},
 /turf/open/floor/wood,
 /area/ruin/powered{
 	name = "Space Bar"
@@ -81,6 +87,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/item/stack/sheet/glass/fifty,
+/obj/item/stack/sheet/metal/fifty,
 /turf/open/floor/wood,
 /area/ruin/powered{
 	name = "Space Bar"
@@ -93,6 +101,8 @@
 "as" = (
 /obj/structure/table,
 /obj/item/toy/figure/bartender,
+/obj/item/weapon/gun/projectile/revolver/doublebarrel,
+/obj/item/weapon/storage/belt/bandolier,
 /turf/open/floor/wood,
 /area/ruin/powered{
 	name = "Space Bar"
@@ -182,10 +192,11 @@
 	name = "Space Bar"
 	})
 "aF" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal{
-	amount = 10
-	},
+/obj/item/weapon/rcd_ammo/large,
+/obj/item/weapon/rcd_ammo/large,
+/obj/item/weapon/rcd_ammo/large,
+/obj/item/weapon/rcd,
+/obj/structure/closet/crate,
 /turf/open/floor/wood,
 /area/ruin/powered{
 	name = "Space Bar"
@@ -436,9 +447,20 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/powered)
-"bs" = (
-/obj/machinery/door/airlock/external,
-/turf/open/floor/plating,
+"bo" = (
+/turf/closed/wall,
+/area/ruin/powered{
+	name = "Space Bar"
+	})
+"bp" = (
+/obj/structure/closet/secure_closet/freezer/kitchen,
+/turf/open/floor/wood,
+/area/ruin/powered{
+	name = "Space Bar"
+	})
+"bq" = (
+/obj/structure/closet/secure_closet/freezer/fridge,
+/turf/open/floor/wood,
 /area/ruin/powered{
 	name = "Space Bar"
 	})
@@ -449,20 +471,27 @@
 /area/ruin/powered{
 	name = "Space Bar"
 	})
-"bq" = (
-/obj/structure/closet/secure_closet/freezer/fridge,
-/turf/open/floor/wood,
+"bs" = (
+/obj/machinery/door/airlock/external,
+/turf/open/floor/plating,
 /area/ruin/powered{
 	name = "Space Bar"
 	})
-"bp" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
-/turf/open/floor/wood,
+"bv" = (
+/obj/machinery/computer/arcade/battle,
+/turf/open/floor/plasteel/bar,
 /area/ruin/powered{
 	name = "Space Bar"
 	})
-"bo" = (
-/turf/closed/wall,
+"bu" = (
+/obj/machinery/computer/arcade/orion_trail,
+/turf/open/floor/plasteel/bar,
+/area/ruin/powered{
+	name = "Space Bar"
+	})
+"bt" = (
+/obj/machinery/autolathe,
+/turf/open/floor/wood,
 /area/ruin/powered{
 	name = "Space Bar"
 	})
@@ -1446,7 +1475,7 @@ ac
 aM
 af
 bo
-ar
+bt
 ar
 ar
 aG
@@ -1456,8 +1485,8 @@ aK
 aR
 aK
 aK
-aK
-aK
+bu
+bv
 aU
 be
 aZ

--- a/_maps/RandomRuins/SpaceRuins/spacebar.dmm
+++ b/_maps/RandomRuins/SpaceRuins/spacebar.dmm
@@ -102,7 +102,10 @@
 	})
 "as" = (
 /obj/structure/table,
-/obj/item/toy/figure/bartender,
+/obj/item/toy/figure/bartender{
+	pixel_x = -8;
+	pixel_y = 5
+	},
 /obj/item/weapon/gun/projectile/revolver/doublebarrel,
 /obj/item/weapon/storage/belt/bandolier,
 /turf/open/floor/wood,
@@ -112,6 +115,7 @@
 "at" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/drinks/shaker,
+/obj/item/weapon/reagent_containers/food/condiment/enzyme,
 /turf/open/floor/wood,
 /area/ruin/powered{
 	name = "Space Bar"
@@ -479,15 +483,30 @@
 /area/ruin/powered{
 	name = "Space Bar"
 	})
-"bv" = (
+"bx" = (
 /obj/machinery/computer/arcade/battle,
 /turf/open/floor/plasteel/bar,
 /area/ruin/powered{
 	name = "Space Bar"
 	})
-"bu" = (
+"bw" = (
 /obj/machinery/computer/arcade/orion_trail,
 /turf/open/floor/plasteel/bar,
+/area/ruin/powered{
+	name = "Space Bar"
+	})
+"bv" = (
+/obj/machinery/vending/dinnerware,
+/turf/open/floor/plasteel/bar,
+/area/ruin/powered{
+	name = "Space Bar"
+	})
+"bu" = (
+/obj/structure/table,
+/mob/living/carbon/monkey{
+	name = "Nup Nup"
+	},
+/turf/open/floor/wood,
 /area/ruin/powered{
 	name = "Space Bar"
 	})
@@ -1354,7 +1373,7 @@ bo
 ao
 ar
 aC
-aG
+bu
 aJ
 aK
 aK
@@ -1487,8 +1506,8 @@ aK
 aR
 aK
 aK
-bu
-bv
+bw
+bx
 aU
 be
 aZ
@@ -1696,7 +1715,7 @@ aK
 aS
 aK
 aK
-aK
+bv
 bo
 bc
 bc


### PR DESCRIPTION
### This is a re-upload of #1024 as it had merging mistakes and its branch was deleted. I've also tweaked some things now that I better understand map editing, and changed this PR description to reflect those changes.

I've always wondered... Why is it that the space bar has LESS things in it than the actual bar itself does?
So I thought, "Let's set it apart and add further to the surprise of discovering the space bar! And maybe also give the space bartender SOMETHING TO ACTUALLY DO, while they wait for their customers that will probably never come."

![dreammaker_2016-10-25_12-32-40](https://cloud.githubusercontent.com/assets/22177874/19697032/5c2574b4-9aaf-11e6-854d-f7f1877ec34b.png)
### Screenshot updated as of f5673b6da18b1a217480997dedfb7d1e5d9e1bfc .
# WHAT WAS ADDED:
### \- An autolathe, with 2 full stacks of both metal and glass next to it.

_Purpose: to enable the bartender to build all sorts of tools and devices to customize the bar. Also to create ammo for the shotgun._
### \- A double-barreled shotgun and bandoiler

_Purpose: If all bartenders start with this, why shouldn't the space bartender?_
### \- A crate with an RCD and 3 _full_ RCD cartriges

_Purpose: to allow the bartender to customize the bar a little bit to their own preferences. Help them feel more at-home by making their permanent home their own._
### \- A Dinnerware Vendor

_Purpose: kitchenware to accommodate the fridges and microwave._
### \- Universal Enzyme

_Purpose: More food-making possibilities._
### \- Nup Nup the monkey

_Purpose: What's a bartender without a monkey with a cute name?_
# WHAT WAS CHANGED:
### \- Soda and Booze dispensers start off emagged

_Purpose: To give the bartender more chemicals to play around with, and to help further set their bar apart from the station's bar. They have had their name slightly changed to reflect this._
# "But isn't this overpowering the space bartender?"

Consider the fact that the space bartender is one of the most isolated ghost spawn roles in the entire game, spawning in a tiny asteroid in space with no internals access. The chance of somebody actually visiting the space bar is even lower than somebody finding a Lifebringer vault in Lavaland, where one can create 100 potency deathnettles with substantially less effort than a standard Botanist. This buff is intended to not only give a space bartender something to do, but also allows them to truly make the bar their own and add to the surprise of its discovery when it's been set up with whatever wacky spin the player wants to put on the bar.

:cl:
rscadd: The Space Bar now has much more to do in it for those lonely nights on an isolated asteroid.
/:cl:
