### PR TITLE
Removes statue from goldcore spawns

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -48,7 +48,6 @@
 
 	var/cannot_be_seen = 1
 	var/mob/living/creator = null
-	gold_core_spawnable = 1
 
 
 // No movement while seen code.


### PR DESCRIPTION
Removes statue from goldcore spawns.
Why?

Statue was made for wizard, and then it could more or less be defeated, and that's by waiting 5 minutes.

From a goldcore, it wasn't. It was completely immortal and OP.

:cl:
tweak: Statues can't by spawned from xenobiology anymore.
/:cl:
