### PR TITLE
You can now have multiple links awaiting approval at the same time

### DIFF
--- a/code/modules/admin/linkapproval/link_request.dm
+++ b/code/modules/admin/linkapproval/link_request.dm
@@ -13,9 +13,10 @@
 			usr << "<span class='boldnotice'>Error: This link is already under approval.</span>"
 			return
 
-		if(ckey(test.poster) == ckey(usr))
-			usr << "<span class='boldnotice'>Error: You already have a link waiting for approval.</span>"
-			return
+		//if(ckey(test.poster) == ckey(usr))
+			//usr << "<span class='boldnotice'>Error: You already have a link waiting for approval.</span>"
+			//return
+			//This causes some bugs
 
 	var/datum/link_approval/link = new /datum/link_approval(hyperlink)
 	link_approval_list += link


### PR DESCRIPTION
Fixes #1313 

I'm so cool I implement my own issues

So basically this comments out the entire function

This makes it so if admins don't notice your link, you're no longer denied from having your links approved til the end of the round

This should also fix some bugs regarding people getting the error while having approved no links during the entire round

And before timato asks, YES I did test this out and it worked perfectly

:cl:
tweak: You can now have multiple links awaiting approval at the same time.
tweak: This means you no longer have to wait the entire round for admins to notice your link before you can get a new one approved.
bugfix: This should ALSO fix some bugs regarding people not being able to use the function at all.
/:cl:
