### PR TITLE
Enabled roundstart signal technicians.

### DIFF
--- a/code/modules/jobs/job_types/engineering.dm
+++ b/code/modules/jobs/job_types/engineering.dm
@@ -161,6 +161,3 @@ Signal Technician
 	dufflebag = /obj/item/weapon/storage/backpack/dufflebag/engineering
 	box = /obj/item/weapon/storage/box/engineer
 	pda_slot = slot_l_store
-
-/datum/job/signal_tech/config_check()
-	return 0


### PR DESCRIPTION
I merged #1195 to avoid all the map conflicts, but disabled the job. This enables it again.