### PR TITLE
Adds more variation to abductor egg gland

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -166,10 +166,10 @@
 	cooldown_high = 400
 	uses = -1
 	icon_state = "egg"
-	var/magic_yolk = "water" //I can't use pick here, so it's at the New(). Water wont be used, it's just there.
+	var/list/magic_yolk = list("mindbreaker", "chloralhydrate", "tiresolution", "spraytan", "space_drugs", "colorful_reagent", "laughter", "godblood")
 
 /obj/item/organ/gland/egg/New()
-	magic_yolk = pick("mindbreaker", "chloralhydrate", "tiresolution", "spraytan", "space_drugs", "colorful_reagent", "laughter", "godblood") //HONK
+	magic_yolk = pick(magic_yolk)
 
 /obj/item/organ/gland/egg/activate()
 	owner << "<span class='boldannounce'>You lay an egg!</span>"

--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -166,11 +166,15 @@
 	cooldown_high = 400
 	uses = -1
 	icon_state = "egg"
+	var/magic_yolk = "water" //I can't use pick here, so it's at the New(). Water wont be used, it's just there.
+
+/obj/item/organ/gland/egg/New()
+	magic_yolk = pick("mindbreaker", "chloralhydrate", "initropidril", "teslium", "tiresolution", "zombiepowder", "amatoxin", "spraytan", "colorful_reagent", "laughter", "godblood") //HONK
 
 /obj/item/organ/gland/egg/activate()
 	owner << "<span class='boldannounce'>You lay an egg!</span>"
 	var/obj/item/weapon/reagent_containers/food/snacks/egg/egg = new(owner.loc)
-	egg.reagents.add_reagent("sacid",20)
+	egg.reagents.add_reagent(magic_yolk,20)
 	egg.desc += " It smells bad."
 
 /obj/item/organ/gland/bloody

--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -169,7 +169,7 @@
 	var/magic_yolk = "water" //I can't use pick here, so it's at the New(). Water wont be used, it's just there.
 
 /obj/item/organ/gland/egg/New()
-	magic_yolk = pick("mindbreaker", "chloralhydrate", "initropidril", "teslium", "tiresolution", "zombiepowder", "amatoxin", "spraytan", "colorful_reagent", "laughter", "godblood") //HONK
+	magic_yolk = pick("mindbreaker", "chloralhydrate", "tiresolution", "spraytan", "colorful_reagent", "laughter", "godblood") //HONK
 
 /obj/item/organ/gland/egg/activate()
 	owner << "<span class='boldannounce'>You lay an egg!</span>"

--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -169,7 +169,7 @@
 	var/magic_yolk = "water" //I can't use pick here, so it's at the New(). Water wont be used, it's just there.
 
 /obj/item/organ/gland/egg/New()
-	magic_yolk = pick("mindbreaker", "chloralhydrate", "tiresolution", "spraytan", "colorful_reagent", "laughter", "godblood") //HONK
+	magic_yolk = pick("mindbreaker", "chloralhydrate", "tiresolution", "spraytan", "space_drugs", "colorful_reagent", "laughter", "godblood") //HONK
 
 /obj/item/organ/gland/egg/activate()
 	owner << "<span class='boldannounce'>You lay an egg!</span>"


### PR DESCRIPTION
The abductor egg laying gland now chooses a random preset of chemicals, instead of boring acid.
So when someone lays an egg, it could have these chems:

Spacedrugs: Do drugs kids
Mindbreaker: Make you see some shit
Chloral: You know what it does
Tiresolution: Makes you slighty tired
Spraytan: Makes you orange and act like a dick
Colorful_reagent: MAKES YOU COLORFUL
Laughter: Makes you laugh
Godblood: Slightly stronger then omnizine and does not OD as quick.

:cl:
rscadd: Makes egg laying gland more interesting
/:cl:
