### PR TITLE
Fixes emojis

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -55,7 +55,7 @@
 	log_ooc("[mob.name]/[key] : [msg]")
 
 
-	if((copytext(msg, 1, 2) in list(".",";",":","#")) || (findtext(lowertext(copytext(msg, 1, 5)), "say")))
+	if((copytext(msg, 1, 2) in list(".",";","#")) || (findtext(lowertext(copytext(msg, 1, 5)), "say")))
 		if(alert("Your message \"[raw_msg]\" looks like it was meant for in game communication, say it in OOC?", "Meant for OOC?", "No", "Yes") != "Yes")
 			return
 


### PR DESCRIPTION
#### Intent of your Pull Request

Whenever you had ":" in your ooc message an annoying box would come up asking if it was meant for ooc.
Well, we don't use that for radio communication anyway. So this PR will disable that only for ":" so you can send emojis straight to OOC without pause.