### PR TITLE
Buffs strange reagent

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -733,14 +733,14 @@
 /datum/reagent/medicine/strange_reagent
 	name = "Strange Reagent"
 	id = "strange_reagent"
-	description = "A miracle drug capable of bringing the dead back to life. Only functions if the target has less than 100 brute and burn damage (independent of one another), and causes slight damage to the living."
+	description = "A miracle drug capable of bringing the dead back to life. Only functions if the target has less than 150 brute and burn damage (independent of one another), and causes slight damage to the living."
 	reagent_state = LIQUID
 	color = "#A0E85E"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 
 /datum/reagent/medicine/strange_reagent/reaction_mob(mob/living/carbon/human/M, method=TOUCH, reac_volume)
 	if(M.stat == DEAD)
-		if(M.getBruteLoss() >= 100 || M.getFireLoss() >= 100)
+		if(M.getBruteLoss() >= 150 || M.getFireLoss() >= 150)
 			M.visible_message("<span class='warning'>[M]'s body convulses a bit, and then falls still once more.</span>")
 			return
 		M.visible_message("<span class='warning'>[M]'s body convulses a bit.</span>")


### PR DESCRIPTION
### Intent of your Pull Request

Right now, strange reagent is only useful in cases where someone died of suffocation or toxin damage, which doesn't really happen unless someone forgot to refill their internals or a Bob Blitzer is running rampart with a hypospray. This PR makes strange reagent a viable alternative to a defib, by raising the damage threshold to 150 burn or brute.

#### Changelog

:cl: McDonald072
tweak: Strange Reagent's revive threshold is now 150 burn or brute damage.
/:cl:

