### PR TITLE
Fix action buttons causing assfucks of lag for no reason

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -3,6 +3,7 @@
 	var/datum/action/linked_action
 	var/actiontooltipstyle = ""
 	screen_loc = null
+	var/overlay_icon_state
 
 /obj/screen/movable/action_button/Click(location,control,params)
 	var/list/modifiers = params2list(params)

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -88,15 +88,13 @@
 			return 1
 
 /datum/action/proc/ApplyIcon(obj/screen/movable/action_button/current_button)
-	current_button.overlays.Cut()
-	if(button_icon && button_icon_state)
+	if(button_icon && button_icon_state && (current_button.overlay_icon_state != button_icon_state))
 		var/image/img
 		img = image(button_icon, current_button, button_icon_state)
 		img.pixel_x = 0
 		img.pixel_y = 0
-		current_button.overlays += img
-
-
+		current_button.overlays = list(img)
+		current_button.overlay_icon_state = button_icon_state
 
 //Presets for item actions
 /datum/action/item_action


### PR DESCRIPTION
:cl: monster860
fix: Fixed the lag. Cause of lag, IT'S THE GOD DAMN ACTION ICONS. Now, name off a few things you'd expect to cause lag: Atmos, large amounts of space carp, maybe having to process breathing and shit, maybe a loose singularity, but no. It's just action icons being ridiculously inefficient as fuck for literally no reason. This fix basically makes them not update their overlays every single tick.
/:cl:

WHAT THE FUCK YOU NEVER CHANGE THE OVERLAYS OF ANY OBJECT REPEATEDLY EACH TICH FOR NO REASON THATS LITERALLY THE MOST EXPENSIVE OPERATION YOU CAN DO IN BYOND YOU /TG/ SHITCODERS OF ABSOLUTE FUCK.