### PR TITLE
Makes S.S. Shitbucket MK. 3 properly load

### DIFF
--- a/_maps/shuttles/whiteship_shitbucket_v3.dmm
+++ b/_maps/shuttles/whiteship_shitbucket_v3.dmm
@@ -21,7 +21,7 @@
 	dir = 2;
 	dwidth = 11;
 	height = 30;
-	id = "whiteship_home";
+	id = "whiteship";
 	launch_status = 0;
 	name = "S.S. Shitbucket, MK.3";
 	roundstart_move = "whiteship_away";


### PR DESCRIPTION
The ship would not correctly load into the world, and we learned that the issue pertained to the docking port. So I looked at the variables of the docking port...

the fix

was the tiniest 
most minor

thing, ever.
#### Changelog

:cl:
fix: The S.S. Shitbucket MK. 3 should now properly load onto the map.
/:cl:
