### PR TITLE
Tweaks borers to no longer be able to claim soulless bodies

### DIFF
--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -188,7 +188,6 @@
 
 	src << "<span class='userdanger'>You begin disconnecting from [victim]'s synapses and prodding at their internal ear canal.</span>"
 
-
 	if(victim.stat != DEAD)
 		host << "<span class='userdanger'>An odd, uncomfortable pressure begins to build inside your skull, behind your ear...</span>"
 

--- a/code/modules/mob/living/simple_animal/borer/borer_powers.dm
+++ b/code/modules/mob/living/simple_animal/borer/borer_powers.dm
@@ -52,6 +52,10 @@
 		src << "<span class='warning'>[H] cannot be infected! Retreating!</span>"
 		return 0
 
+	if(!H.mind.active)
+		src << "<span class='warning'>[H] does not have an active mind.</span>"
+		return 0
+
 	return 1
 	var/unprotected = TRUE
 
@@ -183,6 +187,7 @@
 		return
 
 	src << "<span class='userdanger'>You begin disconnecting from [victim]'s synapses and prodding at their internal ear canal.</span>"
+
 
 	if(victim.stat != DEAD)
 		host << "<span class='userdanger'>An odd, uncomfortable pressure begins to build inside your skull, behind your ear...</span>"


### PR DESCRIPTION
Tweaks borers so that SSD and bodies left behind from cloning can no longer be infected.
:cl:
tweak: Tweaks borers so that SSD and bodies left behind from cloning can no longer be infected.
/:cl:

