### PR TITLE
Allows mutant races into head roles again

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -165,7 +165,7 @@ PROTECT_ROLES_FROM_ANTAGONIST
 #PROTECT_ASSISTANT_FROM_ANTAGONIST
 
 ## If non-human species are barred from joining as a head of staff
-#ENFORCE_HUMAN_AUTHORITY
+maks america grate egayn
 
 ## If late-joining players have a chance to become a traitor/changeling
 ALLOW_LATEJOIN_ANTAGONISTS


### PR DESCRIPTION
It was changed a while back ,without most people knowing

I made this as both a PR and a place to discuss this, as alot of people are unhappy with it.

Anyway, I expect this to be extremely controversial. 

(I know it has to be edited by the host or something, but this is just it's thread)
:cl:
tweak: After 4 revolutions and PETA activists, everyone can apply for headrole again.
/:cl: