### PR TITLE
Adds mechanical toolbox to hydroponics

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -27106,6 +27106,7 @@
 /area/hydroponics)
 "bcp" = (
 /obj/structure/table/reinforced,
+/obj/item/weapon/storage/toolbox/mechanical,
 /turf/open/floor/plasteel{
 	icon_state = "dark"
 	},


### PR DESCRIPTION
### To save the botanists a run to Primary Tool Storage.

![dreammaker_2016-10-25_20-18-18](https://cloud.githubusercontent.com/assets/22177874/19710123/8c901f54-9af1-11e6-98c5-81f925484729.png)
# WHAT WAS ADDED:
- A tool box, on the table of hydroponics.

_Purpose: Minor additions like these can make a huge difference in many rounds, and this PR is no exception. Basic tools are VERY useful to botanists, so why not help give them a start? With this they can quickly start setting up their own personal setups for plant trays as they see fit. They could do this before obviously, but this saves them some extra time at the beginning of the shift. In addition if a botanist is a late-joiner when there were previously none, there might be no more toolboxes left in the Tool Storage, so this also addresses that issue as well._
#### Changelog

:cl:
rscadd: A toolbox has been added to Hydroponics; it can be found on the table behind the front windows.
/:cl:
