### PR TITLE
Comments out drone language from NTSL

### DIFF
--- a/code/modules/scripting/Implementations/Telecomms.dm
+++ b/code/modules/scripting/Implementations/Telecomms.dm
@@ -117,7 +117,7 @@ var/allowed_translateable_langs = ALL
 	interpreter.SetVar("ALIEN"   ,	ALIEN)
 	interpreter.SetVar("ROBOT"   ,	ROBOT)
 	interpreter.SetVar("SLIME"   ,	SLIME)
-	interpreter.SetVar("DRONE"   ,	DRONE)
+	/*interpreter.SetVar("DRONE"   ,	DRONE)*/
 
 	var/curlang = HUMAN
 	if(istype(signal.data["mob"], /atom/movable))


### PR DESCRIPTION
People can still use translators, pAIs, recorders, all sorts of crap.  But intercomms and station bounced radios will hopefully not do it now, with this and Cruix' changes.



:cl:
tweak: Drone language has been removed from NTSL.  Maybe now people will have a harder time speaking to humans as drones and breaking their laws. 
/:cl:
