### PR TITLE
Spawning a clockwork cult no longer creates revenants

### DIFF
--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -138,6 +138,13 @@
 				else
 					message_admins("[key_name_admin(usr)] tried to create a cyberman. Unfortunately, there were no candidates available.")
 					log_admin("[key_name(usr)] failed to create a cyberman.")
+			if("18")
+				if(src.makeClockCult())
+					message_admins("[key_name(usr)] started a clockwork cult.")
+					log_admin("[key_name(usr)] started a clockwork cult.")
+				else
+					message_admins("[key_name_admin(usr)] tried to start a clockwork cult. Unfortunately, there were no candidates available.")
+					log_admin("[key_name(usr)] failed to start a clockwork cult.")
 
 	else if(href_list["forceevent"])
 		if(!check_rights(R_FUN))
@@ -2394,7 +2401,7 @@
 			if("11")
 				set_cybermen_queued_objective()
 		cybermen_panel()//refresh the page.
-	
+
 	else if(href_list["adminserverrestart"])
 		if(!check_rights(R_TICKET))
 			usr << "Clients without ticket administration rights cannot use this command. Get out of here, coder!"

--- a/code/modules/admin/verbs/one_click_antag.dm
+++ b/code/modules/admin/verbs/one_click_antag.dm
@@ -15,7 +15,7 @@
 		<a href='?src=\ref[src];makeAntag=2'>Make Changelings</a><br>
 		<a href='?src=\ref[src];makeAntag=3'>Make Revs</a><br>
 		<a href='?src=\ref[src];makeAntag=4'>Make Cult</a><br>
-		<a href='?src=\ref[src];makeAntag=15'>Make Clockwork Cult</a><br>
+		<a href='?src=\ref[src];makeAntag=18'>Make Clockwork Cult</a><br>
 		<a href='?src=\ref[src];makeAntag=11'>Make Blob</a><br>
 		<a href='?src=\ref[src];makeAntag=12'>Make Gangsters</a><br>
 		<a href='?src=\ref[src];makeAntag=16'>Make Shadowling</a><br>


### PR DESCRIPTION
Fixes https://github.com/yogstation13/yogstation/issues/1153.

### Intent of your Pull Request

Rebasing without copying and pasting is practically mashing someones own code source with another.
So, this was just some of the damage from mashing together our sources with /tg/ to get the limited edition editors-choice clockwork cult version

#### Changelog

:cl:
fix: Spawning a clockwork cult (with antagonist panel) correctly spawns a cult instead of spawning a revenant.
/:cl:

