### PR TITLE
[s] Makes IC pretty-filters silent

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -2,7 +2,12 @@
 /mob/verb/say_verb(message as text)
 	set name = "Say"
 	set category = "IC"
+	var/oldmsg = message
 	message = pretty_filter(message)
+	if(oldmsg != message) //Immersive pretty filters
+		usr << "<span class='notice'>You fumble over your words.</span>"
+		message_admins("[key_name(usr)] just tripped a pretty filter: '[oldmsg]'.")
+		return
 	log_say("[name] : [message]")
 	if(say_disabled)	//This is here to try to identify lag problems
 		usr << "<span class='danger'>Speech is currently admin-disabled.</span>"
@@ -12,7 +17,12 @@
 /mob/verb/whisper(message as text)
 	set name = "Whisper"
 	set category = "IC"
+	var/oldmsg = message
 	message = pretty_filter(message)
+	if(oldmsg != message)
+		usr << "<span class='notice'>You fumble over your words.</span>"
+		message_admins("[key_name(usr)] just tripped a pretty filter: '[oldmsg]'.")
+		return
 	log_whisper("[name] : [message]")
 	if(say_disabled)	//This is here to try to identify lag problems
 		usr << "<span class='danger'>Speech is currently admin-disabled.</span>"


### PR DESCRIPTION
#### Intent of your Pull Request

Now whenever you trip a pretty filter in whisper or say, instead of BANMEADMINS it just goes silent instead. The player is notified with a "You fumble over your words." and admins get a message stating what was changed.

Muh immershuns.

It has been tested, it works fine.
Also I wanted to test how adding `[s]` works but this doesn't actually have to be hidden away from players though.
