### PR TITLE
Removes "Adolph" and "Goebbels" from the random name list

### DIFF
--- a/config/names/ai.txt
+++ b/config/names/ai.txt
@@ -46,7 +46,6 @@ ED-209
 Emma-2
 Erasmus
 Ez-27
-Fagor
 Faith
 Fi
 FRIEND COMPUTER

--- a/config/names/first_male.txt
+++ b/config/names/first_male.txt
@@ -5,7 +5,6 @@ Abraham
 Adam
 Adan
 Aden
-Adolph
 Adrian
 Aidan
 Aiden

--- a/config/names/last.txt
+++ b/config/names/last.txt
@@ -173,7 +173,6 @@ Garrison
 Gettemy
 Gibson
 Glover
-Goebbles
 Goodman
 Graham
 Gray


### PR DESCRIPTION
Since these guys aren't exactly paragons of justice

We would ban people with these names anyway, so good thing to remove them from the list

https://en.wikipedia.org/wiki/Adolf_Hitler

https://en.wikipedia.org/wiki/Joseph_Goebbels

:cl:
rscdel: "Adolph", "Goebbels" and "Fagor" have been removed from the list of random names.
/:cl:

