### PR TITLE
Nerfed the loot and costs of some ruins

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_abductorterrorship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_abductorterrorship.dmm
@@ -103,20 +103,20 @@
 "bY" = (/obj/structure/bed/abductor,/obj/effect/mob_spawn/human/ash_walker{desc = "An Ashwalker egg, this one almost speaks to your mind as you walk near it"; flavour_text = "<font size=3><b>Y</b></font><b>ou are an ash walker. You were <span class='danger'>Abducted</span>. Taken from your home by strange beings, so they could take you apart and then put you back together as something which they could control. They failed, and paid the price. Your prison screamed and shook as ash storms dashed it to the ground. Now you are free, but... something is different.</b>"; icon = 'icons/obj/projectiles.dmi'; icon_state = "bluespace"; name = "Cosmic Ashwalker"},/turf/open/floor/mineral/abductor,/area/ruin/powered)
 "bZ" = (/obj/machinery/door/airlock/abductor{name = "Subject Cell: Scales"},/turf/open/floor/mineral/abductor,/area/ruin/powered)
 "ca" = (/obj/machinery/door/airlock/abductor{locked = 0},/obj/structure/fans/tiny/invisible,/turf/open/floor/mineral/abductor,/area/ruin/powered)
-"cb" = (/obj/structure/table/abductor,/obj/item/weapon/gun/energy/mindflayer,/turf/open/floor/mineral/abductor,/area/ruin/powered)
 "cc" = (/obj/structure/closet/abductor,/obj/item/weapon/gun/energy/alien,/turf/open/floor/mineral/abductor,/area/ruin/powered)
 "cd" = (/obj/structure/table/abductor,/obj/item/stack/sheet/mineral/bananium{amount = 30},/turf/open/floor/mineral/abductor,/area/ruin/powered)
-"ce" = (/obj/structure/table/abductor,/obj/item/weapon/gun/energy/shock_revolver{pin = /obj/item/device/firing_pin},/turf/open/floor/mineral/abductor,/area/ruin/powered)
-"cf" = (/obj/structure/table/abductor,/obj/item/weapon/gun/energy/temperature{pin = /obj/item/device/firing_pin},/turf/open/floor/mineral/abductor,/area/ruin/powered)
 "cg" = (/obj/structure/table/abductor,/obj/item/weapon/storage/toolbox/mechanical,/turf/open/floor/mineral/abductor,/area/ruin/powered)
 "ch" = (/obj/machinery/door/airlock/abductor{locked = 1; state_open = 1},/obj/structure/fans/tiny/invisible,/turf/open/floor/mineral/abductor,/area/ruin/powered)
-"ci" = (/obj/structure/table/abductor,/obj/item/weapon/switchblade,/turf/open/floor/mineral/abductor,/area/ruin/powered)
-"cj" = (/obj/structure/table/abductor,/obj/item/weapon/throwing_star,/turf/open/floor/mineral/abductor,/area/ruin/powered)
-"ck" = (/obj/structure/table/abductor,/obj/item/weapon/gun/energy/gravity_gun,/turf/open/floor/mineral/abductor,/area/ruin/powered)
-"cl" = (/obj/structure/table/abductor,/obj/item/weapon/gun/energy/kinetic_accelerator/crossbow/large,/turf/open/floor/mineral/abductor,/area/ruin/powered)
-"cm" = (/obj/structure/table/abductor,/obj/item/weapon/grenade/spawnergrenade/syndiesoap,/turf/open/floor/mineral/abductor,/area/ruin/powered)
-"cn" = (/obj/structure/table/abductor,/obj/item/weapon/gun/energy/decloner{pin = /obj/item/device/firing_pin},/turf/open/floor/mineral/abductor,/area/ruin/powered)
-"co" = (/obj/structure/table/abductor,/obj/item/weapon/gun/energy/kinetic_accelerator/super,/turf/open/floor/mineral/abductor,/area/ruin/powered)
+"jY" = (/obj/structure/table/abductor,/obj/item/weapon/switchblade,/obj/effect/spawner/mapset{prob_nothing = 60},/turf/open/floor/mineral/abductor,/area/ruin/powered)
+"lE" = (/obj/structure/table/abductor,/obj/item/weapon/gun/energy/kinetic_accelerator/super,/obj/effect/spawner/mapset{prob_nothing = 60},/turf/open/floor/mineral/abductor,/area/ruin/powered)
+"ui" = (/obj/structure/table/abductor,/obj/item/weapon/gun/energy/mindflayer,/obj/effect/spawner/mapset{prob_nothing = 60},/turf/open/floor/mineral/abductor,/area/ruin/powered)
+"AP" = (/obj/structure/table/abductor,/obj/item/weapon/gun/energy/kinetic_accelerator/crossbow/large,/obj/effect/spawner/mapset{prob_nothing = 60},/turf/open/floor/mineral/abductor,/area/ruin/powered)
+"CW" = (/obj/structure/table/abductor,/obj/item/weapon/grenade/spawnergrenade/syndiesoap,/obj/effect/spawner/mapset{prob_nothing = 60},/turf/open/floor/mineral/abductor,/area/ruin/powered)
+"JL" = (/obj/structure/table/abductor,/obj/item/weapon/gun/energy/decloner{pin = /obj/item/device/firing_pin},/obj/effect/spawner/mapset{prob_nothing = 60},/turf/open/floor/mineral/abductor,/area/ruin/powered)
+"Kc" = (/obj/structure/table/abductor,/obj/item/weapon/gun/energy/shock_revolver{pin = /obj/item/device/firing_pin},/obj/effect/spawner/mapset{prob_nothing = 60},/turf/open/floor/mineral/abductor,/area/ruin/powered)
+"RL" = (/obj/structure/table/abductor,/obj/item/weapon/gun/energy/temperature{pin = /obj/item/device/firing_pin},/obj/effect/spawner/mapset{prob_nothing = 60},/turf/open/floor/mineral/abductor,/area/ruin/powered)
+"SP" = (/obj/structure/table/abductor,/obj/item/weapon/gun/energy/gravity_gun,/obj/effect/spawner/mapset{prob_nothing = 60},/turf/open/floor/mineral/abductor,/area/ruin/powered)
+"Uy" = (/obj/structure/table/abductor,/obj/item/weapon/throwing_star,/obj/effect/spawner/mapset{prob_nothing = 60},/turf/open/floor/mineral/abductor,/area/ruin/powered)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
@@ -153,13 +153,13 @@ aaaaaaaaaaaaababacacacacacabacacacacababacabacacabacacacabababacacaebUbVbVbVbVbV
 aaaaaaaaaaaaababacacacabacacacacacacacacacacacacacacaeaeaeaeaeaeaeaeajbVbWajbXbVajaeaeaeaeaeaeababababaaaaaaaa
 aaaaaaaaaaaaababababababacacabacacacacacabacacabacabaeajajajajajajaxajbVajbYajbZaFaeabacabababababababaaaaaaaa
 aaaaaaaaaaaaababababababacabacababacacacacacaeaeaeaeaecaaeaeaeaeaeaebUbVaTajajbVbUaeacacababaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaababacababababacacabacacaecbajccaeajaeahcdajahaeajbVbVbVbVbVaGaeacacababaaaaaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaabababababacacacacacacacaeceajajapajaeajajaFahaeajaFajaGajaGaGaeacacababababaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaababababacacabacacabacabaecfajajaeajaeajahajcgaeaeaeaeaeaeaeaeaeacacacacababaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaababababacacabacacabacacaeaeaeaeaeajchajciajcjaeababacabacacacacacacacacababaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaabababacacababacacababacaeckajccaeajaeajajajclaeababababacacacacacacacacacabaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaababababacacacacacaecmajajapajaeahajajajaeacacababacacacacababababababaaaaaaaaaaaaaa
-aaaaaaaaaaaaaaaaaaaaaaaaaaabacacacacacacacacaecnajajaeaFaeahajcoaZaeababacacacacacacacacababaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaababacababababacacabacacaeuiajccaeajaeahcdajahaeajbVbVbVbVbVaGaeacacababaaaaaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaabababababacacacacacacacaeKcajajapajaeajajaFahaeajaFajaGajaGaGaeacacababababaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaababababacacabacacabacabaeRLajajaeajaeajahajcgaeaeaeaeaeaeaeaeaeacacacacababaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaababababacacabacacabacacaeaeaeaeaeajchajjYajUyaeababacabacacacacacacacacababaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaabababacacababacacababacaeSPajccaeajaeajajajAPaeababababacacacacacacacacacabaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaababababacacacacacaeCWajajapajaeahajajajaeacacababacacacacababababababaaaaaaaaaaaaaa
+aaaaaaaaaaaaaaaaaaaaaaaaaaabacacacacacacacacaeJLajajaeaFaeahajlEaZaeababacacacacacacacacababaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaababababacacacacabaeaeaeaeaeaeaeaeaeaeaeaeacacacacacacacacababababaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababacacabababababababacababacabababababacacacacacababaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabacababacacacababababababacababacabacacacacacacacacacacabaaaaaaaaaaaaaaaaaaaaaa
@@ -170,3 +170,4 @@ aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabacacacababacacabababababababababababab
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaababababababababababababababababababababababaaaaaaaaaaaaaaaaaaaaaaaaaa
 aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 "}
+

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -34,11 +34,11 @@
 "H" = (/obj/structure/table/optable,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "I" = (/mob/living/simple_animal/hostile/asteroid/gutlunch/gubbuck,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "J" = (/obj/item/device/flashlight,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
-"K" = (/obj/structure/closet/crate/necropolis,/obj/item/stack/sheet/mineral/mythril{amount = 50},/obj/item/stack/sheet/mineral/mythril{amount = 50},/obj/item/stack/sheet/mineral/mythril{amount = 50},/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "M" = (/obj/item/weapon/twohanded/spear,/obj/structure/rack,/obj/item/weapon/twohanded/spear,/obj/item/weapon/twohanded/spear,/obj/item/weapon/twohanded/spear,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "N" = (/obj/item/weapon/twohanded/spear,/obj/structure/rack,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "O" = (/obj/structure/mineral_door/iron,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth; blocks_air = 1},/area/ruin/unpowered)
 "R" = (/obj/item/weapon/twohanded/spear,/obj/structure/table,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
+"T" = (/obj/structure/closet/crate/necropolis,/obj/item/stack/sheet/mineral/mythril{amount = 50},/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth},/area/ruin/unpowered)
 "U" = (/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/mapgen_protected)
 "V" = (/obj/structure/ore_box,/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors/mapgen_protected)
 "W" = (/obj/item/weapon/pickaxe,/obj/item/weapon/shovel,/turf/open/floor/engine/cult{baseturf = /turf/open/floor/plating/lava/smooth; initial_gas_mix = "o2=13;n2=24;TEMP=300"},/area/lavaland/surface/outdoors/mapgen_protected)
@@ -58,7 +58,7 @@ aaacpqfrstcccc
 aaccuuvwuucxyc
 aaczABffCDffEc
 aacFfffnGffffc
-aacHIJffffffKc
+aacHIJffffffTc
 UXuMfNuOuuuucc
 YZuRRNuZUZWVaa
 YZuuuuuUUUUUaa

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_mimingdrill.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_mimingdrill.dmm
@@ -21,7 +21,7 @@
 "u" = (/obj/structure/girder,/turf/open/floor/plating/asteroid/basalt/lava,/area/ruin/unpowered)
 "v" = (/obj/structure/closet/crate,/turf/open/floor/plating/asteroid/basalt/lava,/area/ruin/unpowered)
 "w" = (/obj/effect/decal/cleanable/blood/splatter,/turf/open/floor/plating/asteroid/basalt/lava,/area/ruin/unpowered)
-"x" = (/obj/structure/table,/obj/item/weapon/storage/bag/ore,/obj/item/device/mining_scanner,/obj/item/borg/sight/meson,/turf/open/floor/plating/asteroid/basalt/lava,/area/ruin/unpowered)
+"x" = (/obj/structure/table,/obj/item/weapon/storage/bag/ore,/obj/item/device/mining_scanner,/obj/item/clothing/glasses/meson,/turf/open/floor/plating/asteroid/basalt/lava,/area/ruin/unpowered)
 "y" = (/obj/effect/spawner/structure/window,/turf/open/floor/plating/asteroid/basalt/lava,/area/ruin/unpowered)
 "z" = (/obj/item/weapon/shard,/obj/effect/decal/cleanable/blood/tracks,/turf/open/floor/plating/asteroid/basalt/lava,/area/ruin/unpowered)
 "A" = (/obj/item/weapon/shard,/turf/open/floor/plating/asteroid/basalt/lava,/area/ruin/unpowered)

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_wizardden.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_wizardden.dmm
@@ -27,12 +27,13 @@
 "A" = (/obj/structure/chair/wood/normal{dir = 8},/turf/open/floor/wood,/area/ruin/powered)
 "B" = (/obj/structure/bed,/obj/item/weapon/bedsheet/wiz,/obj/item/toy/stuffedmonkey,/turf/open/floor/wood,/area/ruin/powered)
 "C" = (/obj/machinery/light/small{dir = 8},/turf/open/floor/wood{icon_state = "wood-broken4"},/area/ruin/powered)
+"T" = (/obj/structure/table/wood,/obj/item/weapon/spellbook/oneuse/random,/obj/effect/spawner/mapset{prob_nothing = 90},/turf/open/floor/wood,/area/ruin/powered)
 
 (1,1,1) = {"
 aaaaaaaaaaaaaaaaaa
 abbbbbbbbbbcaaaaaa
 abdefbghijbbbbbbba
-abkghihhblbmmnnnba
+abkghihhblbmmTnTba
 abopqbhrbbbhhhhhba
 abbbbbhhbsbthugvba
 aahhwbhgihhghhhhba
@@ -40,3 +41,4 @@ aaxyhihhbhhhhzABba
 aabChbbbbbbbbbbbba
 aaaaaaaaaaaaaaaaaa
 "}
+

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -144,7 +144,7 @@
 	description = "Abductors are not a rare sight in remote and sparsely populated regions of the galaxy, however no being has managed to survive an encounter with a terrorship, but who ever thought a primitive spear could be so robust?"
 	suffix = "lavaland_surface_abductorterrorship.dmm"
 	allow_duplicates = FALSE
-	cost = 10
+	cost = 20
 
 /datum/map_template/ruin/lavaland/cultritual
 	name = "Cult Ritual"
@@ -160,7 +160,7 @@
 	description = "A shop that has the entire collection of Nanotrasen brand action figures!"
 	suffix = "lavaland_surface_cursedtoyshop.dmm"
 	allow_duplicates = FALSE
-	cost = 5
+	cost = 15
 
 /datum/map_template/ruin/lavaland/goliathmound
 	name = "Goliath Mound"
@@ -224,7 +224,7 @@
 	description = "Only Malarky the mad would be mad enough to live in a wooden shack on this planet"
 	suffix = "lavaland_surface_wizardden.dmm"
 	allow_duplicates = FALSE
-	cost = 5
+	cost = 15
 
 /datum/map_template/ruin/lavaland/travellingbard
 	name = "Travelling Bard"

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -168,3 +168,38 @@
 				/obj/structure/closet/crate/secure/loot = 20,
 				"" = 80
 				)
+
+/obj/effect/spawner/mapset
+	icon = 'icons/mob/screen_gen.dmi'
+	icon_state = "x2"
+	color = "#FFFF00"
+	var/prob_nothing = 0
+	var/drops = 1
+
+/obj/effect/spawner/mapset/initialize()
+	if(!loc)
+		return
+	for(var/obj/structure/closet/C in loc)
+		C.open()
+
+	var/list/selected = list()
+	var/list/candidates = list()
+
+	for(var/obj/item/I in loc)
+		candidates += I
+
+	if(!prob(prob_nothing))
+		var/i = 0
+		while(candidates.len && (i<drops))
+			var/S = pick(candidates)
+			selected += S
+			candidates -= S
+			i++
+
+	for(var/V in candidates)
+		qdel(V)
+
+	for(var/obj/structure/closet/C in loc)
+		C.close()
+
+	qdel(src)


### PR DESCRIPTION
Increased the costs of some of the more loot-heavy ruins, and made some loot only drop some of the time. Two of the three spellbooks in the wizard den now only have a 10% chance of spawning, and all of the guns in the abductor terror ship only have a 40% chance of spawning.

Also ashwalkers only get one stack of mythril because they don't need three.