### PR TITLE
Toxins Mixing Piping (new)

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -41111,6 +41111,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	dir = 2;
 	external_pressure_bound = 0;
+	frequency = 1441;
+	id_tag = "burn_out";
 	initialize_directions = 1;
 	internal_pressure_bound = 4000;
 	on = 1;
@@ -41122,6 +41124,10 @@
 "bDV" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 5
+	},
+/obj/machinery/air_sensor{
+	frequency = 1441;
+	id_tag = "burn_sensor"
 	},
 /turf/open/floor/engine/vacuum,
 /area/toxins/mixing)
@@ -41140,8 +41146,8 @@
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 2;
-	frequency = 1443;
-	id = "air_in"
+	frequency = 1441;
+	id = "burn_in"
 	},
 /turf/open/floor/engine/vacuum,
 /area/toxins/mixing)
@@ -69124,6 +69130,19 @@
 	icon_state = "white"
 	},
 /area/medical/sleeper)
+"Yon" = (
+/turf/open/floor/plasteel,
+/obj/machinery/computer/atmos_control/tank{
+	frequency = 1441;
+	input_tag = "burn_in";
+	name = "Burn Chamber Control";
+	output_tag = "burn_out";
+	sensors = list("burn_sensor" = "Tank")
+	},
+/turf/open/floor/plasteel/warningline{
+	dir = 1
+	},
+/area/toxins/mixing)
 "Yoo" = (
 /turf/closed/wall/r_wall,
 /area/space)
@@ -120724,7 +120743,7 @@ bDT
 bDT
 bGX
 Yoz
-YoB
+Yon
 bJO
 bJO
 bMM

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -69168,7 +69168,7 @@
 	name = "blobstart"
 	},
 /turf/open/floor/plating,
-/area/toxins/mixing)
+/area/maintenance/asmaint2)
 "Yov" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -69383,7 +69383,7 @@
 /obj/machinery/atmospherics/pipe/simple,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
-/area/space)
+/area/toxins/mixing)
 "YoS" = (
 /obj/structure/grille,
 /obj/machinery/meter{
@@ -69393,7 +69393,7 @@
 /obj/machinery/atmospherics/pipe/simple,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
-/area/space)
+/area/toxins/mixing)
 "YoT" = (
 /obj/structure/grille,
 /turf/open/floor/plating,
@@ -120207,7 +120207,7 @@ aaa
 aaa
 aaa
 aaa
-adC
+bny
 csk
 bGW
 YoB
@@ -120462,9 +120462,9 @@ aaa
 aaa
 aaa
 aaa
-Yoq
-Yoq
-bFq
+aaa
+aaa
+bny
 You
 bCl
 YoC
@@ -120479,7 +120479,7 @@ bMO
 bJO
 bJO
 bXj
-YoH
+bQO
 bYD
 bZG
 bYE
@@ -120718,7 +120718,7 @@ aaa
 aaa
 aaa
 aaa
-Yoo
+bAZ
 bCl
 bDT
 bDT
@@ -120736,7 +120736,7 @@ bTl
 bJO
 bJO
 bXj
-YoH
+bQO
 bYE
 bZH
 bYF
@@ -120975,7 +120975,7 @@ aaa
 aaa
 aaa
 aaa
-Yop
+bBa
 bCm
 bDU
 bFm
@@ -121232,7 +121232,7 @@ aaa
 aaa
 aaa
 aaa
-Yop
+bBa
 bCn
 bDV
 bFn
@@ -121250,7 +121250,7 @@ bTn
 bFq
 bFq
 bFq
-adC
+bFq
 bYE
 bZH
 bYF
@@ -121489,7 +121489,7 @@ aaA
 aaA
 aaA
 aaA
-Yop
+bBa
 bCo
 bDW
 bFo
@@ -121746,7 +121746,7 @@ aaa
 aaa
 aaa
 aaa
-Yop
+bBa
 bCp
 bDX
 bFp
@@ -122003,10 +122003,10 @@ aaA
 aaa
 aaa
 aaa
-Yoo
-Yor
-Yos
-Yos
+bAZ
+bCq
+bDT
+bDT
 Yov
 bHd
 bIf
@@ -122272,12 +122272,12 @@ bJO
 bMO
 bOt
 bFq
-YoH
-YoH
-YoH
-adC
-YoN
-adC
+bQO
+bQO
+bQO
+bFq
+bVR
+bFq
 aaa
 aaa
 aaa
@@ -122521,14 +122521,14 @@ aaa
 aaa
 aaa
 aaa
-Yow
-adC
-adC
-adC
-adC
-adC
-adC
-adC
+bHe
+bFq
+bFq
+bFq
+bFq
+bFq
+bFq
+bFq
 aaA
 aaA
 aaA

--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -42745,21 +42745,11 @@
 /turf/open/floor/plating,
 /area/maintenance/asmaint2)
 "bGV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
+/turf/closed/wall/r_wall,
 /area/maintenance/asmaint2)
 "bGW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/closet,
-/obj/effect/landmark{
-	name = "blobstart"
-	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/maintenance/asmaint2)
 "bGX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -42830,16 +42820,18 @@
 /turf/open/floor/plasteel,
 /area/toxins/mixing)
 "bHd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/turf/open/floor/plating,
+/turf/open/floor/plasteel/warningline/corner{
+	dir = 1
+	},
+/obj/machinery/meter{
+	name = "Heat Exchanger"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	color = "#000000"
+	},
+/turf/open/floor/plasteel/warningline{
 	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Toxins Mixing Room North";
-	network = list("SS13","RD")
-	},
-/turf/open/floor/plasteel{
-	dir = 4;
-	icon_state = "warning"
 	},
 /area/toxins/mixing)
 "bHe" = (
@@ -43314,12 +43306,16 @@
 /turf/open/floor/plasteel,
 /area/toxins/mixing)
 "bIf" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/turf/open/floor/plating,
+/turf/open/floor/plasteel/warningline{
 	dir = 8
 	},
-/turf/open/floor/plasteel{
-	dir = 4;
-	icon_state = "warning"
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 1;
+	name = "Heat Exchanger input"
+	},
+/turf/open/floor/plasteel/warningline{
+	dir = 4
 	},
 /area/toxins/mixing)
 "bIg" = (
@@ -44218,21 +44214,20 @@
 /turf/open/floor/plating,
 /area/maintenance/asmaint2)
 "bJO" = (
-/obj/machinery/airalarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel{
-	dir = 8;
-	icon_state = "warning"
-	},
+/turf/open/floor/plasteel,
 /area/toxins/mixing)
 "bJP" = (
-/obj/machinery/atmospherics/pipe/simple{
-	color = "#000000";
-	dir = 5;
-	pipe_color = "#000000"
+/turf/open/floor/plating,
+/turf/open/floor/plasteel/warningline{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/meter{
+	name = "Heat Exchanger output"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel/warningline{
+	dir = 4
+	},
 /area/toxins/mixing)
 "bJQ" = (
 /obj/machinery/embedded_controller/radio/airlock_controller{
@@ -44258,17 +44253,16 @@
 	},
 /area/toxins/mixing)
 "bJR" = (
-/obj/machinery/meter{
-	name = "Heat Exchanger"
+/turf/open/floor/plating,
+/turf/open/floor/plasteel/warningline{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple{
-	color = "#000000";
-	dir = 4;
-	pipe_color = "#000000"
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 2;
+	name = "output valve"
 	},
-/turf/open/floor/plasteel{
-	icon_state = "warnwhite";
-	dir = 1
+/turf/open/floor/plasteel/warningline{
+	dir = 4
 	},
 /area/toxins/mixing)
 "bJS" = (
@@ -44297,12 +44291,17 @@
 	},
 /area/toxins/mixing)
 "bJT" = (
-/obj/machinery/atmospherics/pipe/simple{
-	color = "#000000";
-	dir = 4;
-	pipe_color = "#000000"
+/turf/open/floor/plating,
+/turf/open/floor/plasteel/warningline{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 1;
+	name = "input valve"
+	},
+/turf/open/floor/plasteel/warningline{
+	dir = 4
+	},
 /area/toxins/mixing)
 "bJU" = (
 /obj/machinery/atmospherics/components/binary/volume_pump{
@@ -44312,19 +44311,16 @@
 /turf/open/floor/plasteel,
 /area/toxins/mixing)
 "bJV" = (
-/obj/machinery/atmospherics/pipe/simple{
-	dir = 10
+/turf/open/floor/plating,
+/turf/open/floor/plasteel/warningline{
+	dir = 8
 	},
 /obj/machinery/meter{
 	name = "Heat Exchanger input"
 	},
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/turf/open/floor/plasteel{
-	dir = 4;
-	icon_state = "warning"
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel/warningline{
+	dir = 4
 	},
 /area/toxins/mixing)
 "bJW" = (
@@ -44993,13 +44989,18 @@
 	},
 /area/toxins/mixing)
 "bLo" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4;
-	name = "output valve"
+/turf/open/floor/plating,
+/turf/open/floor/plasteel/warningline{
+	dir = 6
 	},
-/turf/open/floor/plasteel{
-	dir = 2;
-	icon_state = "warning"
+/turf/open/floor/plasteel/warningline{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel/warningline{
+	dir = 4
 	},
 /area/toxins/mixing)
 "bLp" = (
@@ -45016,10 +45017,15 @@
 	},
 /area/toxins/mixing)
 "bLq" = (
-/turf/open/floor/plasteel{
-	dir = 2;
-	icon_state = "warnwhite";
-	tag = "icon-warnwhite (NORTH)"
+/turf/open/floor/plating,
+/turf/open/floor/plasteel/warningline{
+	dir = 6
+	},
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 1
+	},
+/turf/open/floor/plasteel/warningline{
+	dir = 8
 	},
 /area/toxins/mixing)
 "bLr" = (
@@ -45808,12 +45814,12 @@
 /turf/closed/wall/r_wall,
 /area/toxins/mixing)
 "bML" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	dir = 1;
@@ -46705,14 +46711,14 @@
 /turf/open/floor/plasteel,
 /area/toxins/mixing)
 "bOo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	d1 = 2;
 	d2 = 8;
 	icon_state = "2-8";
 	tag = ""
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel{
 	dir = 8;
@@ -47489,12 +47495,12 @@
 	},
 /area/toxins/mixing)
 "bPF" = (
-/obj/structure/cable/yellow,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Toxins Mixing Room APC";
 	pixel_x = -25
 	},
+/obj/structure/cable/yellow,
 /turf/open/floor/plasteel{
 	dir = 4;
 	icon_state = "warnwhitecorner"
@@ -48101,12 +48107,6 @@
 "bQK" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -30
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber{
-	dir = 4;
-	on = 1;
-	scrub_N2O = 0;
-	scrub_Toxins = 0
 	},
 /turf/open/floor/plasteel{
 	icon_state = "white"
@@ -50062,18 +50062,10 @@
 /turf/open/floor/plating,
 /area/maintenance/asmaint2)
 "bUJ" = (
-/obj/machinery/meter{
-	name = "Space Cooler input"
-	},
-/obj/machinery/camera{
-	c_tag = "Toxins Mixing Room South";
-	dir = 4;
-	network = list("SS13","RD")
-	},
-/obj/machinery/atmospherics/pipe/simple,
-/turf/open/floor/plasteel{
-	dir = 1;
-	icon_state = "warnwhitecorner"
+/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plasteel/warningline{
+	dir = 5
 	},
 /area/toxins/mixing)
 "bUK" = (
@@ -50605,12 +50597,18 @@
 /turf/open/floor/plating,
 /area/maintenance/asmaint2)
 "bVL" = (
-/obj/machinery/atmospherics/components/binary/volume_pump{
+/turf/open/floor/plating,
+/obj/machinery/meter{
 	name = "Space Cooler input"
 	},
-/turf/open/floor/plasteel{
-	dir = 10;
-	icon_state = "warnwhite"
+/obj/machinery/camera{
+	c_tag = "Toxins Mixing Room South";
+	dir = 4;
+	network = list("SS13","RD")
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel/warningline{
+	dir = 4
 	},
 /area/toxins/mixing)
 "bVM" = (
@@ -51270,20 +51268,17 @@
 /turf/open/floor/plating,
 /area/maintenance/asmaint2)
 "bXi" = (
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple,
-/obj/structure/window/reinforced/fulltile,
 /turf/open/floor/plating,
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	name = "Space Cooler input"
+	},
+/turf/open/floor/plasteel/warningline{
+	dir = 4
+	},
 /area/toxins/mixing)
 "bXj" = (
-/obj/structure/grille,
-/obj/machinery/meter{
-	layer = 3.5;
-	name = "Space Cooler"
-	},
-/obj/machinery/atmospherics/pipe/simple,
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/warningline,
 /area/toxins/mixing)
 "bXk" = (
 /obj/structure/chair{
@@ -69129,6 +69124,280 @@
 	icon_state = "white"
 	},
 /area/medical/sleeper)
+"Yoo" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"Yop" = (
+/obj/machinery/door/poddoor{
+	id = "mixvent";
+	name = "Mixer Room Vent"
+	},
+/turf/open/floor/engine/vacuum,
+/area/space)
+"Yoq" = (
+/turf/open/space,
+/area/toxins/mixing)
+"Yor" = (
+/obj/machinery/atmospherics/pipe/simple{
+	color = "#000000";
+	dir = 10;
+	pipe_color = "#000000"
+	},
+/turf/closed/wall/r_wall,
+/area/space)
+"Yos" = (
+/obj/machinery/atmospherics/pipe/simple{
+	color = "#000000";
+	pipe_color = "#000000"
+	},
+/turf/closed/wall/r_wall,
+/area/space)
+"Yot" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/maintenance/asmaint2)
+"You" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/closet,
+/obj/effect/landmark{
+	name = "blobstart"
+	},
+/turf/open/floor/plating,
+/area/toxins/mixing)
+"Yov" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple{
+	color = "#000000";
+	pipe_color = "#000000"
+	},
+/turf/closed/wall,
+/area/toxins/mixing)
+"Yow" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/space)
+"Yox" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	req_access_txt = 1
+	},
+/turf/closed/wall/r_wall,
+/area/toxins/explab)
+"Yoy" = (
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/asmaint2)
+"Yoz" = (
+/obj/machinery/atmospherics/pipe/simple{
+	color = "#000000";
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/toxins/mixing)
+"YoA" = (
+/turf/open/floor/plasteel,
+/obj/machinery/camera{
+	c_tag = "Toxins Mixing Room North";
+	network = list("SS13","RD")
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/wrench,
+/obj/item/weapon/screwdriver{
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/warningline{
+	dir = 1
+	},
+/area/toxins/mixing)
+"YoB" = (
+/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/warningline{
+	dir = 1
+	},
+/area/toxins/mixing)
+"YoC" = (
+/turf/open/floor/plating,
+/turf/open/floor/plasteel/warningline{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	pixel_y = 24
+	},
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	name = "Heat Exchanger output"
+	},
+/turf/open/floor/plasteel/warningline{
+	dir = 4
+	},
+/area/toxins/mixing)
+"YoD" = (
+/turf/open/floor/plating,
+/turf/open/floor/plasteel/warningline{
+	dir = 8
+	},
+/obj/machinery/embedded_controller/radio/airlock_controller{
+	airpump_tag = "tox_airlock_pump";
+	exterior_door_tag = "tox_airlock_exterior";
+	id_tag = "tox_airlock_control";
+	interior_door_tag = "tox_airlock_interior";
+	pixel_x = 0;
+	pixel_y = 24;
+	sanitize_external = 1;
+	sensor_tag = "tox_airlock_sensor"
+	},
+/obj/machinery/meter{
+	name = "Output"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel/warningline{
+	dir = 4
+	},
+/area/toxins/mixing)
+"YoE" = (
+/turf/open/floor/plating,
+/turf/open/floor/plasteel/warningline{
+	dir = 8
+	},
+/obj/machinery/button/door{
+	id = "mixvent";
+	name = "Mixing Room Vent Control";
+	pixel_x = 5;
+	pixel_y = 25;
+	req_access_txt = "7"
+	},
+/obj/machinery/button/ignition{
+	id = "mixingsparker";
+	pixel_x = -5;
+	pixel_y = 25
+	},
+/obj/machinery/meter{
+	name = "Input"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel/warningline{
+	dir = 4
+	},
+/area/toxins/mixing)
+"YoF" = (
+/obj/machinery/light{
+	dir = 4;
+	icon_state = "tube1"
+	},
+/turf/open/floor/plasteel,
+/area/toxins/mixing)
+"YoG" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber{
+	dir = 4;
+	on = 1;
+	scrub_N2O = 0;
+	scrub_Toxins = 0
+	},
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/mixing)
+"YoH" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/space)
+"YoI" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/toxins/test_area)
+"YoJ" = (
+/obj/structure/sign/securearea{
+	desc = "A warning sign which reads 'BOMB RANGE";
+	name = "BOMB RANGE"
+	},
+/turf/closed/wall,
+/area/space)
+"YoK" = (
+/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/turf/open/floor/plasteel/warningline{
+	dir = 9
+	},
+/area/toxins/mixing)
+"YoL" = (
+/turf/open/floor/plating/airless{
+	dir = 2;
+	icon_state = "warnplate"
+	},
+/area/toxins/test_area)
+"YoM" = (
+/turf/open/floor/plating,
+/obj/machinery/airalarm{
+	dir = 8;
+	icon_state = "alarm0";
+	pixel_x = 24
+	},
+/obj/machinery/meter{
+	name = "Space Cooler output"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/turf/open/floor/plasteel/warningline{
+	dir = 8
+	},
+/area/toxins/mixing)
+"YoN" = (
+/obj/machinery/door/poddoor{
+	id = "toxinsdriver";
+	name = "toxins launcher bay door"
+	},
+/turf/open/floor/plating,
+/area/space)
+"YoO" = (
+/turf/open/space,
+/area/toxins/test_area)
+"YoP" = (
+/turf/open/floor/plating,
+/obj/machinery/atmospherics/components/binary/volume_pump{
+	dir = 1;
+	name = "Space Cooler output"
+	},
+/turf/open/floor/plasteel/warningline{
+	dir = 8
+	},
+/area/toxins/mixing)
+"YoQ" = (
+/turf/open/floor/plating/airless{
+	dir = 1;
+	icon_state = "warnplate"
+	},
+/area/toxins/test_area)
+"YoR" = (
+/obj/structure/grille,
+/obj/machinery/atmospherics/pipe/simple,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/space)
+"YoS" = (
+/obj/structure/grille,
+/obj/machinery/meter{
+	layer = 3.5;
+	name = "Space Cooler"
+	},
+/obj/machinery/atmospherics/pipe/simple,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/space)
+"YoT" = (
+/obj/structure/grille,
+/turf/open/floor/plating,
+/area/space)
 "YoU" = (
 /obj/machinery/golfhole/puttinggreen,
 /turf/open/floor/wood,
@@ -119168,8 +119437,8 @@ btG
 btG
 btG
 btG
-btG
 bGT
+Yox
 bIa
 bJM
 bLm
@@ -119425,8 +119694,8 @@ bxW
 bxW
 bxW
 bxW
-bxW
 bGU
+Yoy
 bIb
 bJN
 bkx
@@ -119682,7 +119951,7 @@ bvh
 bvh
 bvh
 bkx
-bkx
+Yot
 bGV
 bIc
 bAZ
@@ -119696,7 +119965,7 @@ bAZ
 bAZ
 bAZ
 bAZ
-bny
+bGW
 bny
 bny
 bny
@@ -119938,26 +120207,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-bny
+adC
+csk
 bGW
-bAZ
+YoB
 bJO
-bLn
+bJO
 bML
 bOo
 bPF
 bQK
 bRX
-bTk
+bMO
 bUJ
 bVL
 bXi
+YoR
 bYD
 bZF
 bZF
 bZG
-aaa
 bny
 ceS
 bUI
@@ -120193,28 +120462,28 @@ aaa
 aaa
 aaa
 aaa
-bAZ
+Yoq
+Yoq
+bFq
+You
 bCl
-bDT
-bDT
-bGX
-bDT
+YoC
 bJP
 bLo
 bMM
-bOp
-bPG
-bQL
-bPG
-bTl
-bUK
-bVM
+bTm
+bMO
+YoG
+bMO
+bMO
+bJO
+bJO
 bXj
+YoH
 bYD
 bZG
 bYE
 bZH
-aaa
 cdS
 ceT
 bUI
@@ -120449,29 +120718,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-bBa
-bCm
-bDU
-bFm
-bGY
-bFm
-bJQ
-bLp
-bMN
-bOq
-bPH
-bQM
-bRY
-bTm
-bUL
-bVN
-bQO
+Yoo
+bCl
+bDT
+bDT
+bGX
+Yoz
+YoB
+bJO
+bJO
+bMM
+bOp
+bPG
+bQL
+bPG
+bTl
+bJO
+bJO
+bXj
+YoH
 bYE
 bZH
 bYF
 bZG
-aaA
 cdS
 ceS
 bUI
@@ -120706,29 +120975,29 @@ aaa
 aaa
 aaa
 aaa
-aaa
-bBa
-bCn
-bDV
-bFn
-bGZ
-bId
+Yop
+bCm
+bDU
+bFm
+bGY
+bFm
+YoD
 bJR
 bLq
-bMO
-bMM
-bPI
-bFq
-bRZ
-bTn
-bFq
-bFq
-bFq
+bMN
+bOq
+bPH
+bQM
+bRY
+bTm
+YoK
+YoM
+YoP
+YoS
 bYF
 bZG
 bYE
 bZH
-aaA
 bny
 bny
 cdS
@@ -120960,32 +121229,32 @@ blQ
 aGf
 aaa
 aaa
-aaA
-aaA
-aaA
-aaA
-bBa
-bCo
-bDW
-bFo
-bHa
-bFm
-bJS
-bLr
+aaa
+aaa
+aaa
+Yop
+bCn
+bDV
+bFn
+bGZ
+bId
+YoB
+bJO
+bJO
 bMO
 bMM
-bPJ
+bPI
 bFq
-bSa
-bTo
-bUM
-bVO
+bRZ
+bTn
 bFq
+bFq
+bFq
+adC
 bYE
 bZH
 bYF
 bZG
-aaa
 aaC
 aaA
 aaa
@@ -121217,32 +121486,32 @@ blQ
 aGf
 aaA
 aaA
-aaa
-aaa
-aaa
-aaa
-bBa
-bCp
-bDX
-bFp
-bHb
-bAZ
+aaA
+aaA
+aaA
+Yop
+bCo
+bDW
+bFo
+bHa
+bFm
+YoE
 bJT
-bLs
+bLq
 bMO
-bOr
+bMM
+bPJ
 bFq
+bSa
+bTo
+bUM
+bVO
 bFq
-bSb
-bTp
-bQO
-bVP
-bFq
+aaa
 bYF
 bZF
 bZF
 bZH
-aaa
 aaC
 aaA
 aaa
@@ -121477,23 +121746,23 @@ aaa
 aaa
 aaa
 aaa
-aaa
+Yop
+bCp
+bDX
+bFp
+bHb
 bAZ
-bCq
-bDT
-bDT
-bHc
-bIe
-bJU
-bLt
+YoB
+bJO
+bJO
 bMO
-bOs
+bOr
 bFq
-bQN
-bSc
-bTq
+bFq
+bSb
+bTp
 bQO
-bVQ
+bVP
 bFq
 aaa
 aaa
@@ -121734,23 +122003,23 @@ aaA
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-bFq
+Yoo
+Yor
+Yos
+Yos
+Yov
 bHd
 bIf
 bJV
-bLu
+bLq
 bMO
-bOt
+bOs
 bFq
+bQN
+bSc
+bTq
 bQO
-bQO
-bQO
-bFq
-bVR
+bVQ
 bFq
 aaa
 aaa
@@ -121995,20 +122264,20 @@ aaa
 aaa
 aaa
 aaa
-bFq
 bHe
+YoA
+YoF
+bJO
+bJO
+bMO
+bOt
 bFq
-bFq
-bFq
-bFq
-bFq
-bFq
-aaA
-aaA
-aaA
-aaA
-aaa
-aaA
+YoH
+YoH
+YoH
+adC
+YoN
+adC
 aaa
 aaa
 aaa
@@ -122252,17 +122521,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
-bHf
-aaa
-aaa
-aaa
-aaa
+Yow
+adC
+adC
+adC
+adC
+adC
+adC
+adC
 aaA
-aaa
-aaa
-aaa
-aaa
+aaA
+aaA
 aaA
 aaa
 aaA
@@ -122509,8 +122778,8 @@ aaa
 aaa
 aaa
 aaa
+bHf
 aaa
-bHg
 aaa
 aaa
 aaa
@@ -122520,9 +122789,9 @@ aaa
 aaa
 aaa
 aaa
-aCa
+aaA
 aaa
-aGf
+aaA
 aaa
 aaa
 aaa
@@ -122766,20 +123035,20 @@ aaa
 aaa
 aaa
 aaa
+bHg
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaC
 aaa
 aaa
 aaa
 aaa
 aaA
 aaa
-aaA
+aaa
+aaa
+aaa
+aCa
+aaa
+aGf
 aaa
 aaa
 aaa
@@ -123039,7 +123308,7 @@ aaa
 aaA
 aaa
 aaa
-aaa
+adC
 aaa
 aaa
 aaA
@@ -123800,14 +124069,14 @@ aaa
 aaa
 aaa
 aaa
+aaC
+aaa
+aaa
+aaa
+aaa
 aaA
 aaa
-aaa
-aaa
-aaa
-aCa
-aaa
-aGf
+aaA
 aaa
 aaa
 aaa
@@ -124062,10 +124331,10 @@ aaa
 aaa
 aaa
 aaa
-aaA
+aCa
 aaa
-aaA
-aae
+aGf
+aaa
 aaa
 aaa
 aaa
@@ -124314,7 +124583,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaA
 aaa
 aaa
 aaa
@@ -124322,7 +124591,7 @@ aaa
 aaA
 aaa
 aaA
-aaa
+aae
 aaa
 aaa
 aaa
@@ -125090,9 +125359,9 @@ aaa
 aaa
 aaa
 aaa
-aCa
+aaA
 aaa
-aGf
+aaA
 aaa
 aaa
 aaa
@@ -125347,9 +125616,9 @@ aaa
 aaa
 aaa
 aaa
-aaA
+aCa
 aaa
-aaA
+aGf
 aaa
 aaa
 aaa
@@ -126374,11 +126643,11 @@ aaa
 aaa
 aaa
 aaa
-aaA
-aCa
 aaa
-aGf
 aaA
+aaa
+aaA
+aaa
 aaa
 aaa
 aaa
@@ -126630,13 +126899,13 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aaA
+YoL
+YoO
+YoQ
 aaA
-bQQ
-bVS
-bQQ
-aaA
-aaA
+aaa
 aaa
 aaa
 aaa
@@ -126886,15 +127155,15 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aaA
-aaA
-bTr
+YoI
 bQQ
-bVT
+bVS
 bQQ
-bTr
+YoI
 aaA
-aaA
+aaa
 aaa
 aaa
 aaa
@@ -127142,17 +127411,17 @@ aaa
 aaa
 aaa
 aaa
+aaa
 aaA
+YoI
+bTr
+bQQ
+bVT
+bQQ
+bTr
+YoI
 aaA
-bQQ
-bQQ
-bUN
-bVS
-bXk
-bQQ
-bQQ
-aaA
-aaA
+aaa
 aaa
 aaa
 aaa
@@ -127249,6 +127518,263 @@ aaa
 aaa
 "}
 (227,1,1) = {"
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaA
+YoI
+bQQ
+bQQ
+bUN
+bVS
+bXk
+bQQ
+bQQ
+YoI
+aaA
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+"}
+(228,1,1) = {"
 aaa
 aaa
 aaa
@@ -127505,7 +128031,7 @@ aaa
 aaa
 aaa
 "}
-(228,1,1) = {"
+(229,1,1) = {"
 aaa
 aaa
 aaa
@@ -127762,263 +128288,6 @@ aaa
 aaa
 aaa
 "}
-(229,1,1) = {"
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaA
-bQP
-bQP
-bTu
-bUO
-bUO
-bUO
-bYI
-bQP
-bQP
-aaA
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-"}
 (230,1,1) = {"
 aaa
 aaa
@@ -128171,15 +128440,15 @@ aaa
 aaa
 aaa
 aaA
-aaA
-bQQ
-bQQ
-bUP
-bVV
-bXl
-bYJ
-bYJ
-aaA
+adC
+bQP
+bTu
+bUO
+bUO
+bUO
+bYI
+bQP
+adC
 aaA
 aaa
 aaa
@@ -128427,17 +128696,17 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaA
 aaA
-bTr
+bIk
 bQQ
-bVW
-bQQ
-bTr
+bUP
+bVV
+bXl
+bYJ
+YoT
 aaA
 aaA
-aaa
 aaa
 aaa
 aaa
@@ -128685,15 +128954,15 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaA
 aaA
+YoJ
 bQQ
-bQP
+bVW
 bQQ
+YoJ
 aaA
 aaA
-aaa
 aaa
 aaa
 aaa
@@ -128943,13 +129212,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaA
 aaA
+bIk
+adC
+bIk
 aaA
 aaA
-aaA
-aaa
 aaa
 aaa
 aaa
@@ -129201,11 +129470,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaA
 aaA
 aaA
-aaa
+aaA
+aaA
 aaa
 aaa
 aaa
@@ -129459,9 +129728,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaA
-aaa
+aaA
+aaA
 aaa
 aaa
 aaa
@@ -129974,7 +130243,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaA
 aaa
 aaa
 aaa


### PR DESCRIPTION

#### Optimization changes for piping in Toxins Mixing.

Now that Utah has taught me about Map Merge, re-PR'd from [https://github.com/yogstation13/yogstation/pull/1294](PR#1294)

The use of hidden piping and a jumbled set up lead to confusion for some new to the advanced sciences of bomb manufacture. This change optimizes the layout, and changes pipe types from hidden to visible to ensure there is minimal confusion when working with gaseous plasma.

<img src="http://image.prntscr.com/image/0a07e70d31594009b12f936b9a978cad.png">

Old on the left, Pay no attention to the right... Updated image here:

<img src="http://image.prntscr.com/image/15e322b724734aa88020bf00145416e8.png">

##### Changelog

:cl:
rscadd: NT Engineering Division has had their pipefitters in to optimize toxin mixing for the lowest common denominator among the science staff.
/:cl:
