### PR TITLE
Blob buff

### DIFF
--- a/code/game/gamemodes/blob/theblob.dm
+++ b/code/game/gamemodes/blob/theblob.dm
@@ -341,6 +341,7 @@
 	maxhealth = 20
 	health_regen = 1
 	brute_resist = 0.25
+	fire_resist = 0.75
 	atmosblock = 1
 
 /obj/effect/blob/normal/scannerreport()


### PR DESCRIPTION
Now takes 2 welding attacks for a normal blob thing to die.

Blob was extremely weak due to people insta-killing the normal blobs. This makes it take 2 hits. I tested it.

:cl:
tweak: Normal blob tiles now take 2 welder hits to kill
/:cl: