### PR TITLE
makes laughter demons inferior to slaughter demons + other shit

### DIFF
--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -4,7 +4,7 @@
 	name = "Slaughter Demon"
 	real_name = "Slaughter Demon"
 	desc = "A large, menacing creature covered in armored black scales."
-	speak_emote = list("gurgles")
+	speak_emote = list("growls")
 	emote_hear = list("wails","screeches")
 	response_help  = "thinks better of touching"
 	response_disarm = "flails at"
@@ -33,6 +33,7 @@
 	dismember_chance = 30
 	see_in_dark = 8
 	var/boost = 0
+	var/speed_after_boost = 1
 	bloodcrawl = BLOODCRAWL_EAT
 	see_invisible = SEE_INVISIBLE_MINIMUM
 	var/playstyle_string = "<B><font size=3 color='red'>You are a slaughter demon,</font> a terrible creature from another realm. You have a single desire: To kill.  \
@@ -56,7 +57,7 @@
 /mob/living/simple_animal/slaughter/Life()
 	..()
 	if(boost<world.time)
-		speed = 1
+		speed = speed_after_boost
 	else
 		speed = 0
 
@@ -69,7 +70,7 @@
 /mob/living/simple_animal/slaughter/phasein()
 	. = ..()
 	speed = 0
-	boost = world.time + 60
+	boost = world.time + 50
 
 
 //The loot from killing a slaughter demon - can be consumed to allow the user to blood crawl
@@ -119,13 +120,13 @@
 	emote_hear = list("gaffaws","laughs")
 	response_help  = "hugs"
 	attacktext = "wildly tickles"
-
 	attack_sound = 'sound/items/bikehorn.ogg'
 	feast_sound = 'sound/spookoween/scary_horn2.ogg'
 	death_sound = 'sound/misc/sadtrombone.ogg'
-
 	icon_state = "bowmon"
 	icon_living = "bowmon"
+	dismember_chance = 0
+	speed_after_boost = 2
 	deathmessage = "fades out, as all of its friends are released from its \
 		prison of hugs."
 	loot = list(/mob/living/simple_animal/pet/cat/kitten{name = "Laughter"})

--- a/code/modules/spells/spell_types/bloodcrawl.dm
+++ b/code/modules/spells/spell_types/bloodcrawl.dm
@@ -1,4 +1,4 @@
-/obj/effect/proc_holder/spell/bloodcrawl
+/*/obj/effect/proc_holder/spell/bloodcrawl
 	name = "Blood Crawl"
 	desc = "Use pools of blood to phase out of existence."
 	charge_max = 0
@@ -13,7 +13,7 @@
 	action_background_icon_state = "bg_demon"
 	var/phased = 0
 
-/*/obj/effect/proc_holder/spell/bloodcrawl/choose_targets(mob/user = usr)
+/obj/effect/proc_holder/spell/bloodcrawl/choose_targets(mob/user = usr)
 	for(var/obj/effect/decal/cleanable/target in range(range, get_turf(user)))
 		if(target.can_bloodcrawl_in())
 			perform(target)
@@ -37,6 +37,8 @@
 /obj/effect/decal/cleanable/blood/CtrlClick(mob/living/user)
 	..()
 	if(user.bloodcrawl)
+		if(user.stat != CONSCIOUS)//people managed to hide in blood while knocked out which is stupid
+			return
 		if(user.holder)
 			user.phasein(src)
 		else
@@ -46,6 +48,8 @@
 /obj/effect/decal/cleanable/trail_holder/CtrlClick(mob/living/user)
 	..()
 	if(user.bloodcrawl)
+		if(user.stat != CONSCIOUS)
+			return
 		if(user.holder)
 			user.phasein(src)
 		else
@@ -57,6 +61,8 @@
 	if(!istype(user))
 		return
 	if(user.bloodcrawl)
+		if(user.stat != CONSCIOUS)//no hiding in blood while KOed
+			return
 		for(var/obj/effect/decal/cleanable/B in src.contents)
 			if(istype(B, /obj/effect/decal/cleanable/blood) || istype(B, /obj/effect/decal/cleanable/trail_holder))
 				if(user.holder)


### PR DESCRIPTION
le one spell point demon memeon

also decreases the boost time from 6 seconds to 5 seconds because it was too long

:cl: ShadowDeath6
tweak: Laughter demons now move more slowly than regular Slaughter Demons when their boost is gone.
tweak: Laughter demons can no longer dismember.
tweak: Lowers demon boost duration very slightly.
bugfix: You can no longer bloodcrawl when unconscious.
/:cl:

