### PR TITLE
[s] Made bluespace shelter capsules not work on the station.

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -264,10 +264,6 @@
 
 		playsound(get_turf(src), 'sound/effects/phasein.ogg', 100, 1)
 
-		var/turf/T = deploy_location
-		if(T.z != ZLEVEL_MINING && T.z != ZLEVEL_LAVALAND)//only report capsules away from the mining/lavaland level
-			message_admins("[key_name_admin(usr)] (<A HREF='?_src_=holder;adminmoreinfo=\ref[usr]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[usr]'>FLW</A>) activated a bluespace capsule away from the mining level! (<A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>JMP</a>)")
-			log_admin("[key_name(usr)] activated a bluespace capsule away from the mining level at [T.x], [T.y], [T.z]")
 		template.load(deploy_location, centered = TRUE)
 		PoolOrNew(/obj/effect/particle_effect/smoke, get_turf(src))
 		qdel(src)

--- a/code/modules/mining/shelters.dm
+++ b/code/modules/mining/shelters.dm
@@ -14,12 +14,10 @@
 /datum/map_template/shelter/proc/check_deploy(turf/deploy_location)
 	if(!deploy_location)
 		return SHELTER_DEPLOY_BAD_AREA
-	if(deploy_location.z == ZLEVEL_STATION)
-		return SHELTER_DEPLOY_BAD_AREA
 	var/affected = get_affected_turfs(deploy_location, centered=TRUE)
 	for(var/turf/T in affected)
 		var/area/A = get_area(T)
-		if(is_type_in_typecache(A, banned_areas))
+		if(is_type_in_typecache(A, banned_areas) || ((deploy_location.z == ZLEVEL_STATION) && !istype(A, /area/space)) )
 			return SHELTER_DEPLOY_BAD_AREA
 
 		var/banned = is_type_in_typecache(T, blacklisted_turfs)

--- a/code/modules/mining/shelters.dm
+++ b/code/modules/mining/shelters.dm
@@ -12,6 +12,10 @@
 	banned_areas = typecacheof(/area/shuttle)
 
 /datum/map_template/shelter/proc/check_deploy(turf/deploy_location)
+	if(!deploy_location)
+		return SHELTER_DEPLOY_BAD_AREA
+	if(deploy_location.z == ZLEVEL_STATION)
+		return SHELTER_DEPLOY_BAD_AREA
 	var/affected = get_affected_turfs(deploy_location, centered=TRUE)
 	for(var/turf/T in affected)
 		var/area/A = get_area(T)


### PR DESCRIPTION
Requested by GreatBigBen

Shelter capsules no longer work on the station z-level, because 90% of the time they are used to block hallways for no reason.