### PR TITLE
Removes the ARG rifle from ERT commander on non-red alert

### DIFF
--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -105,8 +105,6 @@
 		/obj/item/weapon/storage/box/handcuffs=1,\
 		/obj/item/clothing/mask/gas/sechailer/swat=1,\
 		/obj/item/weapon/storage/box/emps=1,\
-		/obj/item/weapon/gun/projectile/automatic/ar=1,\
-		/obj/item/ammo_box/magazine/m556=2,\
 		/obj/item/weapon/gun/energy/pulse/carbine/loyalpin=1)
 	belt = /obj/item/weapon/storage/belt/military/assault
 	/*

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -38,7 +38,7 @@
 	backpack_contents = list(/obj/item/weapon/storage/box/engineer=1,\
 		/obj/item/weapon/melee/baton/loaded=1,\
 		/obj/item/clothing/mask/gas/sechailer/swat=1,\
-		/obj/item/weapon/gun/energy/gun=1,\)
+		/obj/item/weapon/gun/energy/gun=1)
 	l_pocket = /obj/item/weapon/kitchen/knife/combat
 
 /datum/outfit/ert/commander/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -38,9 +38,7 @@
 	backpack_contents = list(/obj/item/weapon/storage/box/engineer=1,\
 		/obj/item/weapon/melee/baton/loaded=1,\
 		/obj/item/clothing/mask/gas/sechailer/swat=1,\
-		/obj/item/weapon/gun/energy/gun=1,\
-		/obj/item/weapon/gun/projectile/automatic/ar=1,\
-		/obj/item/ammo_box/magazine/m556=2)
+		/obj/item/weapon/gun/energy/gun=1,\)
 	l_pocket = /obj/item/weapon/kitchen/knife/combat
 
 /datum/outfit/ert/commander/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)


### PR DESCRIPTION
#1407 

:cl:
tweak: The ERT commander now only gets the ARG rifle on red alert.
tweak. Red alert ERT security members no longer spawn with a useless ARG along with their plasma rifles.
/:cl:
