### PR TITLE
Adds a slightly longer delay to each AI Vox word being said, hopefully to stop it tripping over words.

### DIFF
--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -152,7 +152,7 @@ var/const/VOX_DELAY = 600
 	if(vox_sounds[word])
 
 		var/sound_file = vox_sounds[word]
-		var/sound/voice = sound(sound_file, wait = 1, channel = VOX_CHANNEL)
+		var/sound/voice = sound(sound_file, wait = 2, channel = VOX_CHANNEL)
 		voice.status = SOUND_STREAM
 
  		// If there is no single listener, broadcast to everyone in the same z level


### PR DESCRIPTION
see:title
also the change is basically un-noticeable, for those of you who give a fuck
:cl:
tweak: The delay between each word being announced by AI VOX has been slightly increased, hopefully it will now stop messing up the order of words.
/:cl:
