### PR TITLE
Adds an SCP facility lavaland ruin

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_scp_facility.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_scp_facility.dmm
@@ -3,10 +3,10 @@
 /turf/template_noop,
 /area/template_noop)
 "ab" = (
-/turf/closed/mineral/volcanic/lava_land_surface,
+/turf/closed/indestructible/rock,
 /area/ruin/unpowered)
 "ac" = (
-/turf/closed/wall/r_wall,
+/turf/closed/indestructible/opshuttle,
 /area/ruin/unpowered)
 "ad" = (
 /obj/structure/rack,
@@ -204,10 +204,14 @@
 	},
 /area/ruin/unpowered)
 "aJ" = (
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/highsecurity,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered)
 "aK" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/indestructible/rock,
+/area/ruin/unpowered)
+"aL" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plasteel/darkred/corner{
 	tag = "icon-darkredcorners (NORTH)";
@@ -215,14 +219,14 @@
 	dir = 1
 	},
 /area/ruin/unpowered)
-"aL" = (
+"aM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/tile/plasteel,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/ruin/unpowered)
-"aM" = (
+"aN" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	tag = "icon-tracks (SOUTHWEST)";
 	icon_state = "tracks";
@@ -234,12 +238,12 @@
 	dir = 1
 	},
 /area/ruin/unpowered)
-"aN" = (
+"aO" = (
 /obj/effect/mob_spawn/human/corpse/nanotrasensoldier,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plasteel/black,
 /area/ruin/unpowered)
-"aO" = (
+"aP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/rods{
 	amount = 50
@@ -248,70 +252,77 @@
 	icon_state = "panelscorched"
 	},
 /area/ruin/unpowered)
-"aP" = (
+"aQ" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/tree,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"aR" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/stack/rods,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/ruin/unpowered)
-"aQ" = (
+"aS" = (
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"aR" = (
+"aT" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"aS" = (
+"aU" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"aT" = (
+"aV" = (
 /obj/structure/girder/displaced,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/ruin/unpowered)
-"aU" = (
+"aW" = (
 /obj/effect/decal/cleanable/cobweb{
 	tag = "icon-cobweb2";
 	icon_state = "cobweb2"
 	},
 /turf/open/floor/engine,
 /area/ruin/unpowered)
-"aV" = (
+"aX" = (
 /obj/structure/sign/kiddieplaque{
 	desc = "WARNING. ACCESS IS LIMITED TO NANOTRASEN LEVEL 5-B PERSONNEL. IF YOU ARE NOT AUTHORIZED PERSONNEL AND ARE READING THIS, PLEASE INFORM YOUR LOCAL STATION COMMANDER OF A LEVEL XK-BREACH OF SITE- *the rest of the plaque is destroyed*";
 	name = "A dusty plaque"
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/indestructible/opshuttle,
 /area/ruin/unpowered)
-"aW" = (
+"aY" = (
 /obj/structure/girder/displaced,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/ruin/unpowered)
-"aX" = (
+"aZ" = (
 /turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"aY" = (
+"ba" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"aZ" = (
+"bb" = (
 /obj/structure/table,
 /obj/item/device/radio,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"ba" = (
+"bc" = (
 /obj/structure/table,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"bb" = (
+"bd" = (
 /obj/structure/frame/computer,
 /turf/open/floor/plating{
 	dir = 4;
@@ -321,11 +332,11 @@
 	temperature = 2.7
 	},
 /area/ruin/unpowered)
-"bc" = (
+"be" = (
 /obj/structure/sign/pods,
-/turf/closed/wall/r_wall,
+/turf/closed/indestructible/opshuttle,
 /area/ruin/unpowered)
-"bd" = (
+"bf" = (
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
@@ -334,18 +345,14 @@
 	icon_state = "panelscorched"
 	},
 /area/ruin/unpowered)
-"be" = (
+"bg" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/ruin/unpowered)
-"bf" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/ruin/unpowered)
-"bg" = (
+"bh" = (
 /mob/living/simple_animal/hostile/carp/eyeball{
 	health = 75;
 	maxHealth = 75;
@@ -354,7 +361,7 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/unpowered)
-"bh" = (
+"bi" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkred/corner{
 	tag = "icon-darkredcorners (NORTH)";
@@ -362,7 +369,7 @@
 	dir = 1
 	},
 /area/ruin/unpowered)
-"bi" = (
+"bj" = (
 /obj/structure/girder/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -370,7 +377,7 @@
 	icon_state = "panelscorched"
 	},
 /area/ruin/unpowered)
-"bj" = (
+"bk" = (
 /turf/open/floor/plating{
 	dir = 4;
 	icon_state = "warnplate";
@@ -379,44 +386,53 @@
 	temperature = 2.7
 	},
 /area/ruin/unpowered)
-"bk" = (
+"bl" = (
 /obj/machinery/door/poddoor/shutters,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"bl" = (
+"bm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
-"bm" = (
+"bn" = (
 /obj/effect/decal/cleanable/blood,
+/obj/effect/mob_spawn/human/corpse/damaged,
 /turf/open/floor/engine,
 /area/ruin/unpowered)
-"bn" = (
+"bo" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/black,
 /area/ruin/unpowered)
-"bo" = (
-/obj/machinery/door/airlock/highsecurity,
-/turf/closed/wall/r_wall,
-/area/ruin/unpowered)
 "bp" = (
+/obj/machinery/door/airlock/highsecurity,
+/turf/closed/indestructible/opshuttle,
+/area/ruin/unpowered)
+"bq" = (
 /obj/item/clothing/suit/cultrobes,
 /obj/item/clothing/head/culthood,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/cult,
 /area/ruin/unpowered)
-"bq" = (
+"br" = (
 /obj/structure/girder/reinforced,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"br" = (
+"bs" = (
 /obj/item/stack/cable_coil/yellow,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"bs" = (
+"bt" = (
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
-"bt" = (
+"bu" = (
+/obj/effect/mob_spawn/human/skeleton,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"bv" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/engine,
+/area/ruin/unpowered)
+"bw" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/body,
 /obj/effect/decal/cleanable/blood/tracks{
@@ -424,34 +440,8 @@
 	icon_state = "tracks";
 	dir = 4
 	},
-/obj/effect/mob_spawn/human/corpse/nanotrasensoldier,
+/obj/effect/mob_spawn/human/corpse/damaged,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered)
-"bu" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	tag = "icon-tracks (WEST)";
-	icon_state = "tracks";
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered)
-"bv" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	tag = "icon-tracks (EAST)";
-	icon_state = "tracks";
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered)
-"bw" = (
-/obj/effect/decal/cleanable/blood/tracks{
-	tag = "icon-tracks (EAST)";
-	icon_state = "tracks";
-	dir = 4
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
 /area/ruin/unpowered)
 "bx" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -459,7 +449,7 @@
 	icon_state = "tracks";
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered)
 "by" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -467,7 +457,7 @@
 	icon_state = "tracks";
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered)
 "bz" = (
 /obj/effect/decal/cleanable/blood/tracks{
@@ -476,6 +466,32 @@
 	dir = 4
 	},
 /turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"bA" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (WEST)";
+	icon_state = "tracks";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"bB" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (EAST)";
+	icon_state = "tracks";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"bC" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (EAST)";
+	icon_state = "tracks";
+	dir = 4
+	},
+/turf/open/floor/plating{
 	dir = 4;
 	icon_state = "warnplate";
 	luminosity = 2;
@@ -483,7 +499,7 @@
 	temperature = 2.7
 	},
 /area/ruin/unpowered)
-"bA" = (
+"bD" = (
 /obj/item/stack/rods,
 /obj/effect/decal/cleanable/blood/tracks{
 	tag = "icon-tracks (EAST)";
@@ -494,7 +510,7 @@
 	icon_state = "platingdmg3"
 	},
 /area/ruin/unpowered)
-"bB" = (
+"bE" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	tag = "icon-tracks (EAST)";
 	icon_state = "tracks";
@@ -502,7 +518,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
-"bC" = (
+"bF" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	tag = "icon-tracks (NORTHEAST)";
 	icon_state = "tracks";
@@ -510,11 +526,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
-"bD" = (
+"bG" = (
 /obj/structure/sign/securearea,
-/turf/closed/wall/r_wall,
+/turf/closed/indestructible/opshuttle,
 /area/ruin/unpowered)
-"bE" = (
+"bH" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	tag = "icon-tracks (NORTH)";
 	icon_state = "tracks";
@@ -522,33 +538,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
-"bF" = (
+"bI" = (
 /obj/structure/girder/reinforced,
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/indestructible/opshuttle,
 /area/ruin/unpowered)
-"bG" = (
+"bJ" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/black,
 /area/ruin/unpowered)
-"bH" = (
+"bK" = (
 /obj/structure/table/reinforced,
 /obj/item/weapon/circuitboard/machine/cyborgrecharger,
 /obj/item/weapon/crowbar,
 /obj/item/weapon/weldingtool,
 /turf/open/floor/plasteel/black,
 /area/ruin/unpowered)
-"bI" = (
+"bL" = (
 /turf/open/floor/plasteel/darkred/corner{
 	tag = "icon-darkredcorners (EAST)";
 	icon_state = "darkredcorners";
 	dir = 4
 	},
 /area/ruin/unpowered)
-"bJ" = (
+"bM" = (
 /obj/structure/sign/directions/medical{
 	dir = 4;
 	icon_state = "direction_med";
@@ -558,57 +574,57 @@
 	},
 /turf/open/floor/engine,
 /area/ruin/unpowered)
-"bK" = (
+"bN" = (
 /obj/machinery/atmospherics/components/unary/tank/air,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"bL" = (
+"bO" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"bM" = (
+"bP" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"bN" = (
+"bQ" = (
 /obj/effect/decal/cleanable/robot_debris/gib,
 /turf/open/floor/plasteel/black,
 /area/ruin/unpowered)
-"bO" = (
+"bR" = (
 /obj/structure/sign/directions/evac{
 	tag = "icon-direction_evac (NORTH)";
 	icon_state = "direction_evac";
 	dir = 1
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/indestructible/opshuttle,
 /area/ruin/unpowered)
-"bP" = (
+"bS" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
-"bQ" = (
+"bT" = (
 /turf/open/floor/plasteel/yellow/corner,
 /area/ruin/unpowered)
-"bR" = (
+"bU" = (
 /obj/item/trash/deadmouse,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"bS" = (
+"bV" = (
 /obj/machinery/doppler_array{
 	desc = "A rusty old machine.";
 	name = "Seismic Warning System"
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"bT" = (
+"bW" = (
 /obj/item/weapon/screwdriver,
 /turf/open/floor/plasteel/black,
 /area/ruin/unpowered)
-"bU" = (
+"bX" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/black,
 /area/ruin/unpowered)
-"bV" = (
+"bY" = (
 /obj/structure/sign/directions/security{
 	dir = 1;
 	icon_state = "direction_sec";
@@ -618,7 +634,7 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/ruin/unpowered)
-"bW" = (
+"bZ" = (
 /obj/structure/girder/reinforced,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
@@ -626,15 +642,15 @@
 	icon_state = "panelscorched"
 	},
 /area/ruin/unpowered)
-"bX" = (
+"ca" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
-"bY" = (
+"cb" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"bZ" = (
+"cc" = (
 /obj/structure/frame/computer,
 /obj/item/weapon/paper{
 	info = "THIS IS AN AUTOMATIC REPORT GENERATED BY THE SEISMIC WARNING SYSTEM (c). \[br] \[br] SLIGHT QUAKES HAVE BEEN DETECTED TO THE SOUTHEAST. OUR CURRENT ALGORITHM SUGGESTS THE SEISMIC INSTABILITY WILL SPREAD TO YOUR CURRENT LOCATION. \[br] \[br] WE PREDICT A 67.2% CHANCE OF A SIGNIFICANT EARTHQUAKE AT YOUR PRESENT LOCATION IN SIX TO TWELVE HOURS. PLEASE PROCEED WITH EARTHQUAKE THREAT PROTOCOL AS STATED IN PAGE 515 SECTION 61-X OF YOUR AOC SITE MANUAL.";
@@ -642,16 +658,16 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"ca" = (
+"cd" = (
 /obj/effect/decal/cleanable/blood,
 /mob/living/simple_animal/hostile/asteroid/goliath,
 /turf/open/floor/plasteel/black,
 /area/ruin/unpowered)
-"cb" = (
+"ce" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plasteel/black,
 /area/ruin/unpowered)
-"cc" = (
+"cf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/body,
@@ -659,98 +675,102 @@
 	icon_state = "panelscorched"
 	},
 /area/ruin/unpowered)
-"cd" = (
+"cg" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
-"ce" = (
+"ch" = (
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"cf" = (
+"ci" = (
 /obj/effect/decal/cleanable/blood/gibs/body,
 /turf/open/floor/plasteel/black,
 /area/ruin/unpowered)
-"cg" = (
+"cj" = (
+/obj/effect/mob_spawn/human/skeleton,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"ck" = (
 /turf/open/floor/plasteel/darkblue/corner,
 /area/ruin/unpowered)
-"ch" = (
+"cl" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue/corner,
 /area/ruin/unpowered)
-"ci" = (
+"cm" = (
 /obj/effect/decal/cleanable/blood/tracks,
 /obj/item/ammo_casing/c9mm,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
-"cj" = (
+"cn" = (
 /obj/structure/rack,
 /obj/item/weapon/storage/box/lights/tubes,
 /obj/item/weapon/storage/toolbox/electrical,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"ck" = (
+"co" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"cl" = (
+"cp" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/fire/firefighter,
 /obj/item/weapon/extinguisher,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"cm" = (
+"cq" = (
 /turf/open/floor/plasteel/darkblue/corner{
 	tag = "icon-darkbluecorners (EAST)";
 	icon_state = "darkbluecorners";
 	dir = 4
 	},
 /area/ruin/unpowered)
-"cn" = (
+"cr" = (
 /obj/structure/girder/reinforced,
 /turf/open/space,
 /area/ruin/unpowered)
-"co" = (
+"cs" = (
 /mob/living/simple_animal/hostile/asteroid/hivelord/legion,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
-"cp" = (
+"ct" = (
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
-"cq" = (
+"cu" = (
 /obj/structure/sign/directions/evac{
 	tag = "icon-direction_evac (WEST)";
 	icon_state = "direction_evac";
 	dir = 8
 	},
-/turf/closed/wall/r_wall,
+/turf/closed/indestructible/opshuttle,
 /area/ruin/unpowered)
-"cr" = (
+"cv" = (
 /obj/structure/sink,
-/turf/closed/wall/r_wall,
+/turf/closed/indestructible/opshuttle,
 /area/ruin/unpowered)
-"cs" = (
+"cw" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel/darkblue,
 /area/ruin/unpowered)
-"ct" = (
+"cx" = (
 /obj/structure/table,
 /obj/item/weapon/hand_labeler,
 /turf/open/floor/plasteel/darkblue,
 /area/ruin/unpowered)
-"cu" = (
+"cy" = (
 /obj/structure/frame/computer,
 /turf/open/floor/plasteel/darkblue,
 /area/ruin/unpowered)
-"cv" = (
+"cz" = (
 /obj/structure/grille,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/space,
 /area/ruin/unpowered)
-"cw" = (
+"cA" = (
 /obj/structure/girder/reinforced,
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
@@ -760,11 +780,11 @@
 	icon_state = "panelscorched"
 	},
 /area/ruin/unpowered)
-"cx" = (
+"cB" = (
 /obj/item/ammo_casing/n762,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
-"cy" = (
+"cC" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	tag = "icon-tracks (NORTH)";
 	icon_state = "tracks";
@@ -773,7 +793,7 @@
 /obj/item/ammo_casing/shotgun/buckshot,
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
-"cz" = (
+"cD" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
@@ -783,14 +803,14 @@
 	dir = 4
 	},
 /area/ruin/unpowered)
-"cA" = (
+"cE" = (
 /turf/open/floor/plasteel/blue/corner{
 	tag = "icon-bluecorner (EAST)";
 	icon_state = "bluecorner";
 	dir = 4
 	},
 /area/ruin/unpowered)
-"cB" = (
+"cF" = (
 /obj/structure/closet/l3closet,
 /turf/open/floor/plasteel/blue/corner{
 	tag = "icon-bluecorner (EAST)";
@@ -798,11 +818,11 @@
 	dir = 4
 	},
 /area/ruin/unpowered)
-"cC" = (
+"cG" = (
 /obj/structure/sign/biohazard,
-/turf/closed/wall/r_wall,
+/turf/closed/indestructible/opshuttle,
 /area/ruin/unpowered)
-"cD" = (
+"cH" = (
 /obj/machinery/shower{
 	desc = "A showerhead found in school science labs and medbays alike, used to quickly wash off any dangerous fluids covering a person.";
 	name = "emergency shower";
@@ -810,19 +830,19 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
-"cE" = (
+"cI" = (
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
-"cF" = (
+"cJ" = (
 /obj/item/weapon/soap/nanotrasen,
 /obj/structure/table,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
-"cG" = (
+"cK" = (
 /obj/structure/sign/xeno_warning_mining,
-/turf/closed/wall/r_wall,
+/turf/closed/indestructible/opshuttle,
 /area/ruin/unpowered)
-"cH" = (
+"cL" = (
 /obj/item/weapon/shard{
 	icon_state = "small"
 	},
@@ -832,23 +852,27 @@
 	dir = 4
 	},
 /area/ruin/unpowered)
-"cI" = (
+"cM" = (
 /obj/structure/grille,
 /obj/item/weapon/shard,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"cJ" = (
+"cN" = (
 /turf/open/floor/plasteel/darkblue,
 /area/ruin/unpowered)
-"cK" = (
+"cO" = (
 /obj/item/weapon/paper/scp_research,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"cL" = (
+"cP" = (
+/mob/living/simple_animal/imp,
+/turf/open/floor/plasteel/darkblue,
+/area/ruin/unpowered)
+"cQ" = (
 /mob/living/simple_animal/hostile/asteroid/basilisk/watcher,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered)
-"cM" = (
+"cR" = (
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
@@ -863,7 +887,7 @@
 	icon_state = "panelscorched"
 	},
 /area/ruin/unpowered)
-"cN" = (
+"cS" = (
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
@@ -878,7 +902,7 @@
 	icon_state = "panelscorched"
 	},
 /area/ruin/unpowered)
-"cO" = (
+"cT" = (
 /obj/effect/decal/cleanable/blood/tracks{
 	tag = "icon-tracks (SOUTHEAST)";
 	icon_state = "tracks";
@@ -886,65 +910,66 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
-"cP" = (
+"cU" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ruin/unpowered)
-"cQ" = (
+"cV" = (
 /obj/machinery/door/airlock/science,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
-"cR" = (
+"cW" = (
 /obj/item/weapon/folder/blue{
 	name = "Research Notes - Objects 15-20"
 	},
 /turf/open/floor/plasteel/darkblue,
 /area/ruin/unpowered)
-"cS" = (
+"cX" = (
 /obj/effect/decal/cleanable/dirt{
 	desc = "A thin layer of dust coating the floor.";
 	name = "dust"
 	},
 /obj/effect/decal/cleanable/blood,
+/obj/effect/mob_spawn/human/corpse/damaged,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/ruin/unpowered)
-"cT" = (
+"cY" = (
 /turf/open/floor/plasteel/blue/corner{
 	tag = "icon-bluecorner (WEST)";
 	icon_state = "bluecorner";
 	dir = 8
 	},
 /area/ruin/unpowered)
-"cU" = (
+"cZ" = (
 /obj/machinery/door/firedoor/border_only{
 	dir = 8
 	},
 /turf/open/floor/plasteel/blue/corner,
 /area/ruin/unpowered)
-"cV" = (
+"da" = (
 /turf/open/floor/plasteel/blue/corner,
 /area/ruin/unpowered)
-"cW" = (
+"db" = (
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel/blue/corner,
 /area/ruin/unpowered)
-"cX" = (
+"dc" = (
 /obj/structure/sign/radiation,
-/turf/closed/wall/r_wall,
+/turf/closed/indestructible/opshuttle,
 /area/ruin/unpowered)
-"cY" = (
+"dd" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white,
 /area/ruin/unpowered)
-"cZ" = (
+"de" = (
 /obj/structure/sign/science,
-/turf/closed/wall/r_wall,
+/turf/closed/indestructible/opshuttle,
 /area/ruin/unpowered)
-"da" = (
+"df" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/darkblue/corner{
 	tag = "icon-darkbluecorners (EAST)";
@@ -952,12 +977,12 @@
 	dir = 4
 	},
 /area/ruin/unpowered)
-"db" = (
+"dg" = (
 /obj/structure/grille,
 /obj/structure/window/fulltile,
 /turf/open/floor/plating,
 /area/ruin/unpowered)
-"dc" = (
+"dh" = (
 /obj/machinery/door/airlock/glass{
 	name = "Staff Room"
 	},
@@ -965,20 +990,20 @@
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dd" = (
+"di" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/plasteel/whiteblue/side,
 /area/ruin/unpowered)
-"de" = (
+"dj" = (
 /obj/structure/bedsheetbin,
 /obj/structure/table,
 /turf/open/floor/plasteel/whiteblue/side,
 /area/ruin/unpowered)
-"df" = (
+"dk" = (
 /obj/structure/sign/directions/engineering,
-/turf/closed/wall/r_wall,
+/turf/closed/indestructible/opshuttle,
 /area/ruin/unpowered)
-"dg" = (
+"dl" = (
 /obj/structure/table,
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
@@ -986,54 +1011,54 @@
 	icon_state = "panelscorched"
 	},
 /area/ruin/unpowered)
-"dh" = (
+"dm" = (
 /obj/structure/table,
 /obj/item/weapon/reagent_containers/food/drinks/britcup,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/ruin/unpowered)
-"di" = (
+"dn" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/plasteel{
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dj" = (
+"do" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel{
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dk" = (
+"dp" = (
 /turf/open/floor/plasteel{
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dl" = (
+"dq" = (
 /obj/item/trash/chips,
 /turf/open/floor/plasteel{
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dm" = (
+"dr" = (
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel{
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dn" = (
+"ds" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/device/analyzer,
 /turf/open/floor/plasteel/black,
 /area/ruin/unpowered)
-"do" = (
+"dt" = (
 /obj/structure/chair,
 /turf/open/floor/plasteel{
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dp" = (
+"du" = (
 /obj/structure/chair{
 	dir = 4
 	},
@@ -1041,13 +1066,13 @@
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dq" = (
+"dv" = (
 /obj/structure/table/glass,
 /turf/open/floor/plasteel{
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dr" = (
+"dw" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper{
 	info = "\[center]\[large]Anomalous Object Containment \[AOC] Site 21 \[/large]\[/center] \[br] \[center]Status Report on 11. 8. 2489 at 8:09 AM Lavaland Time\[/center] \[br] \[br] Nothing unusual to report. Seismic Warning System's blaring about a quake coming in soon, but Scott told me he'd fix it by the weekend. We've had to reschedule some experiments to the next Wednesday due to some broken equipment, but nothing major to worry about. \[br] Signed: Dr. James Walker";
@@ -1057,7 +1082,7 @@
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"ds" = (
+"dx" = (
 /obj/structure/table/glass,
 /obj/item/weapon/paper_bin,
 /obj/item/weapon/pen,
@@ -1065,7 +1090,7 @@
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dt" = (
+"dy" = (
 /obj/structure/chair{
 	dir = 8
 	},
@@ -1073,7 +1098,7 @@
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"du" = (
+"dz" = (
 /obj/structure/table/glass,
 /obj/item/weapon/reagent_containers/food/drinks/coffee,
 /obj/item/clothing/mask/cigarette,
@@ -1081,33 +1106,33 @@
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dv" = (
+"dA" = (
 /obj/machinery/status_display,
 /turf/open/floor/plasteel{
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dw" = (
+"dB" = (
 /obj/structure/table/glass,
 /obj/item/weapon/storage/fancy/donut_box,
 /turf/open/floor/plasteel{
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dx" = (
+"dC" = (
 /obj/item/trash/raisins,
 /turf/open/floor/plasteel{
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dy" = (
+"dD" = (
 /obj/structure/table,
 /obj/machinery/microwave,
 /turf/open/floor/plasteel{
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dz" = (
+"dE" = (
 /obj/structure/table,
 /obj/item/weapon/storage/box/donkpockets{
 	pixel_y = 2;
@@ -1118,25 +1143,25 @@
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dA" = (
+"dF" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel{
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dB" = (
+"dG" = (
 /obj/machinery/vending/cola,
 /turf/open/floor/plasteel{
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dC" = (
+"dH" = (
 /obj/machinery/vending/snack,
 /turf/open/floor/plasteel{
 	icon_state = "barber"
 	},
 /area/ruin/unpowered)
-"dD" = (
+"dI" = (
 /obj/structure/closet/wardrobe/science_white,
 /turf/open/floor/plasteel{
 	icon_state = "barber"
@@ -1393,7 +1418,7 @@ aa
 ab
 ab
 ab
-bd
+bf
 ac
 ab
 ab
@@ -1432,7 +1457,7 @@ ab
 as
 as
 as
-bt
+bw
 as
 as
 as
@@ -1445,7 +1470,7 @@ ab
 ab
 ab
 ac
-bd
+bf
 ac
 ab
 ab
@@ -1484,7 +1509,7 @@ ab
 as
 as
 as
-bu
+bx
 as
 as
 aa
@@ -1497,7 +1522,7 @@ ab
 ab
 ab
 ac
-bd
+bf
 ac
 ab
 ab
@@ -1536,7 +1561,7 @@ ab
 as
 as
 as
-bv
+by
 as
 aa
 aa
@@ -1549,7 +1574,7 @@ ab
 ab
 ab
 ac
-bd
+bf
 ac
 ab
 ab
@@ -1587,9 +1612,9 @@ ab
 ac
 ac
 az
-bq
-bw
-bD
+br
+bz
+bG
 ab
 aa
 aa
@@ -1637,10 +1662,10 @@ at
 ab
 ab
 ac
-aY
-aQ
-aQ
-bx
+ba
+aS
+aS
+bA
 ac
 ab
 ab
@@ -1689,10 +1714,10 @@ at
 ab
 ab
 ac
-aZ
-aQ
-aQ
-bx
+bb
+aS
+aS
+bA
 ac
 ab
 ab
@@ -1740,11 +1765,11 @@ at
 at
 ab
 ab
-aV
-ba
-aQ
-br
-by
+aX
+bc
+aS
+bs
+bB
 ac
 ab
 ab
@@ -1793,10 +1818,10 @@ at
 ab
 ab
 ac
-bb
-bj
-bj
-bz
+bd
+bk
+bk
+bC
 ac
 ab
 ab
@@ -1806,15 +1831,15 @@ ab
 ab
 ab
 ab
-cw
+cA
 ac
-di
-dk
-dk
-dk
-dk
-dk
-dy
+dn
+dp
+dp
+dp
+dp
+dp
+dD
 ac
 ab
 ab
@@ -1845,10 +1870,10 @@ at
 ab
 ab
 ac
-bc
-bk
-bk
-bA
+be
+bl
+bl
+bD
 ac
 ac
 ac
@@ -1856,17 +1881,17 @@ ac
 ac
 ac
 ac
-cw
-cM
-cS
+cA
+cR
+cX
 ac
-dj
-dk
+do
 dp
+du
+du
+du
 dp
-dp
-dk
-dz
+dE
 ac
 ab
 ab
@@ -1897,28 +1922,28 @@ at
 ab
 ab
 ac
-bd
-bl
-bs
-bB
-bs
-bs
-bP
-bX
-bs
-bs
-co
-cx
-cN
-bd
-db
-dk
-do
-dq
-du
-dw
-dk
-dA
+bf
+bm
+bt
+bE
+bt
+bt
+bS
+ca
+bt
+bt
+cs
+cB
+cS
+bf
+dg
+dp
+dt
+dv
+dz
+dB
+dp
+dF
 ac
 ab
 ab
@@ -1949,28 +1974,28 @@ ab
 ab
 ab
 aA
-bd
-bl
-aQ
-bC
-bE
-bE
-bE
-bY
-cd
-ci
-bY
-cy
-cO
-bs
-dc
-dk
-do
-dr
+bf
+bm
+aS
+bF
+bH
+bH
+bH
+cb
+cg
+cm
+cb
+cC
+cT
+bt
+dh
+dp
+dt
+dw
+dA
 dv
-dq
-dk
-dB
+dp
+dG
 ac
 ab
 ab
@@ -2001,28 +2026,28 @@ ab
 ab
 ab
 ab
-be
-bl
-bl
-bs
-bs
-bs
-bQ
-aQ
-ce
-bP
-cp
-bs
-bs
-cT
-db
-dl
-do
-ds
+bg
+bm
+bu
+bt
+bt
+bt
+bT
+aS
+ch
+bS
+ct
+bt
+bt
+cY
+dg
 dq
-dq
-dk
-dC
+dt
+dx
+dv
+dv
+dp
+dH
 ac
 ab
 ab
@@ -2054,27 +2079,27 @@ ab
 ab
 ac
 aA
-bl
-bl
+bm
+bm
 ab
-bF
+bI
 ac
 ac
-aR
+aT
 ac
 ac
-cq
-cz
-cP
+cu
+cD
 cU
+cZ
 ac
-dm
-dk
-dt
-dt
-dt
-dx
-dD
+dr
+dp
+dy
+dy
+dy
+dC
+dI
 ac
 ab
 ab
@@ -2105,28 +2130,28 @@ ab
 ab
 ab
 ac
-bf
+aK
 aE
-bf
+aK
 ab
 ac
-bK
-bR
-aQ
-aQ
-cj
+bN
+bU
+aS
+aS
+cn
 ac
-cA
-aQ
-cV
+cE
+aS
+da
 ac
-dm
-dk
-dk
-dk
-dk
-dk
-dD
+dr
+dp
+dp
+dp
+dp
+dp
+dI
 ac
 ab
 ab
@@ -2162,15 +2187,15 @@ ab
 ab
 ab
 ac
-bL
-aQ
-aQ
-aQ
-ck
+bO
+aS
+aS
+aS
+co
 ac
-cA
-bs
-aQ
+cE
+bt
+aS
 ac
 ac
 ac
@@ -2214,15 +2239,15 @@ ab
 ab
 ab
 ac
-bM
-bS
-bZ
-aQ
-cl
+bP
+bV
+cc
+aS
+cp
 ac
-cA
-bl
-cV
+cE
+bm
+da
 ac
 ab
 ab
@@ -2272,9 +2297,9 @@ ac
 ac
 ac
 ac
-cB
-bs
-cW
+cF
+bt
+db
 ac
 ab
 ab
@@ -2324,9 +2349,9 @@ ab
 ab
 ab
 ac
-cC
-cQ
-cX
+cG
+cV
+dc
 ac
 ac
 ab
@@ -2376,10 +2401,10 @@ ac
 ab
 ab
 ac
-cD
-cE
-cE
-dd
+cH
+cI
+cI
+di
 ac
 ab
 ab
@@ -2421,17 +2446,17 @@ ab
 ab
 ab
 ac
-bG
-bN
-bT
-bn
+bJ
+bQ
+bW
+bo
 ab
 ab
-cr
-cE
-cE
-cE
-dd
+cv
+cI
+cI
+cI
+di
 ac
 ab
 ab
@@ -2473,17 +2498,17 @@ ab
 ab
 ab
 ab
-bH
+bK
 ap
 ap
-bn
+bo
 ab
 ab
 ac
-cF
-cE
-cY
-de
+cJ
+cI
+dd
+dj
 ac
 ab
 ab
@@ -2532,10 +2557,10 @@ ap
 ac
 ac
 ac
-cG
-cQ
-cZ
-df
+cK
+cV
+de
+dk
 ac
 ac
 ac
@@ -2579,16 +2604,16 @@ aC
 aC
 aC
 ac
-bU
+bX
 ap
 ap
 ap
-aQ
-bn
+aS
+bo
 ap
-bn
-bn
-dn
+bo
+bo
+ds
 aE
 aA
 ab
@@ -2621,7 +2646,7 @@ aA
 aE
 ab
 ab
-aQ
+aS
 ac
 aC
 aC
@@ -2633,13 +2658,13 @@ aC
 ac
 ap
 ap
-cf
-aQ
-aQ
+ci
+aS
+aS
 ap
 ap
-bn
-bn
+bo
+bo
 aA
 aA
 ab
@@ -2672,8 +2697,8 @@ aE
 aB
 aB
 ac
-aQ
-aQ
+aS
+aS
 ac
 aC
 aC
@@ -2683,14 +2708,14 @@ aC
 aC
 aC
 ac
-aQ
-ca
-ap
-cm
-cm
-cH
-aQ
-da
+aS
+cd
+cj
+cq
+cq
+cL
+aS
+df
 aE
 ab
 ab
@@ -2724,23 +2749,23 @@ aB
 aB
 aC
 ac
-aQ
-aQ
-aT
+aS
+aS
+aV
 aC
 aC
-bg
+bh
 aC
 aC
 aC
 aC
 ac
 ap
-cb
-cg
+ce
+ck
 ac
 ac
-cI
+cM
 ab
 ab
 ab
@@ -2776,24 +2801,24 @@ aC
 aC
 aC
 ac
-aQ
-aQ
+aS
+aS
 av
 aC
 aC
 aC
-bm
-bm
+bn
+bv
 aC
 aC
 ac
 ap
 ap
-cg
-cn
-cs
-cJ
-cR
+ck
+cr
+cw
+cN
+cW
 av
 av
 ab
@@ -2828,25 +2853,25 @@ aC
 aC
 aC
 ac
-aQ
 aS
+aU
 ac
 aC
 aC
 aB
 aC
-bm
+bv
 aC
 aC
 ac
-bn
-aQ
-cg
+bo
+aS
+ck
 ac
-ct
-cK
-cJ
-cJ
+cx
+cO
+cN
+cN
 aw
 ab
 ab
@@ -2880,10 +2905,10 @@ aC
 aC
 aC
 ac
-aQ
 aS
-ac
 aU
+ac
+aW
 aC
 aC
 aC
@@ -2891,15 +2916,15 @@ aC
 aC
 aC
 ac
-bV
-aQ
-cg
+bY
+aS
+ck
 ac
-aQ
-cJ
-cJ
-cJ
-dg
+aS
+cP
+cN
+cN
+dl
 ab
 ab
 ab
@@ -2932,7 +2957,7 @@ aw
 av
 av
 ac
-aR
+aT
 ab
 ac
 ac
@@ -2942,16 +2967,16 @@ az
 ac
 ac
 ac
-bO
+bR
 ap
 ap
-cg
+ck
 ac
-cu
-cu
-cu
-cu
-dh
+cy
+cy
+cy
+cy
+dm
 ab
 ab
 ab
@@ -2980,30 +3005,30 @@ as
 aD
 aD
 aI
-aK
-aM
+aL
+aN
 aD
 aD
 ap
 ab
 ab
 ab
-aW
-bh
+aY
+bi
 ap
 aD
 aD
 aD
 aD
-aQ
+aS
 ap
-ch
+cl
 ac
-cv
-cv
-cv
-cv
-cv
+cz
+cz
+cz
+cz
+cz
 ab
 ab
 at
@@ -3033,7 +3058,7 @@ as
 ap
 ap
 ap
-aN
+aO
 ap
 ap
 ap
@@ -3041,15 +3066,15 @@ ab
 ab
 ab
 ab
-bi
-bn
+bj
+bo
 ap
 ap
 ap
 ap
 ap
-bn
-bn
+bo
+bo
 ac
 ab
 as
@@ -3094,13 +3119,13 @@ ab
 ab
 aE
 aE
-bn
-aQ
-aQ
-bI
-bI
+bo
+aS
+aS
+bL
+bL
 aE
-cc
+cf
 aE
 ac
 ab
@@ -3137,7 +3162,7 @@ ac
 as
 ac
 aE
-aO
+aP
 aE
 aE
 ab
@@ -3146,17 +3171,17 @@ ac
 ac
 ac
 ac
-bo
+bp
 ac
 ac
 ac
 ac
-bW
+bZ
 ab
 ab
 ab
 ab
-cL
+cQ
 as
 as
 at
@@ -3188,9 +3213,9 @@ as
 as
 as
 aJ
-aL
+aM
 aE
-aE
+aQ
 aE
 ab
 ab
@@ -3201,7 +3226,7 @@ aC
 aC
 aC
 aC
-bJ
+bM
 ac
 ab
 ab
@@ -3239,19 +3264,19 @@ at
 at
 as
 as
-aJ
-ac
+aK
+ab
 aE
-aP
+aR
 aE
 ab
 ab
 ac
 aC
 aC
-aX
+aZ
 aC
-aX
+aZ
 aC
 aC
 ac
@@ -3292,18 +3317,18 @@ at
 at
 at
 as
-as
-ac
-ac
+ab
+ab
+ab
 as
 ab
 ab
 ac
 aC
-aX
-aX
-aX
-aX
+aZ
+aZ
+aZ
+aZ
 aC
 aC
 ac
@@ -3345,18 +3370,18 @@ at
 at
 at
 as
-as
-as
-as
+ab
+ab
+ab
 ab
 ab
 ac
 aC
 aC
-aX
-bp
-aX
-aX
+aZ
+bq
+aZ
+aZ
 aC
 ac
 ab
@@ -3399,15 +3424,15 @@ at
 at
 as
 as
-as
+ab
 ab
 ab
 ac
 aw
 aC
-aX
-aX
-aX
+aZ
+aZ
+aZ
 aC
 aC
 ac
@@ -3457,10 +3482,10 @@ ab
 ab
 av
 aw
-aX
+aZ
 aC
-aX
-aX
+aZ
+aZ
 aC
 ac
 ab

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_scp_facility.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_scp_facility.dmm
@@ -1,0 +1,239 @@
+"aa" = (/turf/template_noop,/area/space)
+"ab" = (/turf/closed/mineral/volcanic/lava_land_surface,/area/space)
+"ac" = (/turf/closed/wall/r_wall,/area/space)
+"ad" = (/obj/structure/rack,/obj/item/weapon/gun/energy/gun,/turf/open/floor/plasteel/black,/area/space)
+"ae" = (/obj/structure/table/reinforced,/obj/item/weapon/melee/baton/loaded{pixel_x = 2},/obj/item/weapon/melee/baton/loaded{pixel_x = -2},/turf/open/floor/plasteel/black,/area/space)
+"af" = (/obj/structure/table/reinforced,/obj/machinery/recharger,/turf/open/floor/plasteel/black,/area/space)
+"ag" = (/obj/structure/table/reinforced,/obj/item/ammo_box/magazine/smgm45,/obj/item/ammo_box/magazine/smgm45,/turf/open/floor/plasteel/black,/area/space)
+"ah" = (/obj/structure/rack,/obj/item/weapon/gun/projectile/automatic/c20r/sc_c20r,/turf/open/floor/plasteel/black,/area/space)
+"ai" = (/obj/structure/rack,/obj/item/clothing/suit/armor/laserproof,/obj/item/clothing/suit/armor/laserproof,/turf/open/floor/plasteel/black,/area/space)
+"aj" = (/turf/open/floor/plasteel/darkred/side{dir = 9},/area/space)
+"ak" = (/turf/open/floor/plasteel/darkred/side{tag = "icon-darkred (NORTH)"; icon_state = "darkred"; dir = 1},/area/space)
+"al" = (/turf/open/floor/plasteel/darkred/side{tag = "icon-darkred (NORTHEAST)"; icon_state = "darkred"; dir = 5},/area/space)
+"am" = (/obj/structure/rack,/obj/item/clothing/suit/armor/bulletproof,/turf/open/floor/plasteel/black,/area/space)
+"an" = (/obj/machinery/deployable/barrier,/turf/open/floor/plasteel/black,/area/space)
+"ao" = (/turf/open/floor/plasteel/darkred/side{tag = "icon-darkred (WEST)"; icon_state = "darkred"; dir = 8},/area/space)
+"ap" = (/turf/open/floor/plasteel/black,/area/space)
+"aq" = (/turf/open/floor/plasteel/darkred/side{tag = "icon-darkred (EAST)"; icon_state = "darkred"; dir = 4},/area/space)
+"ar" = (/obj/structure/rack,/turf/open/floor/plasteel/black,/area/space)
+"as" = (/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/space)
+"at" = (/turf/open/floor/plating/lava/smooth/lava_land_surface,/area/space)
+"au" = (/obj/structure/rack,/obj/item/weapon/storage/box/barriers,/turf/open/floor/plasteel/black,/area/space)
+"av" = (/obj/structure/girder/reinforced,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"aw" = (/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"ax" = (/obj/structure/rack,/obj/item/weapon/storage/box/handcuffs,/turf/open/floor/plasteel/black,/area/space)
+"ay" = (/obj/structure/rack,/obj/item/device/assembly/flash/handheld{pixel_x = -3; pixel_y = -1},/obj/item/device/assembly/flash/handheld{pixel_x = 3},/turf/open/floor/plasteel/black,/area/space)
+"az" = (/obj/machinery/door/airlock/highsecurity,/turf/open/space,/area/space)
+"aA" = (/obj/structure/girder/reinforced,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"aB" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/engine,/area/space)
+"aC" = (/turf/open/floor/engine,/area/space)
+"aD" = (/turf/open/floor/plasteel/darkred/corner{tag = "icon-darkredcorners (NORTH)"; icon_state = "darkredcorners"; dir = 1},/area/space)
+"aE" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"aF" = (/obj/effect/decal/cleanable/blood,/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (WEST)"; icon_state = "tracks"; dir = 8},/mob/living/simple_animal/hostile/faithless,/turf/open/floor/engine,/area/space)
+"aG" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (WEST)"; icon_state = "tracks"; dir = 8},/turf/open/floor/engine,/area/space)
+"aH" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (WEST)"; icon_state = "tracks"; dir = 8},/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"aI" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (NORTHEAST)"; icon_state = "tracks"; dir = 5},/turf/open/floor/plasteel/darkred/corner{tag = "icon-darkredcorners (NORTH)"; icon_state = "darkredcorners"; dir = 1},/area/space)
+"aJ" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/space)
+"aK" = (/obj/effect/decal/cleanable/blood/tracks,/turf/open/floor/plasteel/darkred/corner{tag = "icon-darkredcorners (NORTH)"; icon_state = "darkredcorners"; dir = 1},/area/space)
+"aL" = (/obj/effect/decal/cleanable/dirt,/obj/item/stack/tile/plasteel,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"aM" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (SOUTHWEST)"; icon_state = "tracks"; dir = 10},/turf/open/floor/plasteel/darkred/corner{tag = "icon-darkredcorners (NORTH)"; icon_state = "darkredcorners"; dir = 1},/area/space)
+"aN" = (/obj/effect/mob_spawn/human/corpse/nanotrasensoldier,/obj/effect/decal/cleanable/blood,/turf/open/floor/plasteel/black,/area/space)
+"aO" = (/obj/effect/decal/cleanable/dirt,/obj/item/stack/rods{amount = 50},/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"aP" = (/obj/effect/decal/cleanable/dirt,/obj/item/stack/rods,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"aQ" = (/turf/open/floor/plating,/area/space)
+"aR" = (/obj/machinery/door/airlock/maintenance,/turf/open/floor/plating,/area/space)
+"aS" = (/obj/structure/rack,/obj/effect/spawner/lootdrop/maintenance,/turf/open/floor/plating,/area/space)
+"aT" = (/obj/structure/girder/displaced,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"aU" = (/obj/effect/decal/cleanable/cobweb{tag = "icon-cobweb2"; icon_state = "cobweb2"},/turf/open/floor/engine,/area/space)
+"aV" = (/obj/structure/sign/kiddieplaque{desc = "WARNING. ACCESS IS LIMITED TO NANOTRASEN LEVEL 5-B PERSONNEL. IF YOU ARE NOT AUTHORIZED PERSONNEL AND ARE READING THIS, PLEASE INFORM YOUR LOCAL STATION COMMANDER OF A LEVEL XK-BREACH OF SITE- *the rest of the plaque is destroyed*"; name = "A dusty plaque"},/turf/closed/wall/r_wall,/area/space)
+"aW" = (/obj/structure/girder/displaced,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"aX" = (/turf/open/floor/plasteel/cult,/area/space)
+"aY" = (/obj/effect/decal/cleanable/cobweb,/obj/structure/table,/turf/open/floor/plating,/area/space)
+"aZ" = (/obj/structure/table,/obj/item/device/radio,/turf/open/floor/plating,/area/space)
+"ba" = (/obj/structure/table,/turf/open/floor/plating,/area/space)
+"bb" = (/obj/structure/frame/computer,/turf/open/floor/plating{dir = 4; icon_state = "warnplate"; luminosity = 2; initial_gas_mix = "o2=0.01;n2=0.01"; temperature = 2.7},/area/space)
+"bc" = (/obj/structure/sign/pods,/turf/closed/wall/r_wall,/area/space)
+"bd" = (/obj/effect/decal/cleanable/dirt{desc = "A thin layer of dust coating the floor."; name = "dust"},/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"be" = (/obj/item/stack/rods,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"bf" = (/obj/effect/decal/cleanable/dirt,/turf/closed/mineral/volcanic/lava_land_surface,/area/space)
+"bg" = (/mob/living/simple_animal/hostile/carp/eyeball{health = 75; maxHealth = 75; melee_damage_lower = 25; melee_damage_upper = 30},/turf/open/floor/engine,/area/space)
+"bh" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/darkred/corner{tag = "icon-darkredcorners (NORTH)"; icon_state = "darkredcorners"; dir = 1},/area/space)
+"bi" = (/obj/structure/girder/reinforced,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"bj" = (/turf/open/floor/plating{dir = 4; icon_state = "warnplate"; luminosity = 2; initial_gas_mix = "o2=0.01;n2=0.01"; temperature = 2.7},/area/space)
+"bk" = (/obj/machinery/door/poddoor/shutters,/turf/open/floor/plating,/area/space)
+"bl" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/space)
+"bm" = (/obj/effect/decal/cleanable/blood,/turf/open/floor/engine,/area/space)
+"bn" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/black,/area/space)
+"bo" = (/obj/machinery/door/airlock/highsecurity,/turf/closed/wall/r_wall,/area/space)
+"bp" = (/obj/item/clothing/suit/cultrobes,/obj/item/clothing/head/culthood,/obj/structure/table/reinforced,/turf/open/floor/plasteel/cult,/area/space)
+"bq" = (/obj/structure/girder/reinforced,/turf/open/floor/plating,/area/space)
+"br" = (/obj/item/stack/cable_coil/yellow,/turf/open/floor/plating,/area/space)
+"bs" = (/turf/open/floor/plasteel,/area/space)
+"bt" = (/obj/effect/decal/cleanable/blood,/obj/effect/decal/cleanable/blood/gibs/body,/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (EAST)"; icon_state = "tracks"; dir = 4},/obj/effect/mob_spawn/human/corpse/nanotrasensoldier,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/space)
+"bu" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (WEST)"; icon_state = "tracks"; dir = 8},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/space)
+"bv" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (EAST)"; icon_state = "tracks"; dir = 4},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/space)
+"bw" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (EAST)"; icon_state = "tracks"; dir = 4},/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"bx" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (WEST)"; icon_state = "tracks"; dir = 8},/turf/open/floor/plating,/area/space)
+"by" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (EAST)"; icon_state = "tracks"; dir = 4},/turf/open/floor/plating,/area/space)
+"bz" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (EAST)"; icon_state = "tracks"; dir = 4},/turf/open/floor/plating{dir = 4; icon_state = "warnplate"; luminosity = 2; initial_gas_mix = "o2=0.01;n2=0.01"; temperature = 2.7},/area/space)
+"bA" = (/obj/item/stack/rods,/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (EAST)"; icon_state = "tracks"; dir = 4},/turf/open/floor/plating{icon_state = "platingdmg3"},/area/space)
+"bB" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (EAST)"; icon_state = "tracks"; dir = 4},/turf/open/floor/plasteel,/area/space)
+"bC" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (NORTHEAST)"; icon_state = "tracks"; dir = 5},/turf/open/floor/plasteel,/area/space)
+"bD" = (/obj/structure/sign/securearea,/turf/closed/wall/r_wall,/area/space)
+"bE" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (NORTH)"; icon_state = "tracks"; dir = 1},/turf/open/floor/plasteel,/area/space)
+"bF" = (/obj/structure/girder/reinforced,/obj/effect/decal/cleanable/dirt{desc = "A thin layer of dust coating the floor."; name = "dust"},/turf/closed/wall/r_wall,/area/space)
+"bG" = (/obj/machinery/recharge_station,/turf/open/floor/plasteel/black,/area/space)
+"bH" = (/obj/structure/table/reinforced,/obj/item/weapon/circuitboard/machine/cyborgrecharger,/obj/item/weapon/crowbar,/obj/item/weapon/weldingtool,/turf/open/floor/plasteel/black,/area/space)
+"bI" = (/turf/open/floor/plasteel/darkred/corner{tag = "icon-darkredcorners (EAST)"; icon_state = "darkredcorners"; dir = 4},/area/space)
+"bJ" = (/obj/structure/sign/directions/medical{dir = 4; icon_state = "direction_med"; pixel_x = -32; pixel_y = -24; tag = "icon-direction_med (EAST)"},/turf/open/floor/engine,/area/space)
+"bK" = (/obj/machinery/atmospherics/components/unary/tank/air,/turf/open/floor/plating,/area/space)
+"bL" = (/obj/structure/reagent_dispensers/watertank,/turf/open/floor/plating,/area/space)
+"bM" = (/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/plating,/area/space)
+"bN" = (/obj/effect/decal/cleanable/robot_debris/gib,/turf/open/floor/plasteel/black,/area/space)
+"bO" = (/obj/structure/sign/directions/evac{tag = "icon-direction_evac (NORTH)"; icon_state = "direction_evac"; dir = 1},/turf/closed/wall/r_wall,/area/space)
+"bP" = (/obj/effect/decal/cleanable/blood,/turf/open/floor/plasteel,/area/space)
+"bQ" = (/turf/open/floor/plasteel/yellow/corner,/area/space)
+"bR" = (/obj/item/trash/deadmouse,/turf/open/floor/plating,/area/space)
+"bS" = (/obj/machinery/doppler_array{desc = "A rusty old machine."; name = "Seismic Warning System"},/turf/open/floor/plating,/area/space)
+"bT" = (/obj/item/weapon/screwdriver,/turf/open/floor/plasteel/black,/area/space)
+"bU" = (/obj/effect/decal/cleanable/cobweb,/turf/open/floor/plasteel/black,/area/space)
+"bV" = (/obj/structure/sign/directions/security{dir = 1; icon_state = "direction_sec"; pixel_x = 32; pixel_y = 40; tag = "icon-direction_sec (NORTH)"},/turf/open/floor/plasteel/black,/area/space)
+"bW" = (/obj/structure/girder/reinforced,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/blood,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"bX" = (/obj/item/ammo_casing/c9mm,/turf/open/floor/plasteel,/area/space)
+"bY" = (/obj/effect/decal/cleanable/blood/tracks,/turf/open/floor/plating,/area/space)
+"bZ" = (/obj/structure/frame/computer,/obj/item/weapon/paper{info = "THIS IS AN AUTOMATIC REPORT GENERATED BY THE SEISMIC WARNING SYSTEM (c). \[br] \[br] SLIGHT QUAKES HAVE BEEN DETECTED TO THE SOUTHEAST. OUR CURRENT ALGORITHM SUGGESTS THE SEISMIC INSTABILITY WILL SPREAD TO YOUR CURRENT LOCATION. \[br] \[br] WE PREDICT A 67.2% CHANCE OF A SIGNIFICANT EARTHQUAKE AT YOUR PRESENT LOCATION IN SIX TO TWELVE HOURS. PLEASE PROCEED WITH EARTHQUAKE THREAT PROTOCOL AS STATED IN PAGE 515 SECTION 61-X OF YOUR AOC SITE MANUAL."; name = "SEISMIC WARNING"},/turf/open/floor/plating,/area/space)
+"ca" = (/obj/effect/decal/cleanable/blood,/mob/living/simple_animal/hostile/asteroid/goliath,/turf/open/floor/plasteel/black,/area/space)
+"cb" = (/obj/effect/decal/cleanable/blood,/turf/open/floor/plasteel/black,/area/space)
+"cc" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/blood,/obj/effect/decal/cleanable/blood/gibs/body,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"cd" = (/obj/effect/decal/cleanable/blood/tracks,/obj/effect/decal/cleanable/blood,/turf/open/floor/plasteel,/area/space)
+"ce" = (/obj/item/ammo_casing/c9mm,/turf/open/floor/plating,/area/space)
+"cf" = (/obj/effect/decal/cleanable/blood/gibs/body,/turf/open/floor/plasteel/black,/area/space)
+"cg" = (/turf/open/floor/plasteel/darkblue/corner,/area/space)
+"ch" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/darkblue/corner,/area/space)
+"ci" = (/obj/effect/decal/cleanable/blood/tracks,/obj/item/ammo_casing/c9mm,/turf/open/floor/plasteel,/area/space)
+"cj" = (/obj/structure/rack,/obj/item/weapon/storage/box/lights/tubes,/obj/item/weapon/storage/toolbox/electrical,/turf/open/floor/plating,/area/space)
+"ck" = (/obj/structure/rack,/obj/item/clothing/mask/gas,/turf/open/floor/plating,/area/space)
+"cl" = (/obj/structure/rack,/obj/item/clothing/suit/fire/firefighter,/obj/item/weapon/extinguisher,/turf/open/floor/plating,/area/space)
+"cm" = (/turf/open/floor/plasteel/darkblue/corner{tag = "icon-darkbluecorners (EAST)"; icon_state = "darkbluecorners"; dir = 4},/area/space)
+"cn" = (/obj/structure/girder/reinforced,/turf/open/space,/area/space)
+"co" = (/mob/living/simple_animal/hostile/asteroid/hivelord/legion,/turf/open/floor/plasteel,/area/space)
+"cp" = (/obj/item/ammo_casing/shotgun/buckshot,/turf/open/floor/plasteel,/area/space)
+"cq" = (/obj/structure/sign/directions/evac{tag = "icon-direction_evac (WEST)"; icon_state = "direction_evac"; dir = 8},/turf/closed/wall/r_wall,/area/space)
+"cr" = (/obj/structure/sink,/turf/closed/wall/r_wall,/area/space)
+"cs" = (/obj/structure/reagent_dispensers/water_cooler,/turf/open/floor/plasteel/darkblue,/area/space)
+"ct" = (/obj/structure/table,/obj/item/weapon/hand_labeler,/turf/open/floor/plasteel/darkblue,/area/space)
+"cu" = (/obj/structure/frame/computer,/turf/open/floor/plasteel/darkblue,/area/space)
+"cv" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/turf/open/space,/area/space)
+"cw" = (/obj/structure/girder/reinforced,/obj/effect/decal/cleanable/dirt{desc = "A thin layer of dust coating the floor."; name = "dust"},/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"cx" = (/obj/item/ammo_casing/n762,/turf/open/floor/plasteel,/area/space)
+"cy" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (NORTH)"; icon_state = "tracks"; dir = 1},/obj/item/ammo_casing/shotgun/buckshot,/turf/open/floor/plasteel,/area/space)
+"cz" = (/obj/machinery/door/firedoor/border_only{dir = 8},/turf/open/floor/plasteel/blue/corner{tag = "icon-bluecorner (EAST)"; icon_state = "bluecorner"; dir = 4},/area/space)
+"cA" = (/turf/open/floor/plasteel/blue/corner{tag = "icon-bluecorner (EAST)"; icon_state = "bluecorner"; dir = 4},/area/space)
+"cB" = (/obj/structure/closet/l3closet,/turf/open/floor/plasteel/blue/corner{tag = "icon-bluecorner (EAST)"; icon_state = "bluecorner"; dir = 4},/area/space)
+"cC" = (/obj/structure/sign/biohazard,/turf/closed/wall/r_wall,/area/space)
+"cD" = (/obj/machinery/shower{desc = "A showerhead found in school science labs and medbays alike, used to quickly wash off any dangerous fluids covering a person."; name = "emergency shower"; pixel_y = 15},/turf/open/floor/plasteel/white,/area/space)
+"cE" = (/turf/open/floor/plasteel/white,/area/space)
+"cF" = (/obj/item/weapon/soap/nanotrasen,/obj/structure/table,/turf/open/floor/plasteel/white,/area/space)
+"cG" = (/obj/structure/sign/xeno_warning_mining,/turf/closed/wall/r_wall,/area/space)
+"cH" = (/obj/item/weapon/shard{icon_state = "small"},/turf/open/floor/plasteel/darkblue/corner{tag = "icon-darkbluecorners (EAST)"; icon_state = "darkbluecorners"; dir = 4},/area/space)
+"cI" = (/obj/structure/grille,/obj/item/weapon/shard,/turf/open/floor/plating,/area/space)
+"cJ" = (/turf/open/floor/plasteel/darkblue,/area/space)
+"cK" = (/obj/item/weapon/paper/scp_research,/turf/open/floor/plating,/area/space)
+"cL" = (/mob/living/simple_animal/hostile/asteroid/basilisk/watcher,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/space)
+"cM" = (/obj/effect/decal/cleanable/dirt{desc = "A thin layer of dust coating the floor."; name = "dust"},/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (WEST)"; icon_state = "tracks"; dir = 8},/obj/effect/decal/cleanable/blood/gibs/limb,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"cN" = (/obj/effect/decal/cleanable/dirt{desc = "A thin layer of dust coating the floor."; name = "dust"},/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (WEST)"; icon_state = "tracks"; dir = 8},/obj/effect/decal/cleanable/blood,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"cO" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (SOUTHEAST)"; icon_state = "tracks"; dir = 6},/turf/open/floor/plasteel,/area/space)
+"cP" = (/obj/machinery/door/firedoor/border_only{dir = 8},/turf/open/floor/plasteel,/area/space)
+"cQ" = (/obj/machinery/door/airlock/science,/turf/open/floor/plasteel/white,/area/space)
+"cR" = (/obj/item/weapon/folder/blue{name = "Research Notes - Objects 15-20"},/turf/open/floor/plasteel/darkblue,/area/space)
+"cS" = (/obj/effect/decal/cleanable/dirt{desc = "A thin layer of dust coating the floor."; name = "dust"},/obj/effect/decal/cleanable/blood,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"cT" = (/turf/open/floor/plasteel/blue/corner{tag = "icon-bluecorner (WEST)"; icon_state = "bluecorner"; dir = 8},/area/space)
+"cU" = (/obj/machinery/door/firedoor/border_only{dir = 8},/turf/open/floor/plasteel/blue/corner,/area/space)
+"cV" = (/turf/open/floor/plasteel/blue/corner,/area/space)
+"cW" = (/obj/structure/closet/radiation,/turf/open/floor/plasteel/blue/corner,/area/space)
+"cX" = (/obj/structure/sign/radiation,/turf/closed/wall/r_wall,/area/space)
+"cY" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/space)
+"cZ" = (/obj/structure/sign/science,/turf/closed/wall/r_wall,/area/space)
+"da" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/darkblue/corner{tag = "icon-darkbluecorners (EAST)"; icon_state = "darkbluecorners"; dir = 4},/area/space)
+"db" = (/obj/structure/grille,/obj/structure/window/fulltile,/turf/open/floor/plating,/area/space)
+"dc" = (/obj/machinery/door/airlock/glass{name = "Staff Room"},/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dd" = (/obj/machinery/washing_machine,/turf/open/floor/plasteel/whiteblue/side,/area/space)
+"de" = (/obj/structure/bedsheetbin,/obj/structure/table,/turf/open/floor/plasteel/whiteblue/side,/area/space)
+"df" = (/obj/structure/sign/directions/engineering,/turf/closed/wall/r_wall,/area/space)
+"dg" = (/obj/structure/table,/obj/item/weapon/paper_bin,/obj/item/weapon/pen,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"dh" = (/obj/structure/table,/obj/item/weapon/reagent_containers/food/drinks/britcup,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
+"di" = (/obj/machinery/computer/arcade,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dj" = (/obj/machinery/vending/cigarette,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dk" = (/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dl" = (/obj/item/trash/chips,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dm" = (/obj/structure/filingcabinet/chestdrawer,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dn" = (/obj/effect/decal/cleanable/dirt,/obj/item/device/analyzer,/turf/open/floor/plasteel/black,/area/space)
+"do" = (/obj/structure/chair,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dp" = (/obj/structure/chair{dir = 4},/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dq" = (/obj/structure/table/glass,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dr" = (/obj/structure/table/glass,/obj/item/weapon/paper{info = "\[center]\[large]Anomalous Object Containment \[AOC] Site 21 \[/large]\[/center] \[br] \[center]Status Report on 11. 8. 2489 at 8:09 AM Lavaland Time\[/center] \[br] \[br] Nothing unusual to report. Seismic Warning System's blaring about a quake coming in soon, but Scott told me he'd fix it by the weekend. We've had to reschedule some experiments to the next Wednesday due to some broken equipment, but nothing major to worry about. \[br] Signed: Dr. James Walker"; name = "Status Report"},/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"ds" = (/obj/structure/table/glass,/obj/item/weapon/paper_bin,/obj/item/weapon/pen,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dt" = (/obj/structure/chair{dir = 8},/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"du" = (/obj/structure/table/glass,/obj/item/weapon/reagent_containers/food/drinks/coffee,/obj/item/clothing/mask/cigarette,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dv" = (/obj/machinery/status_display,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dw" = (/obj/structure/table/glass,/obj/item/weapon/storage/fancy/donut_box,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dx" = (/obj/item/trash/raisins,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dy" = (/obj/structure/table,/obj/machinery/microwave,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dz" = (/obj/structure/table,/obj/item/weapon/storage/box/donkpockets{pixel_y = 2; pixel_z = 2},/obj/item/weapon/storage/box/donkpockets,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dA" = (/obj/machinery/vending/coffee,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dB" = (/obj/machinery/vending/cola,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dC" = (/obj/machinery/vending/snack,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+"dD" = (/obj/structure/closet/wardrobe/science_white,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+
+(1,1,1) = {"
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababababababababababaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababacacacacacacacacacabababaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababacadadaeafagahahacabababaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababababacaiajakakakalamacababababaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababacacabababababacanaoapapapaqaracababababaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababacababababasatacanaoapapapaqauacababababaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababasasatatavawawawapapaqaxacabababababaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababatatatatatatasasawawapaqayacabababababaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababasatatatatatatatasasasasazawawacacabababababaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababatatatatatatasasasasasasasasasawatatatabababababaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababatatatatatasababacacacacasasasasasasatatabababababaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababatatatatatasasabaAaBaCaCaCavaDasasacasasatatabababababaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababasatatatatasasababaEaBaCaCaCawaDapasasasasatatatabababababaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaaaababacababasatatatatasasasababaEaFaGaGaGaHaIapacacaJaJasatatatasababababaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaabababababatatatatatasasasababaAaEaBaCaCaCawaKapacaEaLacasasatatasasababababaaaaaaaa
+aaaaaaaaaaaaaaaaabaaababababababasatatatatatasasasasababaAaBaBaCaCaCavaMaNacaOaEaEacasasatatasasabababaaaaaaaa
+aaaaaaaaaaaaabababababababababatatatatatatasasasasasabaAaEaBaCaCaCaCavaDapacaEaEaPacasasasatatasasabababaaaaaa
+aaaaaaaaababababababasasasatatatatatatatasasasasasasabababacacacacacacaDapabaEaEaEasasasasasatatatasababaaaaaa
+ataaaaababababababasatatatatatatatatasasasasasababababababaQaQaQaQaQaRapapabababababababababababatatabababaaaa
+ataaaaaaabababasatatatatatatatababababasasasasabababababaQaQaQaQaSaSababababababababababababababatatabababaaaa
+atatatatatababatatabababababababababababababababababacacacacaTavacacacabababacacacacacacababababatatasababaaaa
+atatatatababababababababababababababababababababababacaCaCaCaCaCaCaUacabababacaCaCaCaCawavabababatatasabababaa
+aaaaaaaaababababacacacaVacacacaAabacacabacacababababacaCaCaCaCaCaCaCacaWabaEacaCaCaXaCaCawawababatatasasababaa
+aaasasaaasasasasacaYaZbabbbcbdbdbeaAbfabababababababacaCaCaCbgaCaBaCacbhbiaEacaCaXaXaXaXaXaCacasasatasasababaa
+aaasasasasasasasazaQaQaQbjbkblblblblaEabababababababacaCaCaCaCbmaCaCazapbnbnboaCaCaXbpaXaCaCacasatatatasasabaa
+aaasasasasasasasbqaQaQbrbjbkbsaQblblbfabababababababacaCaCaCaCbmbmaCacaDapaQacaCaXaXaXaXaXaCacasatatatasasabaa
+aaaaasasasbtbubvbwbxbxbybzbAbBbCbsababababababacacabacaCaCaCaCaCaCaCacaDapaQacaCaCaCaXaCaXaCacasatatasasasabaa
+aaasasasasasasasbDacacacacacbsbEbsbFacacacacabacbGbHacaCaCaCaCaCaCaCacaDapbIacbJaCaCaCaCaCaCacasasatasasababaa
+aaasasasasasasaaabababababacbsbEbsacbKbLbMacabacbNapacacacacacacacacbOaDapbIacacacacacacacacacasatatasababaaaa
+aaaaasasasasaaaaaaababababacbPbEbQacbRaQbSacabacbTapacbUapaQapapbnbVapaQapaEbWababababababababasatasasababaaaa
+aaaaaaaaaaaaaaaaaaababababacbXbYaQaRaQaQbZacabacbnbnapapapcacbapaQaQapapbnccababababababababasasatatabababaaaa
+aaaaaaaaaaaaaaaaabababababacbscdceacaQaQaQacababababacapcfapcgcgcgcgcgchbnaEababababasasasasasatatababaaaaaaaa
+aaaaaaaaaaaaaaaaabababababacbscibPaccjckclacababababacapaQcmaccnacacacacacacabababasasasatatatatababaaaaaaaaaa
+aaaaaaaaaaaaaaaaabababacabaccobYcpcqacacacacacaccracacaQaQcmaccsctaQcucvabababasasasasatatatatababaaaaaaaaaaaa
+aaaaaaaaaaaaabababababababcwcxcybsczcAcAcAcBcCcDcEcFcGbnapcHcIcJcKcJcucvasascLasatatatatatatababaaaaaaaaaaaaaa
+aaaaaaaaaaabababababacababcMcNcObscPaQbsblbscQcEcEcEcQapapaQabcRcJcJcucvasasasatatatatatasababaaaaaaaaaaaaaaaa
+aaaaaaaaababababababababcwcSbdbscTcUcVaQcVcWcXcEcEcYcZbnbndaabavcJcJcucvasasasatatatababababaaaaaaaaaaaaaaaaaa
+aaaaaaababababababababacacacdbdcdbacacacacacacdddddedfbnbnaEabavawdgdhcvasasatatatababaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaabababacacacabababacdidjdkdkdldmdmacababacacacacacdnaAababababababababatatatababaaaaaaaaaaaaaaaaaaaaaaaaaa
+ababababbdbdbdbdabababacdkdkdodododkdkacababababababacaEaAabababababababatatatababaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+ababababacacacacabababacdkdpdqdrdsdtdkacababababababacaAabababababababatatabababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+abababababababababababacdkdpdudvdqdtdkacababababababacababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+abababababababababababacdkdpdwdqdqdtdkacabababababababababababaaaaabababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaabababaaabababacdkdkdkdkdkdxdkacabababababababababababaaaaaaaaababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabababacdydzdAdBdCdDdDacababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabababacacacacacacacacacababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaabababababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaababababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"}

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_scp_facility.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_scp_facility.dmm
@@ -1,239 +1,4005 @@
-"aa" = (/turf/template_noop,/area/space)
-"ab" = (/turf/closed/mineral/volcanic/lava_land_surface,/area/space)
-"ac" = (/turf/closed/wall/r_wall,/area/space)
-"ad" = (/obj/structure/rack,/obj/item/weapon/gun/energy/gun,/turf/open/floor/plasteel/black,/area/space)
-"ae" = (/obj/structure/table/reinforced,/obj/item/weapon/melee/baton/loaded{pixel_x = 2},/obj/item/weapon/melee/baton/loaded{pixel_x = -2},/turf/open/floor/plasteel/black,/area/space)
-"af" = (/obj/structure/table/reinforced,/obj/machinery/recharger,/turf/open/floor/plasteel/black,/area/space)
-"ag" = (/obj/structure/table/reinforced,/obj/item/ammo_box/magazine/smgm45,/obj/item/ammo_box/magazine/smgm45,/turf/open/floor/plasteel/black,/area/space)
-"ah" = (/obj/structure/rack,/obj/item/weapon/gun/projectile/automatic/c20r/sc_c20r,/turf/open/floor/plasteel/black,/area/space)
-"ai" = (/obj/structure/rack,/obj/item/clothing/suit/armor/laserproof,/obj/item/clothing/suit/armor/laserproof,/turf/open/floor/plasteel/black,/area/space)
-"aj" = (/turf/open/floor/plasteel/darkred/side{dir = 9},/area/space)
-"ak" = (/turf/open/floor/plasteel/darkred/side{tag = "icon-darkred (NORTH)"; icon_state = "darkred"; dir = 1},/area/space)
-"al" = (/turf/open/floor/plasteel/darkred/side{tag = "icon-darkred (NORTHEAST)"; icon_state = "darkred"; dir = 5},/area/space)
-"am" = (/obj/structure/rack,/obj/item/clothing/suit/armor/bulletproof,/turf/open/floor/plasteel/black,/area/space)
-"an" = (/obj/machinery/deployable/barrier,/turf/open/floor/plasteel/black,/area/space)
-"ao" = (/turf/open/floor/plasteel/darkred/side{tag = "icon-darkred (WEST)"; icon_state = "darkred"; dir = 8},/area/space)
-"ap" = (/turf/open/floor/plasteel/black,/area/space)
-"aq" = (/turf/open/floor/plasteel/darkred/side{tag = "icon-darkred (EAST)"; icon_state = "darkred"; dir = 4},/area/space)
-"ar" = (/obj/structure/rack,/turf/open/floor/plasteel/black,/area/space)
-"as" = (/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/space)
-"at" = (/turf/open/floor/plating/lava/smooth/lava_land_surface,/area/space)
-"au" = (/obj/structure/rack,/obj/item/weapon/storage/box/barriers,/turf/open/floor/plasteel/black,/area/space)
-"av" = (/obj/structure/girder/reinforced,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"aw" = (/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"ax" = (/obj/structure/rack,/obj/item/weapon/storage/box/handcuffs,/turf/open/floor/plasteel/black,/area/space)
-"ay" = (/obj/structure/rack,/obj/item/device/assembly/flash/handheld{pixel_x = -3; pixel_y = -1},/obj/item/device/assembly/flash/handheld{pixel_x = 3},/turf/open/floor/plasteel/black,/area/space)
-"az" = (/obj/machinery/door/airlock/highsecurity,/turf/open/space,/area/space)
-"aA" = (/obj/structure/girder/reinforced,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"aB" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/engine,/area/space)
-"aC" = (/turf/open/floor/engine,/area/space)
-"aD" = (/turf/open/floor/plasteel/darkred/corner{tag = "icon-darkredcorners (NORTH)"; icon_state = "darkredcorners"; dir = 1},/area/space)
-"aE" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"aF" = (/obj/effect/decal/cleanable/blood,/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (WEST)"; icon_state = "tracks"; dir = 8},/mob/living/simple_animal/hostile/faithless,/turf/open/floor/engine,/area/space)
-"aG" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (WEST)"; icon_state = "tracks"; dir = 8},/turf/open/floor/engine,/area/space)
-"aH" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (WEST)"; icon_state = "tracks"; dir = 8},/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"aI" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (NORTHEAST)"; icon_state = "tracks"; dir = 5},/turf/open/floor/plasteel/darkred/corner{tag = "icon-darkredcorners (NORTH)"; icon_state = "darkredcorners"; dir = 1},/area/space)
-"aJ" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/space)
-"aK" = (/obj/effect/decal/cleanable/blood/tracks,/turf/open/floor/plasteel/darkred/corner{tag = "icon-darkredcorners (NORTH)"; icon_state = "darkredcorners"; dir = 1},/area/space)
-"aL" = (/obj/effect/decal/cleanable/dirt,/obj/item/stack/tile/plasteel,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"aM" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (SOUTHWEST)"; icon_state = "tracks"; dir = 10},/turf/open/floor/plasteel/darkred/corner{tag = "icon-darkredcorners (NORTH)"; icon_state = "darkredcorners"; dir = 1},/area/space)
-"aN" = (/obj/effect/mob_spawn/human/corpse/nanotrasensoldier,/obj/effect/decal/cleanable/blood,/turf/open/floor/plasteel/black,/area/space)
-"aO" = (/obj/effect/decal/cleanable/dirt,/obj/item/stack/rods{amount = 50},/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"aP" = (/obj/effect/decal/cleanable/dirt,/obj/item/stack/rods,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"aQ" = (/turf/open/floor/plating,/area/space)
-"aR" = (/obj/machinery/door/airlock/maintenance,/turf/open/floor/plating,/area/space)
-"aS" = (/obj/structure/rack,/obj/effect/spawner/lootdrop/maintenance,/turf/open/floor/plating,/area/space)
-"aT" = (/obj/structure/girder/displaced,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"aU" = (/obj/effect/decal/cleanable/cobweb{tag = "icon-cobweb2"; icon_state = "cobweb2"},/turf/open/floor/engine,/area/space)
-"aV" = (/obj/structure/sign/kiddieplaque{desc = "WARNING. ACCESS IS LIMITED TO NANOTRASEN LEVEL 5-B PERSONNEL. IF YOU ARE NOT AUTHORIZED PERSONNEL AND ARE READING THIS, PLEASE INFORM YOUR LOCAL STATION COMMANDER OF A LEVEL XK-BREACH OF SITE- *the rest of the plaque is destroyed*"; name = "A dusty plaque"},/turf/closed/wall/r_wall,/area/space)
-"aW" = (/obj/structure/girder/displaced,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"aX" = (/turf/open/floor/plasteel/cult,/area/space)
-"aY" = (/obj/effect/decal/cleanable/cobweb,/obj/structure/table,/turf/open/floor/plating,/area/space)
-"aZ" = (/obj/structure/table,/obj/item/device/radio,/turf/open/floor/plating,/area/space)
-"ba" = (/obj/structure/table,/turf/open/floor/plating,/area/space)
-"bb" = (/obj/structure/frame/computer,/turf/open/floor/plating{dir = 4; icon_state = "warnplate"; luminosity = 2; initial_gas_mix = "o2=0.01;n2=0.01"; temperature = 2.7},/area/space)
-"bc" = (/obj/structure/sign/pods,/turf/closed/wall/r_wall,/area/space)
-"bd" = (/obj/effect/decal/cleanable/dirt{desc = "A thin layer of dust coating the floor."; name = "dust"},/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"be" = (/obj/item/stack/rods,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"bf" = (/obj/effect/decal/cleanable/dirt,/turf/closed/mineral/volcanic/lava_land_surface,/area/space)
-"bg" = (/mob/living/simple_animal/hostile/carp/eyeball{health = 75; maxHealth = 75; melee_damage_lower = 25; melee_damage_upper = 30},/turf/open/floor/engine,/area/space)
-"bh" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/darkred/corner{tag = "icon-darkredcorners (NORTH)"; icon_state = "darkredcorners"; dir = 1},/area/space)
-"bi" = (/obj/structure/girder/reinforced,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/dirt,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"bj" = (/turf/open/floor/plating{dir = 4; icon_state = "warnplate"; luminosity = 2; initial_gas_mix = "o2=0.01;n2=0.01"; temperature = 2.7},/area/space)
-"bk" = (/obj/machinery/door/poddoor/shutters,/turf/open/floor/plating,/area/space)
-"bl" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel,/area/space)
-"bm" = (/obj/effect/decal/cleanable/blood,/turf/open/floor/engine,/area/space)
-"bn" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/black,/area/space)
-"bo" = (/obj/machinery/door/airlock/highsecurity,/turf/closed/wall/r_wall,/area/space)
-"bp" = (/obj/item/clothing/suit/cultrobes,/obj/item/clothing/head/culthood,/obj/structure/table/reinforced,/turf/open/floor/plasteel/cult,/area/space)
-"bq" = (/obj/structure/girder/reinforced,/turf/open/floor/plating,/area/space)
-"br" = (/obj/item/stack/cable_coil/yellow,/turf/open/floor/plating,/area/space)
-"bs" = (/turf/open/floor/plasteel,/area/space)
-"bt" = (/obj/effect/decal/cleanable/blood,/obj/effect/decal/cleanable/blood/gibs/body,/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (EAST)"; icon_state = "tracks"; dir = 4},/obj/effect/mob_spawn/human/corpse/nanotrasensoldier,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/space)
-"bu" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (WEST)"; icon_state = "tracks"; dir = 8},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/space)
-"bv" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (EAST)"; icon_state = "tracks"; dir = 4},/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/space)
-"bw" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (EAST)"; icon_state = "tracks"; dir = 4},/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"bx" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (WEST)"; icon_state = "tracks"; dir = 8},/turf/open/floor/plating,/area/space)
-"by" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (EAST)"; icon_state = "tracks"; dir = 4},/turf/open/floor/plating,/area/space)
-"bz" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (EAST)"; icon_state = "tracks"; dir = 4},/turf/open/floor/plating{dir = 4; icon_state = "warnplate"; luminosity = 2; initial_gas_mix = "o2=0.01;n2=0.01"; temperature = 2.7},/area/space)
-"bA" = (/obj/item/stack/rods,/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (EAST)"; icon_state = "tracks"; dir = 4},/turf/open/floor/plating{icon_state = "platingdmg3"},/area/space)
-"bB" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (EAST)"; icon_state = "tracks"; dir = 4},/turf/open/floor/plasteel,/area/space)
-"bC" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (NORTHEAST)"; icon_state = "tracks"; dir = 5},/turf/open/floor/plasteel,/area/space)
-"bD" = (/obj/structure/sign/securearea,/turf/closed/wall/r_wall,/area/space)
-"bE" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (NORTH)"; icon_state = "tracks"; dir = 1},/turf/open/floor/plasteel,/area/space)
-"bF" = (/obj/structure/girder/reinforced,/obj/effect/decal/cleanable/dirt{desc = "A thin layer of dust coating the floor."; name = "dust"},/turf/closed/wall/r_wall,/area/space)
-"bG" = (/obj/machinery/recharge_station,/turf/open/floor/plasteel/black,/area/space)
-"bH" = (/obj/structure/table/reinforced,/obj/item/weapon/circuitboard/machine/cyborgrecharger,/obj/item/weapon/crowbar,/obj/item/weapon/weldingtool,/turf/open/floor/plasteel/black,/area/space)
-"bI" = (/turf/open/floor/plasteel/darkred/corner{tag = "icon-darkredcorners (EAST)"; icon_state = "darkredcorners"; dir = 4},/area/space)
-"bJ" = (/obj/structure/sign/directions/medical{dir = 4; icon_state = "direction_med"; pixel_x = -32; pixel_y = -24; tag = "icon-direction_med (EAST)"},/turf/open/floor/engine,/area/space)
-"bK" = (/obj/machinery/atmospherics/components/unary/tank/air,/turf/open/floor/plating,/area/space)
-"bL" = (/obj/structure/reagent_dispensers/watertank,/turf/open/floor/plating,/area/space)
-"bM" = (/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/plating,/area/space)
-"bN" = (/obj/effect/decal/cleanable/robot_debris/gib,/turf/open/floor/plasteel/black,/area/space)
-"bO" = (/obj/structure/sign/directions/evac{tag = "icon-direction_evac (NORTH)"; icon_state = "direction_evac"; dir = 1},/turf/closed/wall/r_wall,/area/space)
-"bP" = (/obj/effect/decal/cleanable/blood,/turf/open/floor/plasteel,/area/space)
-"bQ" = (/turf/open/floor/plasteel/yellow/corner,/area/space)
-"bR" = (/obj/item/trash/deadmouse,/turf/open/floor/plating,/area/space)
-"bS" = (/obj/machinery/doppler_array{desc = "A rusty old machine."; name = "Seismic Warning System"},/turf/open/floor/plating,/area/space)
-"bT" = (/obj/item/weapon/screwdriver,/turf/open/floor/plasteel/black,/area/space)
-"bU" = (/obj/effect/decal/cleanable/cobweb,/turf/open/floor/plasteel/black,/area/space)
-"bV" = (/obj/structure/sign/directions/security{dir = 1; icon_state = "direction_sec"; pixel_x = 32; pixel_y = 40; tag = "icon-direction_sec (NORTH)"},/turf/open/floor/plasteel/black,/area/space)
-"bW" = (/obj/structure/girder/reinforced,/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/blood,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"bX" = (/obj/item/ammo_casing/c9mm,/turf/open/floor/plasteel,/area/space)
-"bY" = (/obj/effect/decal/cleanable/blood/tracks,/turf/open/floor/plating,/area/space)
-"bZ" = (/obj/structure/frame/computer,/obj/item/weapon/paper{info = "THIS IS AN AUTOMATIC REPORT GENERATED BY THE SEISMIC WARNING SYSTEM (c). \[br] \[br] SLIGHT QUAKES HAVE BEEN DETECTED TO THE SOUTHEAST. OUR CURRENT ALGORITHM SUGGESTS THE SEISMIC INSTABILITY WILL SPREAD TO YOUR CURRENT LOCATION. \[br] \[br] WE PREDICT A 67.2% CHANCE OF A SIGNIFICANT EARTHQUAKE AT YOUR PRESENT LOCATION IN SIX TO TWELVE HOURS. PLEASE PROCEED WITH EARTHQUAKE THREAT PROTOCOL AS STATED IN PAGE 515 SECTION 61-X OF YOUR AOC SITE MANUAL."; name = "SEISMIC WARNING"},/turf/open/floor/plating,/area/space)
-"ca" = (/obj/effect/decal/cleanable/blood,/mob/living/simple_animal/hostile/asteroid/goliath,/turf/open/floor/plasteel/black,/area/space)
-"cb" = (/obj/effect/decal/cleanable/blood,/turf/open/floor/plasteel/black,/area/space)
-"cc" = (/obj/effect/decal/cleanable/dirt,/obj/effect/decal/cleanable/blood,/obj/effect/decal/cleanable/blood/gibs/body,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"cd" = (/obj/effect/decal/cleanable/blood/tracks,/obj/effect/decal/cleanable/blood,/turf/open/floor/plasteel,/area/space)
-"ce" = (/obj/item/ammo_casing/c9mm,/turf/open/floor/plating,/area/space)
-"cf" = (/obj/effect/decal/cleanable/blood/gibs/body,/turf/open/floor/plasteel/black,/area/space)
-"cg" = (/turf/open/floor/plasteel/darkblue/corner,/area/space)
-"ch" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/darkblue/corner,/area/space)
-"ci" = (/obj/effect/decal/cleanable/blood/tracks,/obj/item/ammo_casing/c9mm,/turf/open/floor/plasteel,/area/space)
-"cj" = (/obj/structure/rack,/obj/item/weapon/storage/box/lights/tubes,/obj/item/weapon/storage/toolbox/electrical,/turf/open/floor/plating,/area/space)
-"ck" = (/obj/structure/rack,/obj/item/clothing/mask/gas,/turf/open/floor/plating,/area/space)
-"cl" = (/obj/structure/rack,/obj/item/clothing/suit/fire/firefighter,/obj/item/weapon/extinguisher,/turf/open/floor/plating,/area/space)
-"cm" = (/turf/open/floor/plasteel/darkblue/corner{tag = "icon-darkbluecorners (EAST)"; icon_state = "darkbluecorners"; dir = 4},/area/space)
-"cn" = (/obj/structure/girder/reinforced,/turf/open/space,/area/space)
-"co" = (/mob/living/simple_animal/hostile/asteroid/hivelord/legion,/turf/open/floor/plasteel,/area/space)
-"cp" = (/obj/item/ammo_casing/shotgun/buckshot,/turf/open/floor/plasteel,/area/space)
-"cq" = (/obj/structure/sign/directions/evac{tag = "icon-direction_evac (WEST)"; icon_state = "direction_evac"; dir = 8},/turf/closed/wall/r_wall,/area/space)
-"cr" = (/obj/structure/sink,/turf/closed/wall/r_wall,/area/space)
-"cs" = (/obj/structure/reagent_dispensers/water_cooler,/turf/open/floor/plasteel/darkblue,/area/space)
-"ct" = (/obj/structure/table,/obj/item/weapon/hand_labeler,/turf/open/floor/plasteel/darkblue,/area/space)
-"cu" = (/obj/structure/frame/computer,/turf/open/floor/plasteel/darkblue,/area/space)
-"cv" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/turf/open/space,/area/space)
-"cw" = (/obj/structure/girder/reinforced,/obj/effect/decal/cleanable/dirt{desc = "A thin layer of dust coating the floor."; name = "dust"},/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"cx" = (/obj/item/ammo_casing/n762,/turf/open/floor/plasteel,/area/space)
-"cy" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (NORTH)"; icon_state = "tracks"; dir = 1},/obj/item/ammo_casing/shotgun/buckshot,/turf/open/floor/plasteel,/area/space)
-"cz" = (/obj/machinery/door/firedoor/border_only{dir = 8},/turf/open/floor/plasteel/blue/corner{tag = "icon-bluecorner (EAST)"; icon_state = "bluecorner"; dir = 4},/area/space)
-"cA" = (/turf/open/floor/plasteel/blue/corner{tag = "icon-bluecorner (EAST)"; icon_state = "bluecorner"; dir = 4},/area/space)
-"cB" = (/obj/structure/closet/l3closet,/turf/open/floor/plasteel/blue/corner{tag = "icon-bluecorner (EAST)"; icon_state = "bluecorner"; dir = 4},/area/space)
-"cC" = (/obj/structure/sign/biohazard,/turf/closed/wall/r_wall,/area/space)
-"cD" = (/obj/machinery/shower{desc = "A showerhead found in school science labs and medbays alike, used to quickly wash off any dangerous fluids covering a person."; name = "emergency shower"; pixel_y = 15},/turf/open/floor/plasteel/white,/area/space)
-"cE" = (/turf/open/floor/plasteel/white,/area/space)
-"cF" = (/obj/item/weapon/soap/nanotrasen,/obj/structure/table,/turf/open/floor/plasteel/white,/area/space)
-"cG" = (/obj/structure/sign/xeno_warning_mining,/turf/closed/wall/r_wall,/area/space)
-"cH" = (/obj/item/weapon/shard{icon_state = "small"},/turf/open/floor/plasteel/darkblue/corner{tag = "icon-darkbluecorners (EAST)"; icon_state = "darkbluecorners"; dir = 4},/area/space)
-"cI" = (/obj/structure/grille,/obj/item/weapon/shard,/turf/open/floor/plating,/area/space)
-"cJ" = (/turf/open/floor/plasteel/darkblue,/area/space)
-"cK" = (/obj/item/weapon/paper/scp_research,/turf/open/floor/plating,/area/space)
-"cL" = (/mob/living/simple_animal/hostile/asteroid/basilisk/watcher,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/space)
-"cM" = (/obj/effect/decal/cleanable/dirt{desc = "A thin layer of dust coating the floor."; name = "dust"},/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (WEST)"; icon_state = "tracks"; dir = 8},/obj/effect/decal/cleanable/blood/gibs/limb,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"cN" = (/obj/effect/decal/cleanable/dirt{desc = "A thin layer of dust coating the floor."; name = "dust"},/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (WEST)"; icon_state = "tracks"; dir = 8},/obj/effect/decal/cleanable/blood,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"cO" = (/obj/effect/decal/cleanable/blood/tracks{tag = "icon-tracks (SOUTHEAST)"; icon_state = "tracks"; dir = 6},/turf/open/floor/plasteel,/area/space)
-"cP" = (/obj/machinery/door/firedoor/border_only{dir = 8},/turf/open/floor/plasteel,/area/space)
-"cQ" = (/obj/machinery/door/airlock/science,/turf/open/floor/plasteel/white,/area/space)
-"cR" = (/obj/item/weapon/folder/blue{name = "Research Notes - Objects 15-20"},/turf/open/floor/plasteel/darkblue,/area/space)
-"cS" = (/obj/effect/decal/cleanable/dirt{desc = "A thin layer of dust coating the floor."; name = "dust"},/obj/effect/decal/cleanable/blood,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"cT" = (/turf/open/floor/plasteel/blue/corner{tag = "icon-bluecorner (WEST)"; icon_state = "bluecorner"; dir = 8},/area/space)
-"cU" = (/obj/machinery/door/firedoor/border_only{dir = 8},/turf/open/floor/plasteel/blue/corner,/area/space)
-"cV" = (/turf/open/floor/plasteel/blue/corner,/area/space)
-"cW" = (/obj/structure/closet/radiation,/turf/open/floor/plasteel/blue/corner,/area/space)
-"cX" = (/obj/structure/sign/radiation,/turf/closed/wall/r_wall,/area/space)
-"cY" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/white,/area/space)
-"cZ" = (/obj/structure/sign/science,/turf/closed/wall/r_wall,/area/space)
-"da" = (/obj/effect/decal/cleanable/dirt,/turf/open/floor/plasteel/darkblue/corner{tag = "icon-darkbluecorners (EAST)"; icon_state = "darkbluecorners"; dir = 4},/area/space)
-"db" = (/obj/structure/grille,/obj/structure/window/fulltile,/turf/open/floor/plating,/area/space)
-"dc" = (/obj/machinery/door/airlock/glass{name = "Staff Room"},/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dd" = (/obj/machinery/washing_machine,/turf/open/floor/plasteel/whiteblue/side,/area/space)
-"de" = (/obj/structure/bedsheetbin,/obj/structure/table,/turf/open/floor/plasteel/whiteblue/side,/area/space)
-"df" = (/obj/structure/sign/directions/engineering,/turf/closed/wall/r_wall,/area/space)
-"dg" = (/obj/structure/table,/obj/item/weapon/paper_bin,/obj/item/weapon/pen,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"dh" = (/obj/structure/table,/obj/item/weapon/reagent_containers/food/drinks/britcup,/turf/open/floor/plating{icon_state = "panelscorched"},/area/space)
-"di" = (/obj/machinery/computer/arcade,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dj" = (/obj/machinery/vending/cigarette,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dk" = (/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dl" = (/obj/item/trash/chips,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dm" = (/obj/structure/filingcabinet/chestdrawer,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dn" = (/obj/effect/decal/cleanable/dirt,/obj/item/device/analyzer,/turf/open/floor/plasteel/black,/area/space)
-"do" = (/obj/structure/chair,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dp" = (/obj/structure/chair{dir = 4},/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dq" = (/obj/structure/table/glass,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dr" = (/obj/structure/table/glass,/obj/item/weapon/paper{info = "\[center]\[large]Anomalous Object Containment \[AOC] Site 21 \[/large]\[/center] \[br] \[center]Status Report on 11. 8. 2489 at 8:09 AM Lavaland Time\[/center] \[br] \[br] Nothing unusual to report. Seismic Warning System's blaring about a quake coming in soon, but Scott told me he'd fix it by the weekend. We've had to reschedule some experiments to the next Wednesday due to some broken equipment, but nothing major to worry about. \[br] Signed: Dr. James Walker"; name = "Status Report"},/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"ds" = (/obj/structure/table/glass,/obj/item/weapon/paper_bin,/obj/item/weapon/pen,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dt" = (/obj/structure/chair{dir = 8},/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"du" = (/obj/structure/table/glass,/obj/item/weapon/reagent_containers/food/drinks/coffee,/obj/item/clothing/mask/cigarette,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dv" = (/obj/machinery/status_display,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dw" = (/obj/structure/table/glass,/obj/item/weapon/storage/fancy/donut_box,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dx" = (/obj/item/trash/raisins,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dy" = (/obj/structure/table,/obj/machinery/microwave,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dz" = (/obj/structure/table,/obj/item/weapon/storage/box/donkpockets{pixel_y = 2; pixel_z = 2},/obj/item/weapon/storage/box/donkpockets,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dA" = (/obj/machinery/vending/coffee,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dB" = (/obj/machinery/vending/cola,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dC" = (/obj/machinery/vending/snack,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
-"dD" = (/obj/structure/closet/wardrobe/science_white,/turf/open/floor/plasteel{icon_state = "barber"},/area/space)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+"aa" = (
+/turf/template_noop,
+/area/template_noop)
+"ab" = (
+/turf/closed/mineral/volcanic/lava_land_surface,
+/area/ruin/unpowered)
+"ac" = (
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered)
+"ad" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/energy/gun,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"ae" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/melee/baton/loaded{
+	pixel_x = 2
+	},
+/obj/item/weapon/melee/baton/loaded{
+	pixel_x = -2
+	},
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"af" = (
+/obj/structure/table/reinforced,
+/obj/machinery/recharger,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"ag" = (
+/obj/structure/table/reinforced,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/ammo_box/magazine/smgm45,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"ah" = (
+/obj/structure/rack,
+/obj/item/weapon/gun/projectile/automatic/c20r/sc_c20r,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"ai" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/laserproof,
+/obj/item/clothing/suit/armor/laserproof,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"aj" = (
+/turf/open/floor/plasteel/darkred/side{
+	dir = 9
+	},
+/area/ruin/unpowered)
+"ak" = (
+/turf/open/floor/plasteel/darkred/side{
+	tag = "icon-darkred (NORTH)";
+	icon_state = "darkred";
+	dir = 1
+	},
+/area/ruin/unpowered)
+"al" = (
+/turf/open/floor/plasteel/darkred/side{
+	tag = "icon-darkred (NORTHEAST)";
+	icon_state = "darkred";
+	dir = 5
+	},
+/area/ruin/unpowered)
+"am" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"an" = (
+/obj/machinery/deployable/barrier,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"ao" = (
+/turf/open/floor/plasteel/darkred/side{
+	tag = "icon-darkred (WEST)";
+	icon_state = "darkred";
+	dir = 8
+	},
+/area/ruin/unpowered)
+"ap" = (
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"aq" = (
+/turf/open/floor/plasteel/darkred/side{
+	tag = "icon-darkred (EAST)";
+	icon_state = "darkred";
+	dir = 4
+	},
+/area/ruin/unpowered)
+"ar" = (
+/obj/structure/rack,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"as" = (
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered)
+"at" = (
+/turf/open/floor/plating/lava/smooth/lava_land_surface,
+/area/ruin/unpowered)
+"au" = (
+/obj/structure/rack,
+/obj/item/weapon/storage/box/barriers,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"av" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"aw" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"ax" = (
+/obj/structure/rack,
+/obj/item/weapon/storage/box/handcuffs,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"ay" = (
+/obj/structure/rack,
+/obj/item/device/assembly/flash/handheld{
+	pixel_x = -3;
+	pixel_y = -1
+	},
+/obj/item/device/assembly/flash/handheld{
+	pixel_x = 3
+	},
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"az" = (
+/obj/machinery/door/airlock/highsecurity,
+/turf/open/space,
+/area/ruin/unpowered)
+"aA" = (
+/obj/structure/girder/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"aB" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/ruin/unpowered)
+"aC" = (
+/turf/open/floor/engine,
+/area/ruin/unpowered)
+"aD" = (
+/turf/open/floor/plasteel/darkred/corner{
+	tag = "icon-darkredcorners (NORTH)";
+	icon_state = "darkredcorners";
+	dir = 1
+	},
+/area/ruin/unpowered)
+"aE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"aF" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (WEST)";
+	icon_state = "tracks";
+	dir = 8
+	},
+/mob/living/simple_animal/hostile/faithless,
+/turf/open/floor/engine,
+/area/ruin/unpowered)
+"aG" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (WEST)";
+	icon_state = "tracks";
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/ruin/unpowered)
+"aH" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (WEST)";
+	icon_state = "tracks";
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"aI" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (NORTHEAST)";
+	icon_state = "tracks";
+	dir = 5
+	},
+/turf/open/floor/plasteel/darkred/corner{
+	tag = "icon-darkredcorners (NORTH)";
+	icon_state = "darkredcorners";
+	dir = 1
+	},
+/area/ruin/unpowered)
+"aJ" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered)
+"aK" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plasteel/darkred/corner{
+	tag = "icon-darkredcorners (NORTH)";
+	icon_state = "darkredcorners";
+	dir = 1
+	},
+/area/ruin/unpowered)
+"aL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/tile/plasteel,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"aM" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (SOUTHWEST)";
+	icon_state = "tracks";
+	dir = 10
+	},
+/turf/open/floor/plasteel/darkred/corner{
+	tag = "icon-darkredcorners (NORTH)";
+	icon_state = "darkredcorners";
+	dir = 1
+	},
+/area/ruin/unpowered)
+"aN" = (
+/obj/effect/mob_spawn/human/corpse/nanotrasensoldier,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"aO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/rods{
+	amount = 50
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"aP" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/stack/rods,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"aQ" = (
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"aR" = (
+/obj/machinery/door/airlock/maintenance,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"aS" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"aT" = (
+/obj/structure/girder/displaced,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"aU" = (
+/obj/effect/decal/cleanable/cobweb{
+	tag = "icon-cobweb2";
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/engine,
+/area/ruin/unpowered)
+"aV" = (
+/obj/structure/sign/kiddieplaque{
+	desc = "WARNING. ACCESS IS LIMITED TO NANOTRASEN LEVEL 5-B PERSONNEL. IF YOU ARE NOT AUTHORIZED PERSONNEL AND ARE READING THIS, PLEASE INFORM YOUR LOCAL STATION COMMANDER OF A LEVEL XK-BREACH OF SITE- *the rest of the plaque is destroyed*";
+	name = "A dusty plaque"
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered)
+"aW" = (
+/obj/structure/girder/displaced,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"aX" = (
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"aY" = (
+/obj/effect/decal/cleanable/cobweb,
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"aZ" = (
+/obj/structure/table,
+/obj/item/device/radio,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"ba" = (
+/obj/structure/table,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"bb" = (
+/obj/structure/frame/computer,
+/turf/open/floor/plating{
+	dir = 4;
+	icon_state = "warnplate";
+	luminosity = 2;
+	initial_gas_mix = "o2=0.01;n2=0.01";
+	temperature = 2.7
+	},
+/area/ruin/unpowered)
+"bc" = (
+/obj/structure/sign/pods,
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered)
+"bd" = (
+/obj/effect/decal/cleanable/dirt{
+	desc = "A thin layer of dust coating the floor.";
+	name = "dust"
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"be" = (
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"bf" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/mineral/volcanic/lava_land_surface,
+/area/ruin/unpowered)
+"bg" = (
+/mob/living/simple_animal/hostile/carp/eyeball{
+	health = 75;
+	maxHealth = 75;
+	melee_damage_lower = 25;
+	melee_damage_upper = 30
+	},
+/turf/open/floor/engine,
+/area/ruin/unpowered)
+"bh" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkred/corner{
+	tag = "icon-darkredcorners (NORTH)";
+	icon_state = "darkredcorners";
+	dir = 1
+	},
+/area/ruin/unpowered)
+"bi" = (
+/obj/structure/girder/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"bj" = (
+/turf/open/floor/plating{
+	dir = 4;
+	icon_state = "warnplate";
+	luminosity = 2;
+	initial_gas_mix = "o2=0.01;n2=0.01";
+	temperature = 2.7
+	},
+/area/ruin/unpowered)
+"bk" = (
+/obj/machinery/door/poddoor/shutters,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"bl" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"bm" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/engine,
+/area/ruin/unpowered)
+"bn" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"bo" = (
+/obj/machinery/door/airlock/highsecurity,
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered)
+"bp" = (
+/obj/item/clothing/suit/cultrobes,
+/obj/item/clothing/head/culthood,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/cult,
+/area/ruin/unpowered)
+"bq" = (
+/obj/structure/girder/reinforced,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"br" = (
+/obj/item/stack/cable_coil/yellow,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"bs" = (
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"bt" = (
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (EAST)";
+	icon_state = "tracks";
+	dir = 4
+	},
+/obj/effect/mob_spawn/human/corpse/nanotrasensoldier,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered)
+"bu" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (WEST)";
+	icon_state = "tracks";
+	dir = 8
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered)
+"bv" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (EAST)";
+	icon_state = "tracks";
+	dir = 4
+	},
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered)
+"bw" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (EAST)";
+	icon_state = "tracks";
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"bx" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (WEST)";
+	icon_state = "tracks";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"by" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (EAST)";
+	icon_state = "tracks";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"bz" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (EAST)";
+	icon_state = "tracks";
+	dir = 4
+	},
+/turf/open/floor/plating{
+	dir = 4;
+	icon_state = "warnplate";
+	luminosity = 2;
+	initial_gas_mix = "o2=0.01;n2=0.01";
+	temperature = 2.7
+	},
+/area/ruin/unpowered)
+"bA" = (
+/obj/item/stack/rods,
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (EAST)";
+	icon_state = "tracks";
+	dir = 4
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/ruin/unpowered)
+"bB" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (EAST)";
+	icon_state = "tracks";
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"bC" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (NORTHEAST)";
+	icon_state = "tracks";
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"bD" = (
+/obj/structure/sign/securearea,
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered)
+"bE" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (NORTH)";
+	icon_state = "tracks";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"bF" = (
+/obj/structure/girder/reinforced,
+/obj/effect/decal/cleanable/dirt{
+	desc = "A thin layer of dust coating the floor.";
+	name = "dust"
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered)
+"bG" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"bH" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/circuitboard/machine/cyborgrecharger,
+/obj/item/weapon/crowbar,
+/obj/item/weapon/weldingtool,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"bI" = (
+/turf/open/floor/plasteel/darkred/corner{
+	tag = "icon-darkredcorners (EAST)";
+	icon_state = "darkredcorners";
+	dir = 4
+	},
+/area/ruin/unpowered)
+"bJ" = (
+/obj/structure/sign/directions/medical{
+	dir = 4;
+	icon_state = "direction_med";
+	pixel_x = -32;
+	pixel_y = -24;
+	tag = "icon-direction_med (EAST)"
+	},
+/turf/open/floor/engine,
+/area/ruin/unpowered)
+"bK" = (
+/obj/machinery/atmospherics/components/unary/tank/air,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"bL" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"bM" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"bN" = (
+/obj/effect/decal/cleanable/robot_debris/gib,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"bO" = (
+/obj/structure/sign/directions/evac{
+	tag = "icon-direction_evac (NORTH)";
+	icon_state = "direction_evac";
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered)
+"bP" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"bQ" = (
+/turf/open/floor/plasteel/yellow/corner,
+/area/ruin/unpowered)
+"bR" = (
+/obj/item/trash/deadmouse,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"bS" = (
+/obj/machinery/doppler_array{
+	desc = "A rusty old machine.";
+	name = "Seismic Warning System"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"bT" = (
+/obj/item/weapon/screwdriver,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"bU" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"bV" = (
+/obj/structure/sign/directions/security{
+	dir = 1;
+	icon_state = "direction_sec";
+	pixel_x = 32;
+	pixel_y = 40;
+	tag = "icon-direction_sec (NORTH)"
+	},
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"bW" = (
+/obj/structure/girder/reinforced,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"bX" = (
+/obj/item/ammo_casing/c9mm,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"bY" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"bZ" = (
+/obj/structure/frame/computer,
+/obj/item/weapon/paper{
+	info = "THIS IS AN AUTOMATIC REPORT GENERATED BY THE SEISMIC WARNING SYSTEM (c). \[br] \[br] SLIGHT QUAKES HAVE BEEN DETECTED TO THE SOUTHEAST. OUR CURRENT ALGORITHM SUGGESTS THE SEISMIC INSTABILITY WILL SPREAD TO YOUR CURRENT LOCATION. \[br] \[br] WE PREDICT A 67.2% CHANCE OF A SIGNIFICANT EARTHQUAKE AT YOUR PRESENT LOCATION IN SIX TO TWELVE HOURS. PLEASE PROCEED WITH EARTHQUAKE THREAT PROTOCOL AS STATED IN PAGE 515 SECTION 61-X OF YOUR AOC SITE MANUAL.";
+	name = "SEISMIC WARNING"
+	},
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"ca" = (
+/obj/effect/decal/cleanable/blood,
+/mob/living/simple_animal/hostile/asteroid/goliath,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"cb" = (
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"cc" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/blood,
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"cd" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"ce" = (
+/obj/item/ammo_casing/c9mm,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"cf" = (
+/obj/effect/decal/cleanable/blood/gibs/body,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"cg" = (
+/turf/open/floor/plasteel/darkblue/corner,
+/area/ruin/unpowered)
+"ch" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkblue/corner,
+/area/ruin/unpowered)
+"ci" = (
+/obj/effect/decal/cleanable/blood/tracks,
+/obj/item/ammo_casing/c9mm,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"cj" = (
+/obj/structure/rack,
+/obj/item/weapon/storage/box/lights/tubes,
+/obj/item/weapon/storage/toolbox/electrical,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"ck" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"cl" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/fire/firefighter,
+/obj/item/weapon/extinguisher,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"cm" = (
+/turf/open/floor/plasteel/darkblue/corner{
+	tag = "icon-darkbluecorners (EAST)";
+	icon_state = "darkbluecorners";
+	dir = 4
+	},
+/area/ruin/unpowered)
+"cn" = (
+/obj/structure/girder/reinforced,
+/turf/open/space,
+/area/ruin/unpowered)
+"co" = (
+/mob/living/simple_animal/hostile/asteroid/hivelord/legion,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"cp" = (
+/obj/item/ammo_casing/shotgun/buckshot,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"cq" = (
+/obj/structure/sign/directions/evac{
+	tag = "icon-direction_evac (WEST)";
+	icon_state = "direction_evac";
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered)
+"cr" = (
+/obj/structure/sink,
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered)
+"cs" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/plasteel/darkblue,
+/area/ruin/unpowered)
+"ct" = (
+/obj/structure/table,
+/obj/item/weapon/hand_labeler,
+/turf/open/floor/plasteel/darkblue,
+/area/ruin/unpowered)
+"cu" = (
+/obj/structure/frame/computer,
+/turf/open/floor/plasteel/darkblue,
+/area/ruin/unpowered)
+"cv" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/space,
+/area/ruin/unpowered)
+"cw" = (
+/obj/structure/girder/reinforced,
+/obj/effect/decal/cleanable/dirt{
+	desc = "A thin layer of dust coating the floor.";
+	name = "dust"
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"cx" = (
+/obj/item/ammo_casing/n762,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"cy" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (NORTH)";
+	icon_state = "tracks";
+	dir = 1
+	},
+/obj/item/ammo_casing/shotgun/buckshot,
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"cz" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/blue/corner{
+	tag = "icon-bluecorner (EAST)";
+	icon_state = "bluecorner";
+	dir = 4
+	},
+/area/ruin/unpowered)
+"cA" = (
+/turf/open/floor/plasteel/blue/corner{
+	tag = "icon-bluecorner (EAST)";
+	icon_state = "bluecorner";
+	dir = 4
+	},
+/area/ruin/unpowered)
+"cB" = (
+/obj/structure/closet/l3closet,
+/turf/open/floor/plasteel/blue/corner{
+	tag = "icon-bluecorner (EAST)";
+	icon_state = "bluecorner";
+	dir = 4
+	},
+/area/ruin/unpowered)
+"cC" = (
+/obj/structure/sign/biohazard,
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered)
+"cD" = (
+/obj/machinery/shower{
+	desc = "A showerhead found in school science labs and medbays alike, used to quickly wash off any dangerous fluids covering a person.";
+	name = "emergency shower";
+	pixel_y = 15
+	},
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"cE" = (
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"cF" = (
+/obj/item/weapon/soap/nanotrasen,
+/obj/structure/table,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"cG" = (
+/obj/structure/sign/xeno_warning_mining,
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered)
+"cH" = (
+/obj/item/weapon/shard{
+	icon_state = "small"
+	},
+/turf/open/floor/plasteel/darkblue/corner{
+	tag = "icon-darkbluecorners (EAST)";
+	icon_state = "darkbluecorners";
+	dir = 4
+	},
+/area/ruin/unpowered)
+"cI" = (
+/obj/structure/grille,
+/obj/item/weapon/shard,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"cJ" = (
+/turf/open/floor/plasteel/darkblue,
+/area/ruin/unpowered)
+"cK" = (
+/obj/item/weapon/paper/scp_research,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"cL" = (
+/mob/living/simple_animal/hostile/asteroid/basilisk/watcher,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered)
+"cM" = (
+/obj/effect/decal/cleanable/dirt{
+	desc = "A thin layer of dust coating the floor.";
+	name = "dust"
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (WEST)";
+	icon_state = "tracks";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood/gibs/limb,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"cN" = (
+/obj/effect/decal/cleanable/dirt{
+	desc = "A thin layer of dust coating the floor.";
+	name = "dust"
+	},
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (WEST)";
+	icon_state = "tracks";
+	dir = 8
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"cO" = (
+/obj/effect/decal/cleanable/blood/tracks{
+	tag = "icon-tracks (SOUTHEAST)";
+	icon_state = "tracks";
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"cP" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ruin/unpowered)
+"cQ" = (
+/obj/machinery/door/airlock/science,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"cR" = (
+/obj/item/weapon/folder/blue{
+	name = "Research Notes - Objects 15-20"
+	},
+/turf/open/floor/plasteel/darkblue,
+/area/ruin/unpowered)
+"cS" = (
+/obj/effect/decal/cleanable/dirt{
+	desc = "A thin layer of dust coating the floor.";
+	name = "dust"
+	},
+/obj/effect/decal/cleanable/blood,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"cT" = (
+/turf/open/floor/plasteel/blue/corner{
+	tag = "icon-bluecorner (WEST)";
+	icon_state = "bluecorner";
+	dir = 8
+	},
+/area/ruin/unpowered)
+"cU" = (
+/obj/machinery/door/firedoor/border_only{
+	dir = 8
+	},
+/turf/open/floor/plasteel/blue/corner,
+/area/ruin/unpowered)
+"cV" = (
+/turf/open/floor/plasteel/blue/corner,
+/area/ruin/unpowered)
+"cW" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel/blue/corner,
+/area/ruin/unpowered)
+"cX" = (
+/obj/structure/sign/radiation,
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered)
+"cY" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/white,
+/area/ruin/unpowered)
+"cZ" = (
+/obj/structure/sign/science,
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered)
+"da" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plasteel/darkblue/corner{
+	tag = "icon-darkbluecorners (EAST)";
+	icon_state = "darkbluecorners";
+	dir = 4
+	},
+/area/ruin/unpowered)
+"db" = (
+/obj/structure/grille,
+/obj/structure/window/fulltile,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
+"dc" = (
+/obj/machinery/door/airlock/glass{
+	name = "Staff Room"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dd" = (
+/obj/machinery/washing_machine,
+/turf/open/floor/plasteel/whiteblue/side,
+/area/ruin/unpowered)
+"de" = (
+/obj/structure/bedsheetbin,
+/obj/structure/table,
+/turf/open/floor/plasteel/whiteblue/side,
+/area/ruin/unpowered)
+"df" = (
+/obj/structure/sign/directions/engineering,
+/turf/closed/wall/r_wall,
+/area/ruin/unpowered)
+"dg" = (
+/obj/structure/table,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"dh" = (
+/obj/structure/table,
+/obj/item/weapon/reagent_containers/food/drinks/britcup,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/ruin/unpowered)
+"di" = (
+/obj/machinery/computer/arcade,
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dj" = (
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dk" = (
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dl" = (
+/obj/item/trash/chips,
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dm" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dn" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/device/analyzer,
+/turf/open/floor/plasteel/black,
+/area/ruin/unpowered)
+"do" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dp" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dq" = (
+/obj/structure/table/glass,
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dr" = (
+/obj/structure/table/glass,
+/obj/item/weapon/paper{
+	info = "\[center]\[large]Anomalous Object Containment \[AOC] Site 21 \[/large]\[/center] \[br] \[center]Status Report on 11. 8. 2489 at 8:09 AM Lavaland Time\[/center] \[br] \[br] Nothing unusual to report. Seismic Warning System's blaring about a quake coming in soon, but Scott told me he'd fix it by the weekend. We've had to reschedule some experiments to the next Wednesday due to some broken equipment, but nothing major to worry about. \[br] Signed: Dr. James Walker";
+	name = "Status Report"
+	},
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"ds" = (
+/obj/structure/table/glass,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dt" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"du" = (
+/obj/structure/table/glass,
+/obj/item/weapon/reagent_containers/food/drinks/coffee,
+/obj/item/clothing/mask/cigarette,
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dv" = (
+/obj/machinery/status_display,
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dw" = (
+/obj/structure/table/glass,
+/obj/item/weapon/storage/fancy/donut_box,
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dx" = (
+/obj/item/trash/raisins,
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dy" = (
+/obj/structure/table,
+/obj/machinery/microwave,
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dz" = (
+/obj/structure/table,
+/obj/item/weapon/storage/box/donkpockets{
+	pixel_y = 2;
+	pixel_z = 2
+	},
+/obj/item/weapon/storage/box/donkpockets,
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dA" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dB" = (
+/obj/machinery/vending/cola,
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dC" = (
+/obj/machinery/vending/snack,
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
+"dD" = (
+/obj/structure/closet/wardrobe/science_white,
+/turf/open/floor/plasteel{
+	icon_state = "barber"
+	},
+/area/ruin/unpowered)
 
 (1,1,1) = {"
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababababababababababaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababacacacacacacacacacabababaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababacadadaeafagahahacabababaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababababacaiajakakakalamacababababaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababacacabababababacanaoapapapaqaracababababaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababacababababasatacanaoapapapaqauacababababaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababasasatatavawawawapapaqaxacabababababaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababababatatatatatatasasawawapaqayacabababababaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababasatatatatatatatasasasasazawawacacabababababaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababatatatatatatasasasasasasasasasawatatatabababababaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababatatatatatasababacacacacasasasasasasatatabababababaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababatatatatatasasabaAaBaCaCaCavaDasasacasasatatabababababaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabababababasatatatatasasababaEaBaCaCaCawaDapasasasasatatatabababababaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaaaababacababasatatatatasasasababaEaFaGaGaGaHaIapacacaJaJasatatatasababababaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaabababababatatatatatasasasababaAaEaBaCaCaCawaKapacaEaLacasasatatasasababababaaaaaaaa
-aaaaaaaaaaaaaaaaabaaababababababasatatatatatasasasasababaAaBaBaCaCaCavaMaNacaOaEaEacasasatatasasabababaaaaaaaa
-aaaaaaaaaaaaabababababababababatatatatatatasasasasasabaAaEaBaCaCaCaCavaDapacaEaEaPacasasasatatasasabababaaaaaa
-aaaaaaaaababababababasasasatatatatatatatasasasasasasabababacacacacacacaDapabaEaEaEasasasasasatatatasababaaaaaa
-ataaaaababababababasatatatatatatatatasasasasasababababababaQaQaQaQaQaRapapabababababababababababatatabababaaaa
-ataaaaaaabababasatatatatatatatababababasasasasabababababaQaQaQaQaSaSababababababababababababababatatabababaaaa
-atatatatatababatatabababababababababababababababababacacacacaTavacacacabababacacacacacacababababatatasababaaaa
-atatatatababababababababababababababababababababababacaCaCaCaCaCaCaUacabababacaCaCaCaCawavabababatatasabababaa
-aaaaaaaaababababacacacaVacacacaAabacacabacacababababacaCaCaCaCaCaCaCacaWabaEacaCaCaXaCaCawawababatatasasababaa
-aaasasaaasasasasacaYaZbabbbcbdbdbeaAbfabababababababacaCaCaCbgaCaBaCacbhbiaEacaCaXaXaXaXaXaCacasasatasasababaa
-aaasasasasasasasazaQaQaQbjbkblblblblaEabababababababacaCaCaCaCbmaCaCazapbnbnboaCaCaXbpaXaCaCacasatatatasasabaa
-aaasasasasasasasbqaQaQbrbjbkbsaQblblbfabababababababacaCaCaCaCbmbmaCacaDapaQacaCaXaXaXaXaXaCacasatatatasasabaa
-aaaaasasasbtbubvbwbxbxbybzbAbBbCbsababababababacacabacaCaCaCaCaCaCaCacaDapaQacaCaCaCaXaCaXaCacasatatasasasabaa
-aaasasasasasasasbDacacacacacbsbEbsbFacacacacabacbGbHacaCaCaCaCaCaCaCacaDapbIacbJaCaCaCaCaCaCacasasatasasababaa
-aaasasasasasasaaabababababacbsbEbsacbKbLbMacabacbNapacacacacacacacacbOaDapbIacacacacacacacacacasatatasababaaaa
-aaaaasasasasaaaaaaababababacbPbEbQacbRaQbSacabacbTapacbUapaQapapbnbVapaQapaEbWababababababababasatasasababaaaa
-aaaaaaaaaaaaaaaaaaababababacbXbYaQaRaQaQbZacabacbnbnapapapcacbapaQaQapapbnccababababababababasasatatabababaaaa
-aaaaaaaaaaaaaaaaabababababacbscdceacaQaQaQacababababacapcfapcgcgcgcgcgchbnaEababababasasasasasatatababaaaaaaaa
-aaaaaaaaaaaaaaaaabababababacbscibPaccjckclacababababacapaQcmaccnacacacacacacabababasasasatatatatababaaaaaaaaaa
-aaaaaaaaaaaaaaaaabababacabaccobYcpcqacacacacacaccracacaQaQcmaccsctaQcucvabababasasasasatatatatababaaaaaaaaaaaa
-aaaaaaaaaaaaabababababababcwcxcybsczcAcAcAcBcCcDcEcFcGbnapcHcIcJcKcJcucvasascLasatatatatatatababaaaaaaaaaaaaaa
-aaaaaaaaaaabababababacababcMcNcObscPaQbsblbscQcEcEcEcQapapaQabcRcJcJcucvasasasatatatatatasababaaaaaaaaaaaaaaaa
-aaaaaaaaababababababababcwcSbdbscTcUcVaQcVcWcXcEcEcYcZbnbndaabavcJcJcucvasasasatatatababababaaaaaaaaaaaaaaaaaa
-aaaaaaababababababababacacacdbdcdbacacacacacacdddddedfbnbnaEabavawdgdhcvasasatatatababaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaabababacacacabababacdidjdkdkdldmdmacababacacacacacdnaAababababababababatatatababaaaaaaaaaaaaaaaaaaaaaaaaaa
-ababababbdbdbdbdabababacdkdkdodododkdkacababababababacaEaAabababababababatatatababaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-ababababacacacacabababacdkdpdqdrdsdtdkacababababababacaAabababababababatatabababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-abababababababababababacdkdpdudvdqdtdkacababababababacababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-abababababababababababacdkdpdwdqdqdtdkacabababababababababababaaaaabababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaabababaaabababacdkdkdkdkdkdxdkacabababababababababababaaaaaaaaababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaabababacdydzdAdBdCdDdDacababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaabababacacacacacacacacacababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaabababababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaababababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+"}
+(2,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+as
+as
+as
+aa
+as
+as
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+"}
+(3,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+as
+as
+as
+as
+as
+as
+as
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+"}
+(4,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+aa
+aa
+aa
+aa
+aa
+as
+as
+as
+as
+as
+as
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+"}
+(5,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+aa
+ab
+ab
+as
+as
+as
+as
+as
+as
+as
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+bd
+ac
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+"}
+(6,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+as
+as
+as
+bt
+as
+as
+as
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ac
+bd
+ac
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+"}
+(7,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+as
+as
+as
+bu
+as
+as
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ac
+bd
+ac
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+"}
+(8,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+as
+at
+ab
+ab
+as
+as
+as
+bv
+as
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ac
+bd
+ac
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+"}
+(9,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+at
+at
+ab
+ac
+ac
+az
+bq
+bw
+bD
+ab
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(10,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+as
+at
+ab
+ab
+ac
+aY
+aQ
+aQ
+bx
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(11,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+as
+at
+at
+ab
+ab
+ac
+aZ
+aQ
+aQ
+bx
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(12,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+as
+at
+at
+ab
+ab
+aV
+ba
+aQ
+br
+by
+ac
+ab
+ab
+ab
+ab
+ab
+ac
+ab
+ab
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ab
+ab
+"}
+(13,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+as
+at
+at
+ab
+ab
+ac
+bb
+bj
+bj
+bz
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+cw
+ac
+di
+dk
+dk
+dk
+dk
+dk
+dy
+ac
+ab
+ab
+"}
+(14,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+at
+at
+at
+ab
+ab
+ac
+bc
+bk
+bk
+bA
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+cw
+cM
+cS
+ac
+dj
+dk
+dp
+dp
+dp
+dk
+dz
+ac
+ab
+ab
+"}
+(15,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+at
+at
+at
+ab
+ab
+ac
+bd
+bl
+bs
+bB
+bs
+bs
+bP
+bX
+bs
+bs
+co
+cx
+cN
+bd
+db
+dk
+do
+dq
+du
+dw
+dk
+dA
+ac
+ab
+ab
+"}
+(16,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+at
+at
+at
+ab
+ab
+ab
+aA
+bd
+bl
+aQ
+bC
+bE
+bE
+bE
+bY
+cd
+ci
+bY
+cy
+cO
+bs
+dc
+dk
+do
+dr
+dv
+dq
+dk
+dB
+ac
+ab
+ab
+"}
+(17,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ac
+ab
+as
+at
+at
+at
+ab
+ab
+ab
+ab
+be
+bl
+bl
+bs
+bs
+bs
+bQ
+aQ
+ce
+bP
+cp
+bs
+bs
+cT
+db
+dl
+do
+ds
+dq
+dq
+dk
+dC
+ac
+ab
+ab
+"}
+(18,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+at
+at
+at
+at
+ab
+ab
+ab
+ac
+aA
+bl
+bl
+ab
+bF
+ac
+ac
+aR
+ac
+ac
+cq
+cz
+cP
+cU
+ac
+dm
+dk
+dt
+dt
+dt
+dx
+dD
+ac
+ab
+ab
+"}
+(19,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+at
+at
+at
+at
+as
+ab
+ab
+ab
+ac
+bf
+aE
+bf
+ab
+ac
+bK
+bR
+aQ
+aQ
+cj
+ac
+cA
+aQ
+cV
+ac
+dm
+dk
+dk
+dk
+dk
+dk
+dD
+ac
+ab
+ab
+"}
+(20,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+as
+at
+at
+at
+at
+as
+as
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+bL
+aQ
+aQ
+aQ
+ck
+ac
+cA
+bs
+aQ
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ab
+ab
+"}
+(21,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+as
+at
+at
+at
+at
+as
+as
+as
+ab
+ab
+ac
+ab
+ab
+ab
+ab
+ac
+bM
+bS
+bZ
+aQ
+cl
+ac
+cA
+bl
+cV
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(22,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+at
+at
+at
+at
+at
+as
+as
+as
+as
+ab
+ab
+ac
+ab
+ab
+ab
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+cB
+bs
+cW
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(23,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+at
+at
+at
+at
+at
+as
+as
+as
+as
+as
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+cC
+cQ
+cX
+ac
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(24,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+at
+at
+at
+at
+at
+as
+as
+as
+as
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+ac
+ac
+ac
+ac
+ab
+ab
+ac
+cD
+cE
+cE
+dd
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+"}
+(25,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+as
+at
+at
+at
+at
+as
+as
+as
+as
+as
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+bG
+bN
+bT
+bn
+ab
+ab
+cr
+cE
+cE
+cE
+dd
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+"}
+(26,1,1) = {"
+aa
+aa
+aa
+aa
+ab
+ab
+ac
+ac
+ab
+ab
+at
+at
+at
+at
+as
+as
+as
+as
+as
+as
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+bH
+ap
+ap
+bn
+ab
+ab
+ac
+cF
+cE
+cY
+de
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+"}
+(27,1,1) = {"
+aa
+aa
+aa
+ab
+ab
+ab
+ac
+ab
+ab
+ab
+at
+at
+at
+as
+as
+as
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ap
+ac
+ac
+ac
+cG
+cQ
+cZ
+df
+ac
+ac
+ac
+ac
+ab
+ab
+aa
+aa
+aa
+aa
+"}
+(28,1,1) = {"
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+at
+at
+at
+as
+as
+ab
+ab
+ab
+ab
+aA
+ab
+ab
+ab
+ac
+aC
+aC
+aC
+aC
+aC
+aC
+aC
+ac
+bU
+ap
+ap
+ap
+aQ
+bn
+ap
+bn
+bn
+dn
+aE
+aA
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+"}
+(29,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+as
+at
+at
+at
+ab
+ab
+ab
+ab
+aA
+aA
+aE
+ab
+ab
+aQ
+ac
+aC
+aC
+aC
+aC
+aC
+aC
+aC
+ac
+ap
+ap
+cf
+aQ
+aQ
+ap
+ap
+bn
+bn
+aA
+aA
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+"}
+(30,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+as
+at
+at
+as
+ab
+aA
+aE
+aE
+aE
+aB
+aB
+ac
+aQ
+aQ
+ac
+aC
+aC
+aC
+aC
+aC
+aC
+aC
+ac
+aQ
+ca
+ap
+cm
+cm
+cH
+aQ
+da
+aE
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+"}
+(31,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+as
+at
+at
+at
+as
+ac
+aB
+aB
+aF
+aB
+aB
+aC
+ac
+aQ
+aQ
+aT
+aC
+aC
+bg
+aC
+aC
+aC
+aC
+ac
+ap
+cb
+cg
+ac
+ac
+cI
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+"}
+(32,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+at
+at
+at
+at
+as
+ac
+aC
+aC
+aG
+aC
+aC
+aC
+ac
+aQ
+aQ
+av
+aC
+aC
+aC
+bm
+bm
+aC
+aC
+ac
+ap
+ap
+cg
+cn
+cs
+cJ
+cR
+av
+av
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(33,1,1) = {"
+aa
+ab
+ab
+ac
+ac
+ac
+ac
+ac
+av
+at
+as
+as
+ac
+aC
+aC
+aG
+aC
+aC
+aC
+ac
+aQ
+aS
+ac
+aC
+aC
+aB
+aC
+bm
+aC
+aC
+ac
+bn
+aQ
+cg
+ac
+ct
+cK
+cJ
+cJ
+aw
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(34,1,1) = {"
+aa
+ab
+ab
+ac
+ad
+ai
+an
+an
+aw
+as
+as
+as
+ac
+aC
+aC
+aG
+aC
+aC
+aC
+ac
+aQ
+aS
+ac
+aU
+aC
+aC
+aC
+aC
+aC
+aC
+ac
+bV
+aQ
+cg
+ac
+aQ
+cJ
+cJ
+cJ
+dg
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+"}
+(35,1,1) = {"
+ab
+ab
+ab
+ac
+ad
+aj
+ao
+ao
+aw
+as
+as
+as
+as
+av
+aw
+aH
+aw
+av
+av
+ac
+aR
+ab
+ac
+ac
+ac
+ac
+az
+ac
+ac
+ac
+bO
+ap
+ap
+cg
+ac
+cu
+cu
+cu
+cu
+dh
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+"}
+(36,1,1) = {"
+ab
+ab
+ab
+ac
+ae
+ak
+ap
+ap
+aw
+aw
+as
+as
+as
+aD
+aD
+aI
+aK
+aM
+aD
+aD
+ap
+ab
+ab
+ab
+aW
+bh
+ap
+aD
+aD
+aD
+aD
+aQ
+ap
+ch
+ac
+cv
+cv
+cv
+cv
+cv
+ab
+ab
+at
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+"}
+(37,1,1) = {"
+ab
+ab
+ab
+ac
+af
+ak
+ap
+ap
+ap
+aw
+az
+as
+as
+as
+ap
+ap
+ap
+aN
+ap
+ap
+ap
+ab
+ab
+ab
+ab
+bi
+bn
+ap
+ap
+ap
+ap
+ap
+bn
+bn
+ac
+ab
+as
+as
+as
+as
+ab
+at
+at
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+"}
+(38,1,1) = {"
+ab
+ab
+ab
+ac
+ag
+ak
+ap
+ap
+ap
+ap
+aw
+as
+as
+as
+as
+ac
+ac
+ac
+ac
+ab
+ab
+ab
+ab
+ab
+aE
+aE
+bn
+aQ
+aQ
+bI
+bI
+aE
+cc
+aE
+ac
+ab
+as
+as
+as
+as
+at
+at
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+"}
+(39,1,1) = {"
+ab
+ab
+ab
+ac
+ah
+al
+aq
+aq
+aq
+aq
+aw
+aw
+as
+ac
+as
+ac
+aE
+aO
+aE
+aE
+ab
+ab
+ac
+ac
+ac
+ac
+bo
+ac
+ac
+ac
+ac
+bW
+ab
+ab
+ab
+ab
+cL
+as
+as
+at
+at
+at
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(40,1,1) = {"
+ab
+ab
+ab
+ac
+ah
+am
+ar
+au
+ax
+ay
+ac
+at
+as
+as
+as
+aJ
+aL
+aE
+aE
+aE
+ab
+ab
+ac
+aC
+aC
+aC
+aC
+aC
+aC
+bJ
+ac
+ab
+ab
+ab
+ab
+as
+as
+at
+at
+at
+at
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(41,1,1) = {"
+ab
+ab
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+ac
+at
+at
+as
+as
+aJ
+ac
+aE
+aP
+aE
+ab
+ab
+ac
+aC
+aC
+aX
+aC
+aX
+aC
+aC
+ac
+ab
+ab
+ab
+ab
+as
+at
+at
+at
+at
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(42,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+at
+at
+at
+at
+as
+as
+ac
+ac
+as
+ab
+ab
+ac
+aC
+aX
+aX
+aX
+aX
+aC
+aC
+ac
+ab
+ab
+ab
+as
+as
+at
+at
+at
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(43,1,1) = {"
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+at
+at
+at
+as
+as
+as
+as
+ab
+ab
+ac
+aC
+aC
+aX
+bp
+aX
+aX
+aC
+ac
+ab
+ab
+as
+as
+as
+at
+at
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(44,1,1) = {"
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+at
+at
+at
+as
+as
+as
+ab
+ab
+ac
+aw
+aC
+aX
+aX
+aX
+aC
+aC
+ac
+ab
+ab
+as
+as
+at
+at
+at
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(45,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+at
+at
+at
+as
+as
+ab
+ab
+ab
+av
+aw
+aX
+aC
+aX
+aX
+aC
+ac
+ab
+ab
+as
+at
+at
+at
+as
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(46,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+as
+as
+at
+at
+as
+ab
+ab
+ab
+ab
+aw
+aC
+aC
+aC
+aC
+aC
+ac
+ab
+ab
+as
+at
+at
+at
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(47,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+as
+as
+at
+at
+ab
+ab
+ab
+ab
+ab
+ac
+ac
+ac
+ac
+ac
+ac
+ab
+as
+as
+at
+at
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(48,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+as
+as
+at
+ab
+ab
+ab
+ab
+ab
+as
+as
+as
+as
+as
+as
+as
+as
+at
+at
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(49,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+as
+at
+at
+at
+at
+at
+at
+as
+at
+at
+at
+as
+at
+at
+at
+at
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(50,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+as
+at
+at
+at
+at
+at
+at
+at
+at
+at
+at
+at
+as
+at
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(51,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+as
+as
+as
+as
+at
+at
+as
+as
+as
+as
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(52,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+as
+as
+as
+as
+as
+as
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(53,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+as
+as
+as
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(54,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+"}
+(55,1,1) = {"
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+aa
 "}

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -269,3 +269,10 @@
 	suffix = "lavaland_surface_hermit.dmm"
 	allow_duplicates = FALSE
 	cost = 5
+/datum/map_template/ruin/lavaland/scp_facility
+	name = "Anomalous Object Site"
+	id = "scp_facility"
+	description = "An abandoned storage site for dangerous and paranormal objects and creatures."
+	suffix = "lavaland_surface_scp_facility.dmm"
+	allow_duplicates = FALSE
+	cost = 20

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -411,3 +411,30 @@
 			<b>4.</b> If you feel it necessary, detonation of a collar will kill the person wearing it while also destroying the collar.<br>\
 			<b>5.</b> The implant allows you to check status and bind collars to you, so they detonate when you die, or act like you do. Click the detonator in-hand to sync<br>\
 			<i>Do not use bomb collars solely for executions! They are expensive and not easily replacable - use lethal injections instead.</i>"
+/obj/item/weapon/paper/scp_research
+	name = "Research Notes: Objects 15-25"
+	info = "<b>AO-15:</b><br><br>\
+	        Security: High <br>\
+	        Info: Strange creature extracted from an old mining asteroid. Dark skin, piercing red eyes. Highly aggressive. Appears to be sentient. <br> <br>\
+	        <b>AO-16:</b><br><br>\
+	        Security: Medium <br>\
+	        Info: A hood and robes. Red colour. Emanates a dark-energy field that engraves all material near it with undeciphered patterns. Believed to be connected to the cult of <b>REDACTED</b> <br> <br>\
+	        <b>AO-17:</b><br><br>\
+	        Security: Apollyon <br>\
+	        Info: <b>REDACTED</b> has been linked to <b>REDACTED</b> not to be activated in any circumstances, including <b>REDACTED</b>. <i>CentCom note: Site 21 lacks required security measures. Transfer to site 11-X scheduled for <b>REDACTED</b>. <br> <br>\
+	        <i>Several paragraphs are covered with black highlighter...</i> <br> <br>\
+	        <b>AO-21:</b><br><br>\
+	        Security: Low <br>\
+	        Info: Ocular gland extracted from AO-6 during experiment EX-56b. Highly aggressive. After breach 91-A subject was neutralized with a solution of poisons. Subject is to be injected with the solution every half-hour to keep it in a semi-comatose state. Solution recipe stored at Site 11-X archives. <br> <br>\
+	        <i>The rest of the paper is covered in scribbles of strange symbols, made of dried blood.</i>"
+
+
+
+
+
+
+
+
+
+
+

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -15,8 +15,6 @@
 // BEGIN_INCLUDE
 #include "_maps\__MAP_DEFINES.dm"
 #include "_maps\tgstation2.dm"
-#include "_maps\RandomRuins\LavaRuins\lavaland_surface_scp_facility.dmm"
-#include "_maps\RandomRuins\SpaceRuins\emptyshell.dmm"
 #include "code\_compile_options.dm"
 #include "code\hub.dm"
 #include "code\world.dm"

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -15,6 +15,8 @@
 // BEGIN_INCLUDE
 #include "_maps\__MAP_DEFINES.dm"
 #include "_maps\tgstation2.dm"
+#include "_maps\RandomRuins\LavaRuins\lavaland_surface_scp_facility.dmm"
+#include "_maps\RandomRuins\SpaceRuins\emptyshell.dmm"
 #include "code\_compile_options.dm"
 #include "code\hub.dm"
 #include "code\world.dm"


### PR DESCRIPTION
Adds a new lavaland ruin. It's an anomalous object containment site run by NanoTrasen. It was hit by an earthquake a few decades ago and it has fallen to ruin. It holds some dangerous creatures inside, but it's got an open armoury at the end as a reward.

<a href="http://imgur.com/uBfTd54"><img src="http://i.imgur.com/uBfTd54.png" title="source: imgur.com" /></a>

Includes fluff object testing logs!

:cl:
rscadd: A new lavaland ruin has been unearthed!
/:cl:

