### PR TITLE
Sentient animals are allowed to attack themselves again.

### DIFF
--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -654,8 +654,6 @@
 /mob/living/simple_animal/proc/AttackingTarget(atom/T)
 	if(harness && harness.on_melee_attack(src, T, 1))
 		return
-	if(T == src)
-		return
 	T.attack_animal(src)
 
 /mob/living/simple_animal/hostile/RangedAttack(atom/A, params) //Player firing


### PR DESCRIPTION
#### Changelog

:cl:
tweak: Sentient animals can attack themselves again.
/:cl:

Note: This is NOT letting pissed off mob animals TARGET themselves. This is letting players CONTROLLING a mob, and you wanna click yourself to death, than you can or vice versa. It also easily fixes a bug where artificers weren't able to attack themselves (like https://github.com/yogstation13/yogstation/pull/1212). 