### PR TITLE
Fixes a gravity bug with golems

### DIFF
--- a/code/modules/awaymissions/maploader/reader.dm
+++ b/code/modules/awaymissions/maploader/reader.dm
@@ -396,6 +396,7 @@ var/global/dmm_suite/preloader/_preloader = new
 
 /area/template_noop
 	name = "Area Passthrough"
+	has_gravity = 1
 
 /area/template_noop/mapgen_protected
 	name = "Area Passthrough"


### PR DESCRIPTION
#### Intent of your Pull Request

I'm possibly going about this wrong, but the golem area (and other areas on lavaland) have a problem where 1-2 feet away from their ruin they start floating because gravity doesn't exist on those turfs. The exact turf placed there is a `/area/template_noop` which has something to do with planetary maps, as it's only used on most lavaland maps. 

So this PR tweaks a small little variable giving that specific area gravity.