### PR TITLE
Toxin Cooling Piping & TileDir Fix, now Merge Conflict Free!

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -42817,17 +42817,14 @@
 /turf/closed/wall/r_wall,
 /area/toxins/mixing)
 "bHd" = (
-/turf/open/floor/plating,
-/turf/open/floor/plasteel/warningline/corner{
-	dir = 1
-	},
 /obj/machinery/meter{
 	name = "Heat Exchanger"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	color = "#000000"
 	},
-/turf/open/floor/plasteel/warningline{
+/turf/open/floor/plating{
+	icon_state = "warnplate";
 	dir = 4
 	},
 /area/toxins/mixing)
@@ -43287,15 +43284,12 @@
 /turf/open/floor/engine,
 /area/toxins/mixing)
 "bIf" = (
-/turf/open/floor/plating,
-/turf/open/floor/plasteel/warningline{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	dir = 1;
 	name = "Heat Exchanger input"
 	},
-/turf/open/floor/plasteel/warningline{
+/turf/open/floor/plating{
+	icon_state = "warnplate";
 	dir = 4
 	},
 /area/toxins/mixing)
@@ -44198,54 +44192,42 @@
 /turf/open/floor/plasteel,
 /area/toxins/mixing)
 "bJP" = (
-/turf/open/floor/plating,
-/turf/open/floor/plasteel/warningline{
-	dir = 8
-	},
 /obj/machinery/meter{
 	name = "Heat Exchanger output"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plasteel/warningline{
+/turf/open/floor/plating{
+	icon_state = "warnplate";
 	dir = 4
 	},
 /area/toxins/mixing)
 "bJR" = (
-/turf/open/floor/plating,
-/turf/open/floor/plasteel/warningline{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 2;
 	name = "output valve"
 	},
-/turf/open/floor/plasteel/warningline{
+/turf/open/floor/plating{
+	icon_state = "warnplate";
 	dir = 4
 	},
 /area/toxins/mixing)
 "bJT" = (
-/turf/open/floor/plating,
-/turf/open/floor/plasteel/warningline{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 1;
 	name = "input valve"
 	},
-/turf/open/floor/plasteel/warningline{
+/turf/open/floor/plating{
+	icon_state = "warnplate";
 	dir = 4
 	},
 /area/toxins/mixing)
 "bJV" = (
-/turf/open/floor/plating,
-/turf/open/floor/plasteel/warningline{
-	dir = 8
-	},
 /obj/machinery/meter{
 	name = "Heat Exchanger input"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plasteel/warningline{
+/turf/open/floor/plating{
+	icon_state = "warnplate";
 	dir = 4
 	},
 /area/toxins/mixing)
@@ -44905,18 +44887,13 @@
 /turf/open/floor/plating,
 /area/maintenance/asmaint2)
 "bLo" = (
-/turf/open/floor/plating,
-/turf/open/floor/plasteel/warningline{
-	dir = 6
-	},
-/turf/open/floor/plasteel/warningline{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel/warningline{
-	dir = 4
+/turf/open/floor/plating{
+	tag = "icon-warnplate (SOUTHEAST)";
+	icon_state = "warnplate";
+	dir = 6
 	},
 /area/toxins/mixing)
 "bLq" = (
@@ -68891,7 +68868,6 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "Yon" = (
-/turf/open/floor/plasteel,
 /obj/machinery/computer/atmos_control/tank{
 	frequency = 1441;
 	input_tag = "burn_in";
@@ -68899,8 +68875,8 @@
 	output_tag = "burn_out";
 	sensors = list("burn_sensor" = "Tank")
 	},
-/turf/open/floor/plasteel/warningline{
-	dir = 1
+/turf/open/floor/plasteel/warning{
+	dir = 5
 	},
 /area/toxins/mixing)
 "Yot" = (
@@ -68952,7 +68928,6 @@
 /turf/closed/wall/r_wall,
 /area/toxins/mixing)
 "YoA" = (
-/turf/open/floor/plasteel,
 /obj/machinery/camera{
 	c_tag = "Toxins Mixing Room North";
 	network = list("SS13","RD")
@@ -68962,36 +68937,28 @@
 /obj/item/weapon/screwdriver{
 	pixel_y = 10
 	},
-/turf/open/floor/plasteel/warningline{
+/turf/open/floor/plasteel/warning{
 	dir = 1
 	},
 /area/toxins/mixing)
 "YoB" = (
-/turf/open/floor/plasteel,
-/turf/open/floor/plasteel/warningline{
-	dir = 1
+/turf/open/floor/plasteel/warning{
+	dir = 5
 	},
 /area/toxins/mixing)
 "YoC" = (
-/turf/open/floor/plating,
-/turf/open/floor/plasteel/warningline{
-	dir = 8
-	},
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
 /obj/machinery/atmospherics/components/binary/volume_pump{
 	name = "Heat Exchanger output"
 	},
-/turf/open/floor/plasteel/warningline{
+/turf/open/floor/plating{
+	icon_state = "warnplate";
 	dir = 4
 	},
 /area/toxins/mixing)
 "YoD" = (
-/turf/open/floor/plating,
-/turf/open/floor/plasteel/warningline{
-	dir = 8
-	},
 /obj/machinery/embedded_controller/radio/airlock_controller{
 	airpump_tag = "tox_airlock_pump";
 	exterior_door_tag = "tox_airlock_exterior";
@@ -69006,15 +68973,12 @@
 	name = "Output"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plasteel/warningline{
+/turf/open/floor/plating{
+	icon_state = "warnplate";
 	dir = 4
 	},
 /area/toxins/mixing)
 "YoE" = (
-/turf/open/floor/plating,
-/turf/open/floor/plasteel/warningline{
-	dir = 8
-	},
 /obj/machinery/button/door{
 	id = "mixvent";
 	name = "Mixing Room Vent Control";
@@ -69031,7 +68995,8 @@
 	name = "Input"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plasteel/warningline{
+/turf/open/floor/plating{
+	icon_state = "warnplate";
 	dir = 4
 	},
 /area/toxins/mixing)
@@ -69178,6 +69143,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"Zyo" = (
+/turf/open/floor/plasteel/warning{
+	dir = 4
+	},
+/area/toxins/mixing)
 "Zyp" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Teleporter Room";
@@ -119977,8 +119947,8 @@ bny
 csk
 bGW
 YoB
-bJO
-bJO
+Zyo
+Zyo
 bML
 bOo
 bPF
@@ -120246,8 +120216,8 @@ bJO
 bJO
 bXj
 bQO
-bYD
-bZG
+aaa
+aaa
 bYE
 bZH
 cdS
@@ -120491,8 +120461,8 @@ bDT
 bGX
 Yoz
 Yon
-bJO
-bJO
+Zyo
+Zyo
 bMM
 bOp
 bPG
@@ -120503,8 +120473,8 @@ bJO
 bJO
 bXj
 bQO
-bYE
-bZH
+aaa
+aaa
 bYF
 bZG
 cdS
@@ -120749,7 +120719,7 @@ bGY
 bFm
 YoD
 bJR
-bLq
+bLo
 bMN
 bOq
 bPH
@@ -120760,7 +120730,7 @@ YoK
 YoM
 YoP
 YoS
-bYF
+bYD
 bZG
 bYE
 bZH
@@ -121005,8 +120975,8 @@ bFn
 bGZ
 bId
 YoB
-bJO
-bJO
+Zyo
+Zyo
 bMO
 bMM
 bPI
@@ -121263,7 +121233,7 @@ bHa
 bFm
 YoE
 bJT
-bLq
+bLo
 bMO
 bMM
 bPJ
@@ -121275,8 +121245,8 @@ bVO
 bFq
 aaa
 bYF
-bZF
-bZF
+bZG
+bYE
 bZH
 aaC
 aaA
@@ -121519,8 +121489,8 @@ bFp
 bHb
 bAZ
 YoB
-bJO
-bJO
+Zyo
+Zyo
 bMO
 bOr
 bFq
@@ -121532,8 +121502,8 @@ bVP
 bFq
 aaa
 aaa
-aaa
-aaa
+bYF
+bZH
 aaa
 aaA
 aaA
@@ -121777,7 +121747,7 @@ Yov
 bHd
 bIf
 bJV
-bLq
+bLo
 bMO
 bOs
 bFq


### PR DESCRIPTION
Refer to issue #1320 
And closed PR: 1323

#### Fixes Chiller Loop, and updates floor tile dir values for cosmetic reasons.

My bad, my fix. Tossed my original changes while I was figuring out the map merge stuff, it's fixed and tested here. Merge me real good, Cruix!

##### Changelog

:cl:
bugfix: NT pipefitters fired for not working in space to update the coolant loop along with the rest of Toxins Mixing. Scabs performed the work admirably, and all is well in Science again!
/:cl:
