### PR TITLE
Edits the description of the QM cloak to be more accurate

### DIFF
--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -2,7 +2,7 @@
 
 /obj/item/clothing/suit/cloak
 	name = "brown cloak"
-	desc = "It's a cape that can be worn on your back."
+	desc = "Also known as a cape."
 	icon = 'icons/obj/clothing/cloaks.dmi'
 	icon_state = "qmcloak"
 	item_state = "qmcloak"


### PR DESCRIPTION
Changed from "It's a cape that can be worn on your back" to "Also known as a cape"

:cl:
tweak: The QM cloak's description no longer falsely says it can be worn on your back.
/:cl: