### PR TITLE
Bartenders spawn with zippo lighters

### DIFF
--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -125,6 +125,7 @@ Bartender
 	suit = /obj/item/clothing/suit/armor/vest
 	backpack_contents = list(/obj/item/weapon/storage/box/beanbag=1)
 	shoes = /obj/item/clothing/shoes/laceup
+	l_pocket = /obj/item/weapon/lighter
 
 /datum/job/bartender/space
 	title = "Space Bartender"


### PR DESCRIPTION
#### Intent of your Pull Request

It doesn't spawn on the map, so...

##### Changelog

:cl:
tweak: Bartenders spawn with zippo lighters.
/:cl:
