### PR TITLE
Doubles food cart's storage capacity

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/food_cart.dm
@@ -1,5 +1,5 @@
-#define STORAGE_CAPACITY 30
-#define LIQUID_CAPACIY 200
+#define STORAGE_CAPACITY 60
+#define LIQUID_CAPACIY 400
 #define MIXER_CAPACITY 100
 
 /obj/machinery/food_cart


### PR DESCRIPTION
### Now you can bring buffets onto the shuttle that can even feed highpop crews!
# WHAT WAS CHANGED:
- The chef's food cart now has **twice** the carrying capacity as it previously had.

_Purpose: If you've ever tried to put multiple items of a cut food (pie slices, cake slices, bread slices, etc,) it's impossible to carry anything substantial along with the food cart. It defeats the food cart's purpose entirely during highpop, as a robust chef that can make tons of varied foods in a short span of time will have to wave goodbye to a lot of food simply because of two values!_

:cl:
rscadd: Centcomm's Bluespace Appliances team has upgraded the chef's food cart. Now it can hold twice as much food and liquid as it could before!
/:cl:
