### PR TITLE
The HoP can no longer spawn as a traitor or changeling, this might effectively cause fluffysurvivor to also roll around in his grave.

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -17,7 +17,7 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 	config_tag = "changeling"
 	antag_flag = ROLE_CHANGELING
 	restricted_jobs = list("AI", "Cyborg")
-	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain")
+	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
 	required_players = 15
 	required_enemies = 1
 	recommended_enemies = 4

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -10,7 +10,7 @@
 	config_tag = "traitor"
 	antag_flag = ROLE_TRAITOR
 	restricted_jobs = list("AI", "Cyborg")
-	protected_jobs = list("Security Officer","Detective", "Warden", "Head of Security", "Captain")
+	protected_jobs = list("Security Officer","Detective", "Warden", "Head of Security", "Captain", "Head of Personnel")
 	required_players = 0
 	required_enemies = 1
 	recommended_enemies = 4


### PR DESCRIPTION
latejoin as captain, get killed by hop who has taken all my shit, has a holoparasite and emp flashlight. He then proceeds to control sec and force them into doing shit, inevitably dies to greytide lynch mob. There was 4 people in perma, not all were antags.

The power that HoP traitor and changeling has is beyond crippling to the entire station, it needs to change because it may as well be the old antag captain that we had years back.

HoP can still be recruited by gangs and is susceptible to mind slave for those who actually want to go to the trouble of trying to recruit him into their cause. He's also vulnerable to Shadowlings but suffice to say this would require someone to kidnap him or put him in a position where the Sling can grab him which is pretty hard given how vulnerable to light they are.

And before anyone points out "but other heads can spawn as antags", Yeah they can, but other heads cant give themselves all acces, subvert the ai, kill the captain and become the acting captain. Other head antags still have to work towards their goals while HoP has the most minimal effort since he can subvert the ai at roundstart, have all of sec under his thumb and wipe out any command staff that stand in his way and there's nothing that can really be done about it unless a giant lynch mob forms and slaughters the hop in cold blood.

:cl: Stealthkibber
tweak: The Head of Personnel can no longer be a traitor or changeling so you unskilled CUNTS who keep rolling it will actually have to work towards your greentext from now on with another job. BUT STEALTH HUR...MUH VALIDS DUR....HNNNGN...YOGCULTURE.
/:cl: