### PR TITLE
Comments the "antag weight stat verb" out

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -281,7 +281,7 @@ var/next_external_rsc = 0
 		admin_memo_output("Show")
 		if((global.comms_key == "default_pwd" || length(global.comms_key) <= 6) && global.comms_allowed) //It's the default value or less than 6 characters long, but it somehow didn't disable comms.
 			src << "<span class='danger'>The server's API key is either too short or is the default value! Consider changing it immediately!</span>"
-		verbs += /client/verb/weightstats
+		//verbs += /client/verb/weightstats
 
 	add_verbs_from_config()
 	set_client_age_from_db()

--- a/code/modules/client/verbs/weightinfo.dm
+++ b/code/modules/client/verbs/weightinfo.dm
@@ -1,4 +1,4 @@
-/client/verb/weightstats()
+/*/client/verb/weightstats()
 	set name = "Antag Weight Stats"
 	set category = "OOC"
 	set desc = "Shows information about your current antagonist weight."
@@ -43,3 +43,6 @@
 		src << "(Some statistics are cached for performance purposes, and may be slightly inaccurate.)"
 	else
 		src << "No database connection detected!"
+*/
+
+//Also uncomment code\modules\client\client_procs line 284


### PR DESCRIPTION
It hardly works. 
Aswell, there was an exploit wich allowed you to see the current rountype with it. More or less.

I don't think people should see it anyway.

REMOVE DONT IMPROVE

:cl:
rscdel: Removes the antag weight stat verb
/:cl: