### PR TITLE
Nerfs the syndicate portal storm event.

### DIFF
--- a/code/modules/events/portal_storm.dm
+++ b/code/modules/events/portal_storm.dm
@@ -7,8 +7,8 @@
 
 /datum/round_event/portal_storm/syndicate_shocktroop
 	boss_types = list(/mob/living/simple_animal/hostile/syndicate/melee/space/stormtrooper = 2)
-	hostile_types = list(/mob/living/simple_animal/hostile/syndicate/melee/space = 8,\
-						/mob/living/simple_animal/hostile/syndicate/ranged/space = 2)
+	hostile_types = list(/mob/living/simple_animal/hostile/syndicate/melee/space = 3,\
+						/mob/living/simple_animal/hostile/syndicate/ranged/space = 1)
 
 /datum/round_event_control/portal_storm_narsie
 	name = "Portal Storm: Constructs"


### PR DESCRIPTION
#### Intent of your Pull Request

Nerfs the syndicate portal storm event. It spawns much less enemies.
Someone [special](http://prntscr.com/dcx39b) wanted it gone. So instead I nerfed it heavily.

If this makes the event boring we can revert the change so no harm really done.

##### Changelog

:cl:
tweak: Nerfs the syndicate portal storm event. This change might be temporary.
/:cl:

