### PR TITLE
Severely nerfs more ashwalker gear

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -55,7 +55,7 @@
 	min_cold_protection_temperature = GLOVES_MIN_TEMP_PROTECT
 	max_heat_protection_temperature = GLOVES_MAX_TEMP_PROTECT
 	burn_state = FIRE_PROOF
-	armor = list(melee = 15, bullet = 35, laser = 35, energy = 20, bomb = 35, bio = 35, rad = 35) //Not like anything ever hits the arms anyways.
+	armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 10, bio = 10, rad = 0)
 
 /obj/item/clothing/gloves/chitinhands
 	name = "chitin gauntlets"
@@ -67,4 +67,4 @@
 	put_on_delay = 20
 	body_parts_covered = ARMS
 	burn_state = FIRE_PROOF
-	armor = list(melee = 35, bullet = 50, laser = 45, energy = 30, bomb = 50, bio = 50, rad = 40)
+	armor = list(melee = 15, bullet = 35, laser = 35, energy = 20, bomb = 35, bio = 35, rad = 35)

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -105,7 +105,6 @@
 	body_parts_covered = LEGS|FEET
 	burn_state = FIRE_PROOF
 	can_hold_items = 1
-	armor = list(melee = 35, bullet = 35, laser = 0, energy = 10, bomb = 25, bio = 0, rad = 0)
 
 /obj/item/clothing/shoes/jackboots
 	name = "jackboots"


### PR DESCRIPTION
#### Intent of your Pull Request

I would've removed all of the armor in the first place if bone bracers didn't have armor before chitin gauntlets. So I threw their armor values around, and nerfed them.

Bone bracers is far more weaker than it once was.
Chitin Gauntlets are fairly strong.

The reason for this was because in combination, chitin gauntlets, chitin shoes, and chitin plate people were able to **tank legion attacks** for a full on 5 minutes and make it out **with only getting 10 brute damage**. Enough is enough, and I'm sure we heard of 

https://github.com/yogstation13/yogstation/pull/1423

But that only nerfed the plates, not the rest. This is the fallout

Bone Bracer Initially: `armor = list(melee = 15, bullet = 35, laser = 35, energy = 20, bomb = 35, bio = 35, rad = 35)`
Bone Bracer: `armor = list(melee = 5, bullet = 5, laser = 5, energy = 0, bomb = 10, bio = 10, rad = 0)`
Gauntlets Initially: `armor = list(melee = 35, bullet = 50, laser = 45, energy = 30, bomb = 50, bio = 50, rad = 40)  `
Gauntlets: `armor = list(melee = 15, bullet = 35, laser = 35, energy = 20, bomb = 35, bio = 35, rad = 35)`

i was debating on just getting rid of gauntlets, but instead i gave them bone bracer levels, and bone bracers the lesser. it's best to hear other peoples opinions on this

and the shoes lose their armor values completely. you can still put knives inside of them. yes, i know pathfinder shoes lets you do the same knive thing, but pathfinder is irrevelant given the ashwalker overhaul. and, the gear needs a rework (that I tried to do before the entire PR got busted).

Moving on from this PR, Chitin Shoes **REALLY** need an item sprite that's not their on-mob sprite.

##### Changelog

:cl:
tweak: Ashwalker Chitin Shoes no longer have armor values.
tweak: Ashwalker Chitin Gauntlets have weaker armor values.
tweak: Bone Bracers have even weaker armor values.
/:cl: