### PR TITLE
Fixed icon error with ash walkers

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -128,7 +128,7 @@ datum/species/lizard/before_equip_job(datum/job/J, mob/living/carbon/human/H)
 
 /datum/species/lizard/ashwalker
 	name = "Ash Walker"
-	id = "ashlizard"
+	id = "lizard"
 	specflags = list(MUTCOLORS,EYECOLOR,LIPS,NOBREATH,NOGUNS)
 
 /datum/species/lizard/fly


### PR DESCRIPTION
I gave ash walkers a different ID than regular lizards so you can use the magic mirror or varedit to change a human's species to them, but apparently icons depend on that var.
