### PR TITLE
The titlescreen now changes between the original and alternate version

### DIFF
--- a/_maps/asteroidstation.dm
+++ b/_maps/asteroidstation.dm
@@ -18,7 +18,7 @@ z9 = empty space
 #if !defined(MAP_FILE)
 
         #define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
-		#define TITLESCREEN_ALT "title_2"
+		#define TITLESCREEN_ALT null
 
         #define MINETYPE "mining"
 

--- a/_maps/asteroidstation.dm
+++ b/_maps/asteroidstation.dm
@@ -18,6 +18,7 @@ z9 = empty space
 #if !defined(MAP_FILE)
 
         #define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
+		#define TITLESCREEN_ALT "title_2"
 
         #define MINETYPE "mining"
 

--- a/_maps/birdstation.dm
+++ b/_maps/birdstation.dm
@@ -9,6 +9,7 @@ A small map intended for lowpop(40 players and less).
 #if !defined(MAP_FILE)
 
 		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
+		#define TITLESCREEN_ALT "title_2"
 
 		#define MINETYPE "lavaland"
 

--- a/_maps/birdstation.dm
+++ b/_maps/birdstation.dm
@@ -9,7 +9,7 @@ A small map intended for lowpop(40 players and less).
 #if !defined(MAP_FILE)
 
 		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
-		#define TITLESCREEN_ALT "title_2"
+		#define TITLESCREEN_ALT null
 
 		#define MINETYPE "lavaland"
 

--- a/_maps/dreamstation.dm
+++ b/_maps/dreamstation.dm
@@ -16,6 +16,7 @@ z7 = empty space
 #if !defined(MAP_FILE)
 
 		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
+		#define TITLESCREEN_ALT "title_2"
 
 		#define MINETYPE "lavaland"
 

--- a/_maps/dreamstation.dm
+++ b/_maps/dreamstation.dm
@@ -16,7 +16,7 @@ z7 = empty space
 #if !defined(MAP_FILE)
 
 		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
-		#define TITLESCREEN_ALT "title_2"
+		#define TITLESCREEN_ALT null
 
 		#define MINETYPE "lavaland"
 

--- a/_maps/efficiencystation.dm
+++ b/_maps/efficiencystation.dm
@@ -16,6 +16,7 @@ z7 = empty space
 #if !defined(MAP_FILE)
 
 		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
+		#define TITLESCREEN_ALT "title_2"
 
 		#define MINETYPE "lavaland"
 

--- a/_maps/efficiencystation.dm
+++ b/_maps/efficiencystation.dm
@@ -16,7 +16,7 @@ z7 = empty space
 #if !defined(MAP_FILE)
 
 		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
-		#define TITLESCREEN_ALT "title_2"
+		#define TITLESCREEN_ALT null
 
 		#define MINETYPE "lavaland"
 

--- a/_maps/metastation.dm
+++ b/_maps/metastation.dm
@@ -16,6 +16,7 @@ z7 = empty space
 #if !defined(MAP_FILE)
 
 		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
+		#define TITLESCREEN_ALT "title_2"
 
 		#define MINETYPE "lavaland"
 

--- a/_maps/metastation.dm
+++ b/_maps/metastation.dm
@@ -16,7 +16,7 @@ z7 = empty space
 #if !defined(MAP_FILE)
 
 		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
-		#define TITLESCREEN_ALT "title_2"
+		#define TITLESCREEN_ALT null
 
 		#define MINETYPE "lavaland"
 

--- a/_maps/ministation.dm
+++ b/_maps/ministation.dm
@@ -49,7 +49,7 @@ Changes to the uplinks were made to discourage murderboning, the rest is the sam
 #if !defined(MAP_FILE)
 
 		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
-		#define TITLESCREEN_ALT "title_2"
+		#define TITLESCREEN_ALT null
 
 		#define MINETYPE "mining"
 

--- a/_maps/ministation.dm
+++ b/_maps/ministation.dm
@@ -49,6 +49,7 @@ Changes to the uplinks were made to discourage murderboning, the rest is the sam
 #if !defined(MAP_FILE)
 
 		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
+		#define TITLESCREEN_ALT "title_2"
 
 		#define MINETYPE "mining"
 

--- a/_maps/tgstation2.dm
+++ b/_maps/tgstation2.dm
@@ -18,7 +18,7 @@ z9 = empty space
 #if !defined(MAP_FILE)
 
 		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
-		#define TITLESCREEN_ALT "title_2"
+		#define TITLESCREEN_ALT null
 
 		#define MINETYPE "lavaland"
 

--- a/_maps/tgstation2.dm
+++ b/_maps/tgstation2.dm
@@ -18,6 +18,7 @@ z9 = empty space
 #if !defined(MAP_FILE)
 
 		#define TITLESCREEN "title" //Add an image in misc/fullscreen.dmi, and set this define to the icon_state, to set a custom titlescreen for your map
+		#define TITLESCREEN_ALT "title_2"
 
 		#define MINETYPE "lavaland"
 

--- a/code/game/turfs/closed.dm
+++ b/code/game/turfs/closed.dm
@@ -27,11 +27,18 @@
 	icon_state = "title"
 	layer = FLY_LAYER
 	var/titlescreen = TITLESCREEN
+	var/titlescreenalt = TITLESCREEN_ALT
 
 /turf/closed/indestructible/splashscreen/New()
 	..()
 	if(titlescreen)
-		icon_state = titlescreen
+		if(titlescreenalt)
+			if(prob(50))
+				icon_state = titlescreen
+			else
+				icon_state = titlescreenalt
+		else
+			icon_state = titlescreen
 
 /turf/closed/indestructible/riveted
 	icon_state = "riveted"


### PR DESCRIPTION
#### Intent of your Pull Request

![](http://image.prntscr.com/image/f07b9c42edb74191bb66d234733226f6.png)
For instance, IF we were going to use titlescreen2 than there'd be a 50/50 chance between the first and second one.

##### Changelog

:cl:
rscadd: The splash screen can now operate with more than 1 titlescreen.
/:cl:
