### PR TITLE
Shuttle Notifications

### DIFF
--- a/code/modules/mining/laborcamp/laborshuttle.dm
+++ b/code/modules/mining/laborcamp/laborshuttle.dm
@@ -5,6 +5,7 @@
 	shuttleId = "laborcamp"
 	possible_destinations = "laborcamp_home;laborcamp_away"
 	req_access = list(access_brig)
+	notification = SEC_FREQ
 
 
 /obj/machinery/computer/shuttle/labor/one_way

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -57,6 +57,7 @@
 	shuttleId = "mining"
 	possible_destinations = "mining_home;mining_away"
 	no_destination_swap = 1
+	notification = SUPP_FREQ
 
 /*********************Pickaxe & Drills**************************/
 

--- a/code/modules/shuttle/computer.dm
+++ b/code/modules/shuttle/computer.dm
@@ -8,12 +8,18 @@
 	var/possible_destinations = ""
 	var/admin_controlled
 	var/no_destination_swap = 0
+	var/notification // assign a frequency here - ex: SEC_FREQ, etc
 
 /obj/machinery/computer/shuttle/New(location, obj/item/weapon/circuitboard/computer/shuttle/C)
 	..()
 	if(istype(C))
 		possible_destinations = C.possible_destinations
 		shuttleId = C.shuttleId
+
+	if(notification)
+		var/obj/item/device/radio/R = new(src)
+		R.set_frequency(notification)
+		R.listening = FALSE
 
 /obj/machinery/computer/shuttle/attack_hand(mob/user)
 	if(..(user))
@@ -65,6 +71,11 @@
 		switch(SSshuttle.moveShuttle(shuttleId, href_list["move"], 1))
 			if(0)
 				usr << "<span class='notice'>Shuttle received message and will be sent shortly.</span>"
+				if(notification)
+					for(var/obj/item/device/radio/R in src.contents)
+						if(R.frequency != notification)
+							R.frequency = notification
+						R.talk_into(src,"The [shuttleId] shuttle is taking off!",notification)
 			if(1)
 				usr << "<span class='warning'>Invalid shuttle requested.</span>"
 			else


### PR DESCRIPTION
Refer to issue https://github.com/yogstation13/yogstation/issues/1176.

### Intent of your Pull Request

Shuttles now send notifications everytime they're sent.
These notifications will go to their assigned division's radio channel (ex: labor camp goes to sec, mining goes to supply).

Currently the only shuttles that send messages are:
- Mining Shuttle
- Labor Camp Shuttle

#### Changelog

:cl:
rscadd: Every time the labor camp or mining shuttle is launched a notification is sent over the radio.
/:cl: