### PR TITLE
blob tweaks

### DIFF
--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -14,7 +14,7 @@
 	var/health_regen = 2 //how much health this blob regens when pulsed
 	var/pulse_timestamp = 0 //we got pulsed/healed when?
 	var/brute_resist = 0.8 //multiplies brute damage by this
-	var/fire_resist = 2 //multiplies burn damage by this
+	var/fire_resist = 1.5 //multiplies burn damage by this
 	var/atmosblock = 0 //if the blob blocks atmos
 	var/heatblock = 0 // if the blob blocks heatspread
 	var/mob/camera/blob/overmind

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -544,6 +544,8 @@
 	analyzerdescdamage = "Does medium freezing damage and kills unconscious humans, reaping resources from them."
 	color = "#8BA6E9"
 	complementary_color = "#E9CE8B"
+	message = "The blob splashes you with an icy liquid"
+	message_living = ", and you feel as cold as death"
 
 /datum/reagent/blob/frost_nexuses/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
 	reac_volume = ..()

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -134,10 +134,10 @@
 /datum/reagent/blob/energized_fibers
 	name = "Energized Fibers"
 	id = "energized_fibers"
-	description = "will do low burn and high stamina damage and conduct electricity, but is weak to EMPs."
+	description = "will do low burn and high stamina damage and conduct electricity."
 	shortdesc = "will do low burn and high stamina damage."
 	analyzerdescdamage = "Does low burn damage and massively drains stamina."
-	analyzerdesceffect = "Is immune to electricity and will easily conduct it, but is weak to EMPs."
+	analyzerdesceffect = "Is immune to electricity and will easily conduct it."
 	color = "#EFD65A"
 	complementary_color = "#5A73EF"
 	blobbernaut_message = "shocks"
@@ -152,9 +152,9 @@
 /datum/reagent/blob/energized_fibers/tesla_reaction(obj/effect/blob/B, power)
 	return 0
 
-/datum/reagent/blob/energized_fibers/emp_reaction(obj/effect/blob/B, severity)
+/*/datum/reagent/blob/energized_fibers/emp_reaction(obj/effect/blob/B, severity) // commented out for the time being because tesla EMPs stuff
 	var/damage = rand(30, 50) - severity * rand(10, 15)
-	B.take_damage(damage, BURN)
+	B.take_damage(damage, BURN)*/
 
 //sets you on fire, does burn damage, weak to water
 /datum/reagent/blob/boiling_oil
@@ -274,8 +274,9 @@
 
 /datum/reagent/blob/zombifying_feelers/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
 	reac_volume = ..()
-	if(O && ishuman(M) && M.stat == UNCONSCIOUS)
-		M.death() //sleeping in a fight? bad plan.
+	if(O && ishuman(M) && M.stat != CONSCIOUS)
+		if(M.stat != DEAD)
+			M.death() //sleeping in a fight? bad plan.
 		var/mob/living/simple_animal/hostile/blob/blobspore/BS = new/mob/living/simple_animal/hostile/blob/blobspore/weak(get_turf(M))
 		BS.overmind = O
 		BS.update_icons()
@@ -393,7 +394,7 @@
 			return damage * 1.5 //take more from fire, tesla, and flashbangs
 	return ..()
 
-//does semi-random brute damage and reacts to brute damage
+/*/does semi-random brute damage and reacts to brute damage
 /datum/reagent/blob/reactive_gelatin
 	name = "Reactive Gelatin"
 	id = "reactive_gelatin"
@@ -417,10 +418,10 @@
 			B.visible_message("<span class='warning'><b>The blob retaliates, lashing out!</b></span>")
 		for(var/atom/A in range(1, B))
 			A.blob_act(B)
-	return ..()
+	return ..()*/
 
 //does low burn damage and stamina damage and cools targets down
-/datum/reagent/blob/cryogenic_liquid
+/*/datum/reagent/blob/cryogenic_liquid
 	name = "Cryogenic Liquid"
 	id = "cryogenic_liquid"
 	description = "will do low burn and stamina damage, and cause targets to freeze."
@@ -438,7 +439,7 @@
 		M.reagents.add_reagent("ice", 0.3*reac_volume)
 	M.apply_damage(0.4*reac_volume, BURN)
 	if(M)
-		M.adjustStaminaLoss(0.3*reac_volume)
+		M.adjustStaminaLoss(0.3*reac_volume)*/
 
 //does burn damage and EMPs, slightly fragile
 /datum/reagent/blob/electromagnetic_web
@@ -511,32 +512,40 @@
 	else
 		return damage * 1.25
 
-//does brute damage through armor and bio resistance
-/datum/reagent/blob/penetrating_spines
-	name = "Penetrating Spines"
+//does brute damage through armor and bio resistance, also combined with reactive gel to repel melee
+/datum/reagent/blob/reactive_spines
+	name = "Reactive Spines"
 	id = "penetrating_spines"
-	description = "will do medium brute damage through armor and bio resistance."
+	description = "will do medium brute damage through armor and bio resistance, and repels brute damage."
 	analyzerdescdamage = "Does medium brute damage, ignoring armor and bio resistance."
-	color = "#6E4664"
+	color = "#990033"
 	complementary_color = "#466E50"
 	blobbernaut_message = "stabs"
 	message = "The blob stabs you"
 
-/datum/reagent/blob/penetrating_spines/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
+/datum/reagent/blob/reactive_spines/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
 	if(M.stat == DEAD || istype(M, /mob/living/simple_animal/hostile/blob))
 		return 0 //the dead, and blob mobs, don't cause reactions
 	M.adjustBruteLoss(0.7*reac_volume)
 
-/datum/reagent/blob/adaptive_nexuses
-	name = "Adaptive Nexuses"
-	id = "adaptive_nexuses"
-	description = "will do medium brute damage and kill unconscious targets, giving you bonus resources."
-	shortdesc = "will do medium brute damage and kill unconscious targets, giving your overmind bonus resources."
-	analyzerdescdamage = "Does medium brute damage and kills unconscious humans, reaping resources from them."
-	color = "#4A64C0"
-	complementary_color = "#823ABB"
+/datum/reagent/blob/reactive_spines/damage_reaction(obj/effect/blob/B, original_health, damage, damage_type, cause)
+	if(damage && damage_type == BRUTE && original_health - damage > 0) //is there any damage, is it brute, and will we be alive
+		if(isliving(cause))
+			B.visible_message("<span class='warning'><b>The blob retaliates, lashing out!</b></span>")
+		for(var/atom/A in range(1, B))
+			A.blob_act(B)
+	return ..()
 
-/datum/reagent/blob/adaptive_nexuses/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
+/datum/reagent/blob/frost_nexuses //cryo liquid and adaptive nexuses
+	name = "Frost Nexuses"
+	id = "frost_nexuses"
+	description = "will do medium burn damage and kill unconscious targets, giving you bonus resources. Also freezes victims."
+	shortdesc = "will do medium freezing damage and kill unconscious targets, giving your overmind bonus resources."
+	analyzerdescdamage = "Does medium freezing damage and kills unconscious humans, reaping resources from them."
+	color = "#8BA6E9"
+	complementary_color = "#E9CE8B"
+
+/datum/reagent/blob/frost_nexuses/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message, touch_protection, mob/camera/blob/O)
 	reac_volume = ..()
 	if(O && ishuman(M) && M.stat == UNCONSCIOUS)
 		PoolOrNew(/obj/effect/overlay/temp/revenant, get_turf(M))
@@ -544,8 +553,12 @@
 		O.add_points(points)
 		O << "<span class='notice'>Gained [points] resources from the death of [M].</span>"
 		M.death()
+	if(M.reagents)
+		M.reagents.add_reagent("frostoil", 0.3*reac_volume)
+		M.reagents.add_reagent("ice", 0.3*reac_volume)
+	M.apply_damage(0.4*reac_volume, BURN)
 	if(M)
-		M.apply_damage(0.6*reac_volume, BRUTE)
+		M.adjustStaminaLoss(0.3*reac_volume)
 
 //does low brute damage, oxygen damage, and stamina damage and wets tiles when damaged
 /datum/reagent/blob/pressurized_slime
@@ -675,7 +688,7 @@
 	M.eye_blind = 1
 	M.ear_deaf = 10
 	M.eye_blurry = 10
-	if(prob(10))
+	if(prob(5))
 		M.disabilities |= CLUMSY
 
 /datum/reagent/blob/proc/send_message(mob/living/M)


### PR DESCRIPTION
sets blob burn weakness to 1.5 down from 2, this makes welders and lasers do 30 damage rather than 40. Will it help? uh..... hopefully, blobs still die in one shot from lasers but 10 damage less per hit means something, right?

also combined some shitly types so they were more noticeable, 
reactive gelatin + penetrating spines to reactive spines, very clever I know
nexuses + cryo liquid to frost nexuses
also makes zombifying feelers zombie dead bodies that it attacks because it was a consistency issue that unconscious people could be possessed but dead ones could only be possessed by spores
:cl: ShadowDeath6
tweak: Slightly buffed blob resistance to burn damage.
tweak: Combined some slightly less useful blob types to form new ones.
rscadd: Reactive Spines- Repels brute damage and penetrates armor
rscadd: Frost Nexuses- Freezes victims and kills unconscious humans for more blobpoints.
/:cl:

