### PR TITLE
Fixed sleeping carp

### DIFF
--- a/code/datums/martial.dm
+++ b/code/datums/martial.dm
@@ -536,5 +536,5 @@
 	if(wielded)
 		if((attack_type == MELEE_ATTACK) || (attack_type == UNARMED_ATTACK)) //Don't use a stick against fucking bullets and lasers
 			final_block_chance = max(final_block_chance, melee_block_chance)
-		return ..(owner, attack_text, final_block_chance, damage, attack_type)
+		return ..(owner, attack_text, final_block_chance, damage, attack_type, AT)
 	return 0

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -202,14 +202,9 @@
 	apply_damage(5, BRUTE, affecting, run_armor_check(affecting, "melee"))
 	return
 
-/mob/living/carbon/human/bullet_act()
-	if(martial_art && martial_art.deflection_chance) //Some martial arts users can deflect projectiles!
-		if(!prob(martial_art.deflection_chance))
-			return ..()
-		if(!src.lying && dna && !dna.check_mutation(HULK)) //But only if they're not lying down, and hulks can't do it
-			src.visible_message("<span class='danger'>[src] deflects the projectile; they can't be hit with ranged weapons!</span>", "<span class='userdanger'>You deflect the projectile!</span>")
-			playsound(src, pick("sound/weapons/bulletflyby.ogg","sound/weapons/bulletflyby2.ogg","sound/weapons/bulletflyby3.ogg"), 75, 1)
-			return 0
+/mob/living/carbon/human/bullet_act(obj/item/projectile/Proj)
+	if(martial_art && martial_art.try_deflect_projectile(src, Proj)) //Some martial arts users can deflect projectiles!
+		return
 	..()
 
 /mob/living/carbon/human/attack_ui(slot)

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -161,7 +161,7 @@
 			src << "<span class='warning'>Your fingers don't fit in the trigger guard!</span>"
 			return 0
 
-	if(martial_art && martial_art.name == "The Sleeping Carp") //great dishonor to famiry
+	if(martial_art && martial_art.no_ranged_weapons) //great dishonor to famiry
 		src << "<span class='warning'>Use of ranged weaponry would bring dishonor to the clan.</span>"
 		return 0
 


### PR DESCRIPTION
Fixed stuff from https://github.com/yogstation13/yogstation/pull/1452
Fixes #1571

Fixed bostaffs always blocking everything
Reduced bostaffs melee block chance to 80% from 100%
Made sleeping carp drop your active hand if you deflect a projectile

:cl:
tweak: Wielded bostaffs now only block melee attacks, and only 80% of the time
tweak: Using sleeping carp to deflect a projectile will drop the item in your active hand
/:cl:
