### PR TITLE
Ported /tg/'s fixed custom war declarations

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear_challenge.dm
+++ b/code/game/gamemodes/nuclear/nuclear_challenge.dm
@@ -10,24 +10,42 @@
 	desc = "Use to send a declaration of hostilities to the target, delaying your shuttle departure for 20 minutes while they prepare for your assault.  \
 			Such a brazen move will attract the attention of powerful benefactors within the Syndicate, who will supply your team with a massive amount of bonus telecrystals.  \
 			Must be used within five minutes, or your benefactors will lose interest."
-	var/declaring_war = 0
+	var/declaring_war = FALSE
 
 /obj/item/device/nuclear_challenge/attack_self(mob/living/user)
 	if(!check_allowed(user))
 		return
 
-	declaring_war = 1
-	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]]. Are you sure you want to alert the enemy crew?", "Declare war?", "Yes", "No")
-	declaring_war = 0
-	if(are_you_sure == "No")
-		user << "On second thought, the element of surprise isn't so bad after all."
-		return
+	declaring_war = TRUE
+	var/are_you_sure = alert(user, "Consult your team carefully before you declare war on [station_name()]]. Are you sure you want to alert the enemy crew? You have [-round((world.time-round_start_time - CHALLENGE_TIME_LIMIT)/10)] seconds to decide", "Declare war?", "Yes", "No")
+	declaring_war = FALSE
+
 	if(!check_allowed(user))
 		return
 
-	declaring_war = 1
+	if(are_you_sure == "No")
+		user << "On second thought, the element of surprise isn't so bad after all."
+		return
+
 	var/war_declaration = "[user.real_name] has declared his intent to utterly destroy [station_name()] with a nuclear device, and dares the crew to try and stop them."
+
+	declaring_war = TRUE
+	var/custom_threat = alert(user, "Do you want to customize your declaration?", "Customize?", "Yes", "No")
+	declaring_war = FALSE
+
+	if(!check_allowed(user))
+		return
+
+	if(custom_threat == "Yes")
+		declaring_war = TRUE
+		war_declaration = stripped_input(user, "Insert your custom declaration", "Declaration")
+		declaring_war = FALSE
+
+	if(!check_allowed(user) || !war_declaration)
+		return
+
 	priority_announce(war_declaration, title = "Declaration of War", sound = 'sound/machines/Alarm.ogg')
+
 	user << "You've attracted the attention of powerful forces within the syndicate. A bonus bundle of telecrystals has been granted to your team. Great things await you if you complete the mission."
 
 	for(var/V in syndicate_shuttle_boards)
@@ -43,6 +61,7 @@
 
 /obj/item/device/nuclear_challenge/proc/check_allowed(mob/living/user)
 	if(declaring_war)
+		user << "You are already in the process of declaring war! Make your mind up."
 		return 0
 	if(player_list.len < CHALLENGE_MIN_PLAYERS)
 		user << "The enemy crew is too small to be worth declaring war on."
@@ -50,8 +69,8 @@
 	if(user.z != ZLEVEL_CENTCOM)
 		user << "You have to be at your base to use this."
 		return 0
-	if(world.time > CHALLENGE_TIME_LIMIT)
-		user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make  do with what you have on hand."
+	if(world.time-round_start_time > CHALLENGE_TIME_LIMIT)
+		user << "It's too late to declare hostilities. Your benefactors are already busy with other schemes. You'll have to make do with what you have on hand."
 		return 0
 	for(var/V in syndicate_shuttle_boards)
 		var/obj/item/weapon/circuitboard/computer/syndicate_shuttle/board = V


### PR DESCRIPTION
closes #1341

:cl: AdamElTablawy
rscadd: Nuclear Operatives can now customize the message broadcast to the station when declaring war. Ported from /tg/.
/:cl:

