### PR TITLE
Deletes the abductor glands that killed players with no counter

### DIFF
--- a/_maps/map_files/BirdStation/BirdStation.dmm
+++ b/_maps/map_files/BirdStation/BirdStation.dmm
@@ -22446,7 +22446,7 @@
 /area/maintenance/asmaint2)
 "bbD" = (
 /obj/effect/spawner/lootdrop{
-	loot = list(/obj/item/organ/gland/bloody = 7, /obj/item/organ/gland/bodysnatch = 4, /obj/item/organ/gland/egg = 7, /obj/item/organ/gland/emp = 3, /obj/item/organ/gland/mindshock = 5, /obj/item/organ/gland/plasma = 7, /obj/item/organ/gland/pop = 5, /obj/item/organ/gland/slime = 4, /obj/item/organ/gland/spiderman = 5, /obj/item/organ/gland/ventcrawling = 1, /obj/item/organ/body_egg/alien_embryo = 1, /obj/item/organ/hivelord_core = 2);
+	loot = list(/obj/item/organ/gland/bloody = 7, /obj/item/organ/gland/egg = 7, /obj/item/organ/gland/emp = 3, /obj/item/organ/gland/mindshock = 5, /obj/item/organ/gland/pop = 5, /obj/item/organ/gland/slime = 4, /obj/item/organ/gland/spiderman = 5, /obj/item/organ/gland/ventcrawling = 1, /obj/item/organ/body_egg/alien_embryo = 1, /obj/item/organ/hivelord_core = 2);
 	lootcount = 3;
 	name = "organ spawner"
 	},

--- a/code/game/gamemodes/miniantags/abduction/gland.dm
+++ b/code/game/gamemodes/miniantags/abduction/gland.dm
@@ -13,7 +13,6 @@
 	var/uses // -1 For inifinite
 	var/human_only = 0
 	var/active = 0
-	var/banned // abductors can't pick this one up.
 
 /obj/item/organ/gland/proc/ownerCheck()
 	if(ishuman(owner))
@@ -194,23 +193,6 @@
 	for(var/mob/living/carbon/human/H in oview(3,owner)) //Blood decals for simple animals would be neat. aka Carp with blood on it.
 		H.add_mob_blood(owner)
 
-/obj/item/organ/gland/bodysnatch
-	cooldown_low = 600
-	cooldown_high = 600
-	human_only = 1
-	uses = 1
-	banned = TRUE
-
-/obj/item/organ/gland/bodysnatch/activate()
-	owner << "<span class='warning'>You feel something moving around inside you...</span>"
-	//spawn cocoon with clone greytide snpc inside
-	if(ishuman(owner))
-		var/obj/effect/cocoon/abductor/C = new (get_turf(owner))
-		C.Copy(owner)
-		C.Start()
-	owner.gib()
-	return
-
 /obj/effect/cocoon/abductor
 	name = "slimy cocoon"
 	desc = "Something is moving inside."
@@ -245,24 +227,3 @@
 			src.visible_message("<span class='warning'>[src] hatches!</span>")
 			M.loc = src.loc
 		qdel(src)
-
-/obj/item/organ/gland/plasma
-	cooldown_low = 2400
-	cooldown_high = 3000
-	origin_tech = "materials=4;biotech=4;plasmatech=6;abductor=3"
-	uses = 1
-	banned = TRUE
-
-/obj/item/organ/gland/plasma/activate()
-	owner << "<span class='warning'>You feel bloated.</span>"
-	sleep(150)
-	if(!owner) return
-	owner << "<span class='userdanger'>A massive stomachache overcomes you.</span>"
-	sleep(50)
-	if(!owner) return
-	owner.visible_message("<span class='danger'>[owner] explodes in a cloud of plasma!</span>")
-	var/turf/open/T = get_turf(owner)
-	if(istype(T))
-		T.atmos_spawn_air("plasma=300;TEMP=[T20C]")
-	owner.gib()
-	return

--- a/code/game/gamemodes/miniantags/abduction/machinery/dispenser.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/dispenser.dm
@@ -15,9 +15,6 @@
 
 /obj/machinery/abductor/gland_dispenser/New()
 	gland_types = subtypesof(/obj/item/organ/gland)
-	for(var/obj/item/organ/gland/G in gland_types)
-		if(G.banned)
-			gland_types -= G
 	gland_types = shuffle(gland_types)
 	gland_colors = new/list(gland_types.len)
 	amounts = new/list(gland_types.len)


### PR DESCRIPTION
#### Intent of your Pull Request

Successor of my other attempts to delete them.
Read the branch name!

##### Changelog

:cl:
rscdel: The Abductor Glands that explode you into a cloud of plasma or just kill you in general are now BANNED from the abductor market.
/:cl:
