### PR TITLE
Fixed powernet runtimes

### DIFF
--- a/code/__HELPERS/type2type.dm
+++ b/code/__HELPERS/type2type.dm
@@ -489,47 +489,31 @@ for(var/t in test_times)
 /proc/color2hex(color)	//web colors
 	if(!color)
 		return "#000000"
-
-	switch(color)
-		if("white")
-			return "#FFFFFF"
-		if("black")
-			return "#000000"
-		if("gray")
-			return "#808080"
-		if("brown")
-			return "#A52A2A"
-		if("red")
-			return "#FF0000"
-		if("darkred")
-			return "#8B0000"
-		if("crimson")
-			return "#DC143C"
-		if("orange")
-			return "#FFA500"
-		if("yellow")
-			return "#FFFF00"
-		if("green")
-			return "#008000"
-		if("lime")
-			return "#00FF00"
-		if("darkgreen")
-			return "#006400"
-		if("cyan")
-			return "#00FFFF"
-		if("blue")
-			return "#0000FF"
-		if("navy")
-			return "#000080"
-		if("teal")
-			return "#008080"
-		if("purple")
-			return "#800080"
-		if("indigo")
-			return "#4B0082"
-		else
-			return "#FFFFFF"
-
+	var/hex
+	var/static/list/color2hexes = list(
+	"white"		= "#FFFFFF",
+	"black"		= "#000000",
+	"gray"		= "#808080",
+	"brown"		= "#A52A2A",
+	"red"		= "#FF0000",
+	"darkred"	= "#8B0000",
+	"crimson"	= "#DC143C",
+	"orange"	= "#FFA500",
+	"yellow"	= "#FFFF00",
+	"green"		= "#008000",
+	"lime"		= "#00FF00",
+	"darkgreen"	= "#006400",
+	"cyan"		= "#00FFFF",
+	"blue"		= "#0000FF",
+	"navy"		= "#000080",
+	"teal"		= "#008080",
+	"purple"	= "#800080",
+	"indigo"	= "#4B0082"
+	)
+	hex = color2hexes[color]
+	if(!hex)
+		hex = "#FFFFFF"
+	return hex
 
 //This is a weird one:
 //It returns a list of all var names found in the string

--- a/code/modules/power/terminal.dm
+++ b/code/modules/power/terminal.dm
@@ -86,7 +86,7 @@
 	return ..()
 
 /obj/machinery/power/terminal/proc/add_wires()
-	if(master)
+	if(istype(master, /obj/machinery/power/apc))
 		var/obj/machinery/power/apc/APC = src.master
 		wiring_color = APC.wiring_color
 		var/image/I = new('icons/obj/power.dmi', "term_wire")


### PR DESCRIPTION
Compressed the color2hex() proc.
Fixed SMES terminal runtime from an inappropriate typecast.