### PR TITLE
Removes the "adult" bookcases from the library

### DIFF
--- a/_maps/map_files/Yogstation/yogstation.2.1.3.dmm
+++ b/_maps/map_files/Yogstation/yogstation.2.1.3.dmm
@@ -24355,9 +24355,8 @@
 	},
 /area/hydroponics)
 "aWJ" = (
-/obj/structure/bookcase{
-	name = "bookcase (Adult)"
-	},
+/obj/structure/table/wood,
+/obj/item/weapon/storage/photo_album,
 /turf/open/floor/wood,
 /area/library)
 "aWK" = (
@@ -69173,6 +69172,11 @@
 	},
 /turf/open/space,
 /area/space)
+"cGp" = (
+/obj/structure/table/wood,
+/obj/item/weapon/storage/crayons,
+/turf/open/floor/wood,
+/area/library)
 
 (1,1,1) = {"
 aaa
@@ -112213,7 +112217,7 @@ aQF
 aJA
 aTC
 aJA
-aWJ
+cGp
 aGs
 baa
 bbJ


### PR DESCRIPTION
Our rules don't allow ERP texts, so what's the point of having them there

I replace them with a table with some crayons and a photo album

:cl:
rscdel: The "adult" bookcases from the library have been removed.
/:cl:
