### PR TITLE
Makes library scanner movable

### DIFF
--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -502,6 +502,7 @@ var/global/list/datum/cachedbook/cachedbooks // List of our cached book datums
 			if (do_after(user, 20/W.toolspeed, target = src))
 				anchored = 0
 				user << "<span class='notice'>You unsecure the scanner control interface.</span>"
+
 /obj/machinery/libraryscanner/attack_hand(mob/user)
 	if(!anchored)
 		user << "<span class='warning'>You cannot use scanner control interface while it's unsecured!</span>"

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -476,6 +476,14 @@ var/global/list/datum/cachedbook/cachedbooks // List of our cached book datums
 	anchored = 1
 	density = 1
 	var/obj/item/weapon/book/cache		// Last scanned book
+	
+/obj/machinery/libraryscanner/attackby(obj/O, mob/user, params)
+	if(istype(O, /obj/item/weapon/book))
+		if(!user.drop_item())
+			return
+		O.loc = src
+	else
+		return ..()
 
 /obj/machinery/libraryscanner/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/weapon/wrench))

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -484,12 +484,9 @@ var/global/list/datum/cachedbook/cachedbooks // List of our cached book datums
 		O.loc = src
 	else
 		return ..()
-		
 /obj/machinery/libraryscanner/attackby(obj/item/W, mob/user, params)
-
-
 	if(istype(W, /obj/item/weapon/wrench))
-		if(anchored == 0)
+		if(!anchored)
 			if(!istype(loc, /turf/open/floor))
 				user << "<span class='warning'>A floor must be present to secure the scanner control interface!</span>"
 			else
@@ -498,17 +495,13 @@ var/global/list/datum/cachedbook/cachedbooks // List of our cached book datums
 				do_after(user, 20/W.toolspeed, target = src)
 				anchored = 1
 				user << "<span class='notice'>You secure the scanner control interface.</span>"
-		else if(anchored == 1)
-			if (anchored == 1)
-				playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
-				user << "<span class='notice'>You start unsecuring the scanner control interface...</span>"
-				do_after(user, 20/W.toolspeed, target = src)
-				anchored = 0
-				user << "<span class='notice'>You unsecure the scanner control interface.</span>"
-				return
-			return
-		return
-	return 0	
+		else
+			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
+			user << "<span class='notice'>You start unsecuring the scanner control interface...</span>"
+			do_after(user, 20/W.toolspeed, target = src)
+			anchored = 0
+			user << "<span class='notice'>You unsecure the scanner control interface.</span>"
+			return 0
 
 /obj/machinery/libraryscanner/attack_hand(mob/user)
 	if(anchored == 0)

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -485,8 +485,7 @@ var/global/list/datum/cachedbook/cachedbooks // List of our cached book datums
 	else
 		return ..()
 		
-/obj/machinery/libraryscanner/attackby(obj/item/W
-, mob/user, params)
+/obj/machinery/libraryscanner/attackby(obj/item/W, mob/user, params)
 
 
 	if(istype(W, /obj/item/weapon/wrench))

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -477,13 +477,6 @@ var/global/list/datum/cachedbook/cachedbooks // List of our cached book datums
 	density = 1
 	var/obj/item/weapon/book/cache		// Last scanned book
 
-/obj/machinery/libraryscanner/attackby(obj/O, mob/user, params)
-	if(istype(O, /obj/item/weapon/book))
-		if(!user.drop_item())
-			return
-		O.loc = src
-	else
-		return ..()
 /obj/machinery/libraryscanner/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/weapon/wrench))
 		if(!anchored)
@@ -498,13 +491,11 @@ var/global/list/datum/cachedbook/cachedbooks // List of our cached book datums
 		else
 			playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
 			user << "<span class='notice'>You start unsecuring the scanner control interface...</span>"
-			do_after(user, 20/W.toolspeed, target = src)
-			anchored = 0
-			user << "<span class='notice'>You unsecure the scanner control interface.</span>"
-			return 0
-
+			if (do_after(user, 20/W.toolspeed, target = src))
+				anchored = 0
+				user << "<span class='notice'>You unsecure the scanner control interface.</span>"
 /obj/machinery/libraryscanner/attack_hand(mob/user)
-	if(anchored == 0)
+	if(!anchored)
 		user << "<span class='warning'>You cannot use scanner control interface while it's unsecured!</span>"
 		return 0
 	usr.set_machine(src)

--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -484,8 +484,37 @@ var/global/list/datum/cachedbook/cachedbooks // List of our cached book datums
 		O.loc = src
 	else
 		return ..()
+		
+/obj/machinery/libraryscanner/attackby(obj/item/W
+, mob/user, params)
+
+
+	if(istype(W, /obj/item/weapon/wrench))
+		if(anchored == 0)
+			if(!istype(loc, /turf/open/floor))
+				user << "<span class='warning'>A floor must be present to secure the scanner control interface!</span>"
+			else
+				playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
+				user << "<span class='notice'>You start securing the scanner control interface...</span>"
+				do_after(user, 20/W.toolspeed, target = src)
+				anchored = 1
+				user << "<span class='notice'>You secure the scanner control interface.</span>"
+		else if(anchored == 1)
+			if (anchored == 1)
+				playsound(src.loc, 'sound/items/Ratchet.ogg', 100, 1)
+				user << "<span class='notice'>You start unsecuring the scanner control interface...</span>"
+				do_after(user, 20/W.toolspeed, target = src)
+				anchored = 0
+				user << "<span class='notice'>You unsecure the scanner control interface.</span>"
+				return
+			return
+		return
+	return 0	
 
 /obj/machinery/libraryscanner/attack_hand(mob/user)
+	if(anchored == 0)
+		user << "<span class='warning'>You cannot use scanner control interface while it's unsecured!</span>"
+		return 0
 	usr.set_machine(src)
 	var/dat = "" // <META HTTP-EQUIV='Refresh' CONTENT='10'>
 	if(cache)


### PR DESCRIPTION
With the help of KMC, Shadowdeath. and Cruix , I present to you:
## Make library great again : Monkey Coder Version
But if seriously : library's scanner control interface is a useless thing that makes rebuilding library even harder because you cannot move it.This PR will fix this problem.
#### Changelog

:cl:
rscadd: makes library scanners movable , for building purposes only
/:cl:
