### PR TITLE
stimpacks now hold 10u more stims and inject 20u rather than all of it

### DIFF
--- a/code/modules/reagents/reagent_containers/syringes.dm
+++ b/code/modules/reagents/reagent_containers/syringes.dm
@@ -203,9 +203,9 @@
 /obj/item/weapon/reagent_containers/syringe/stimulants
 	name = "Stimpack"
 	desc = "Contains stimulants."
-	amount_per_transfer_from_this = 50
-	volume = 50
-	list_reagents = list("stimulants" = 50)
+	amount_per_transfer_from_this = 20
+	volume = 60
+	list_reagents = list("stimulants" = 60)
 
 /obj/item/weapon/reagent_containers/syringe/calomel
 	name = "syringe (calomel)"

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -714,7 +714,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	desc = "Stimpacks, the tool of many great heroes, make you nearly immune to stuns and knockdowns for about \
 			5 minutes after injection. You also cannot be put into critical as long as the stimulants are in your body."
 	item = /obj/item/weapon/reagent_containers/syringe/stimulants
-	cost = 10
+	cost = 8
 	surplus = 30
 
 /datum/uplink_item/stealthy_tools/mulligan


### PR DESCRIPTION
#1105 
who's multi-use now you fuckin dickhead adrenal implant

:cl: ShadowDeath6
tweak: Stimulant syringes (stimpacks) now hold 60u of stimulants, up from 50.
tweak: Stimulant syringes now inject 20u per inject, down from 50.
tweak: Stimulants cost 8 tc, down from 10.
/:cl:

