### PR TITLE
Nerfs phytosians

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -349,63 +349,46 @@ datum/species/lizard/before_equip_job(datum/job/J, mob/living/carbon/human/H)
 				if (H.mind.special_role == "thrall")
 					//thralled phytosians have their natural regeneration massively stunted, but their weakness to darkness removed
 					if (H.stat != UNCONSCIOUS && H.stat != DEAD)
-						H.adjustToxLoss(-0.1)
-						H.adjustOxyLoss(-0.1)
-						H.heal_overall_damage(0.2, 0.2)
+						regen(0.2, H)
 						return
 
 			if (T.lighting_lumcount)
 				switch (T.lighting_lumcount)
 					if (0.1 to 3)
 						//very low light
-						H.nutrition -= T.lighting_lumcount/1.5
+						regen(-2, H)
 						if (prob(10))
 							H << "<span class='warning'>There isn't enough light here, and you can feel your body protesting the fact violently.</span>"
-						H.adjustOxyLoss(3)
 					if (3.1 to 6)
 						//low light
-						H.nutrition -= T.lighting_lumcount/2
 						if (prob(3))
 							H << "<span class='warning'>The ambient light levels are too low. Your breath is coming more slowly as your insides struggle to keep up on their own.</span>"
-							H.adjustOxyLoss(6)
+						regen(-1, H)
 					if (6.1 to 10)
 						//medium, average, doing nothing for now
-						H.nutrition += T.lighting_lumcount/10
+						regen(0, H) //Why am I even doing this?
 					if (10.1 to 22)
 						//high light, regen here
-						H.nutrition += T.lighting_lumcount/6
 						if (H.stat != UNCONSCIOUS && H.stat != DEAD)
-							H.adjustToxLoss(-0.5)
-							H.adjustOxyLoss(-0.5)
-							H.heal_overall_damage(1, 1)
+							regen(1, H)
 					if (22.1 to INFINITY)
 						//super high light
-						H.nutrition += T.lighting_lumcount/4
 						if (H.stat != UNCONSCIOUS && H.stat != DEAD)
-							H.adjustToxLoss(-1)
-							H.adjustOxyLoss(-0.5)
-							H.heal_overall_damage(1.5, 1.5)
+							regen(1.5, H)
 			else if(T.loc.luminosity == 1 || A.lighting_use_dynamic == 0)
-				H.nutrition += 1.4
 				if (H.stat != UNCONSCIOUS && H.stat != DEAD)
-					H.adjustToxLoss(-1)
-					H.adjustOxyLoss(-0.5)
-					H.heal_overall_damage(1.5, 1.5)
+					regen(2, H)
 			else
 				//no light, this is baaaaaad
-				H.nutrition -= 3
 				if (prob(8))
 					H << "<span class='userdanger'>Darkness! Your insides churn and your skin screams in pain!</span>"
-				H.adjustOxyLoss(3)
-				H.adjustToxLoss(1)
+				regen(-2.5, H)
 	else
 		if(H.loc != /obj/mecha)
 			//inside a container or something else, inflict low-level light degen
-			H.nutrition -= 1.5
 			if (prob(3))
 				H << "<span class='warning'>There's not enough light reaching you in here. You start to feel very claustrophobic as your energy begins to drain away.</span>"
-				H.adjustOxyLoss(9)
-				H.adjustToxLoss(3)
+				regen(-0.5, H)
 
 	if(H.nutrition > NUTRITION_LEVEL_FULL)
 		H.nutrition = NUTRITION_LEVEL_FULL
@@ -413,8 +396,33 @@ datum/species/lizard/before_equip_job(datum/job/J, mob/living/carbon/human/H)
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)
 		if (H.stat != UNCONSCIOUS && H.stat != DEAD)
 			if (prob(5))
-				H << "<span class='userdanger'>Your internal stores of light are depleted. Find a source to replenish your nourishment at once!</span>"
-			H.take_overall_damage(2,0)
+				H << "<span class='userdanger'>Your internal stores of nutriment are depleted. Find a source to replenish your nourishment at once!</span>"
+			H.take_overall_damage(1,0)
+
+/datum/species/plant/proc/regen(var/light, mob/living/carbon/human/H)
+	world << "1"
+	if(light < 0)
+		H.adjustOxyLoss(-1.5 * light) //example: -1.5 * -2 = 3. So do 3 oxy damage.
+		world << "2"
+	else if (light > 0)
+		world << "6"
+		if(H.nutrition > 100) //If the person is hungry, they wont regen because that'd be more efficient with nutriment use.
+			H.adjustToxLoss(-0.5 * light)
+			H.adjustOxyLoss(-0.5 * light)
+			H.heal_overall_damage(1 * light, 1 * light) //Just heal them in-case something breaks
+			world << "3"
+			if((!H.health == H.maxHealth) && (prob(50))) //We use nutrition to heal, but not when we are already at full health
+				H.nutrition -= 2
+				world << "4"
+		return
+	else
+		world << "5"
+		return //Should only be when it's zero, so nothing really happens.
+
+
+
+
+
 
 /datum/species/plant/fly
 	// Phytosian turned into fly-like abominations in teleporter accidents.

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -400,23 +400,17 @@ datum/species/lizard/before_equip_job(datum/job/J, mob/living/carbon/human/H)
 			H.take_overall_damage(1,0)
 
 /datum/species/plant/proc/regen(var/light, mob/living/carbon/human/H)
-	world << "1"
 	if(light < 0)
 		H.adjustOxyLoss(-1.5 * light) //example: -1.5 * -2 = 3. So do 3 oxy damage.
-		world << "2"
 	else if (light > 0)
-		world << "6"
 		if(H.nutrition > 100) //If the person is hungry, they wont regen because that'd be more efficient with nutriment use.
 			H.adjustToxLoss(-0.5 * light)
 			H.adjustOxyLoss(-0.5 * light)
 			H.heal_overall_damage(1 * light, 1 * light) //Just heal them in-case something breaks
-			world << "3"
-			if((!H.health == H.maxHealth) && (prob(50))) //We use nutrition to heal, but not when we are already at full health
+			if((!H.health == H.maxHealth) && (prob(10))) //We use nutrition to heal, but not when we are already at full health
 				H.nutrition -= 2
-				world << "4"
 		return
 	else
-		world << "5"
 		return //Should only be when it's zero, so nothing really happens.
 
 

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -356,7 +356,7 @@ datum/species/lizard/before_equip_job(datum/job/J, mob/living/carbon/human/H)
 				switch (T.lighting_lumcount)
 					if (0.1 to 3)
 						//very low light
-						regen(-2, H)
+						regen(-1.5, H)
 						if (prob(10))
 							H << "<span class='warning'>There isn't enough light here, and you can feel your body protesting the fact violently.</span>"
 					if (3.1 to 6)
@@ -382,7 +382,7 @@ datum/species/lizard/before_equip_job(datum/job/J, mob/living/carbon/human/H)
 				//no light, this is baaaaaad
 				if (prob(8))
 					H << "<span class='userdanger'>Darkness! Your insides churn and your skin screams in pain!</span>"
-				regen(-2.5, H)
+				regen(-2, H)
 	else
 		if(H.loc != /obj/mecha)
 			//inside a container or something else, inflict low-level light degen


### PR DESCRIPTION
I think I might've found the right nerf for them:

## Nerf:

- Phytosiansnow need to eat.(Plants need more then just light)

- They loose nutrition on healing.

## Buff?:

- They take less damage from starving, since they will be dealing with it alot. 

:cl:
tweak: Phytosians realised nutriment doesn't come from lights, so they now also eat in order to stay fit.
/:cl:
