### PR TITLE
Fixes a bug with borers (BE_ALIEN -> BE_BORER)

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/borer.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer.dm
@@ -276,7 +276,7 @@ var/total_borer_hosts_needed = 10
 	name = "borer vessel"
 	zone = "head"
 	slot = "brain tumor"
-	desc = "A hunk of alien flesh developed from inside the brain, and also a command center for any type of borer. Home is where the heart is. Or in this case, the head."
+	desc = "A hunk of alien flesh molded from the inside of a human brain. It now resembles a once operatable command center for a borer. Home is where the heart is. Or in this case, the head."
 	icon_state = "eggsac"
 	var/mob/living/simple_animal/borer/borer = null
 

--- a/code/modules/mob/living/simple_animal/borer/borer_event.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_event.dm
@@ -46,7 +46,7 @@
 	while(spawncount >= 1)
 		var/obj/vent = pick_n_take(vents)
 		for(var/client/C in candidates)
-			if(jobban_check_mob(C.mob, "borer") || !(C.prefs.toggles & MIDROUND_ANTAG))
+			if(!(C.prefs.toggles & MIDROUND_ANTAG))
 				candidates -= C
 		if(!candidates.len)
 			return kill()

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -386,13 +386,14 @@ mob/living/carbon/proc/release_control()
 		return
 
 	if(borer.chemicals >= 100)
-		var/list/candidates = get_candidates(ROLE_ALIEN, ALIEN_AFK_BRACKET)
+		var/list/candidates = get_candidates(ROLE_BORER, null, ROLE_BORER)
 		for(var/client/C in candidates)
-			if(jobban_isbanned(C.mob, "borer") || !(C.prefs.toggles & MIDROUND_ANTAG))
+			if(!(C.prefs.toggles & MIDROUND_ANTAG))
 				candidates -= C
 		if(!candidates.len)
 			src << "<span class='usernotice'>Our reproduction system seems to have failed... Perhaps we should try again some other time?</span>"
 			return
+
 		var/client/C = pick(candidates)
 
 		borer.chemicals -= 100


### PR DESCRIPTION
Fixes https://github.com/yogstation13/yogstation/issues/1142

### Intent of your Pull Request

- Change description of borer home
- Removes useless checks
- Fixes #1142

#### Changelog

:cl:
fix: When borers puke, they correctly grab the ghosts with BE_BORER instead of BE_ALIEN.
/:cl:

