### PR TITLE
borgs can't be flashed while stunned

### DIFF
--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -117,7 +117,7 @@
 		else
 			add_logs(user, M, "flashed", src)
 			update_icon(1)
-			M.Weaken(9)
+			M.Weaken(10)
 			user.visible_message("<span class='disarm'>[user] overloads [M]'s sensors with the flash!</span>", "<span class='danger'>You overload [M]'s sensors with the flash!</span>")
 			return 1
 

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -112,7 +112,7 @@
 
 	else if(issilicon(M))
 		if(M.weakened)
-			user.visible_message("<span class='disarm'>[user] fails to flash [M]!!</span>", "<span class='warning'>You fail to flash [M]!</span>")
+			user.visible_message("<span class='disarm'>[user] fails to flash [M]!!</span>", "<span class='warning'>[M]'s sensors are already overloaded!</span>")
 			return 0
 		else
 			add_logs(user, M, "flashed", src)

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -111,11 +111,15 @@
 		return 1
 
 	else if(issilicon(M))
-		add_logs(user, M, "flashed", src)
-		update_icon(1)
-		M.Weaken(rand(5,10))
-		user.visible_message("<span class='disarm'>[user] overloads [M]'s sensors with the flash!</span>", "<span class='danger'>You overload [M]'s sensors with the flash!</span>")
-		return 1
+		if(M.weakened)
+			user.visible_message("<span class='disarm'>[user] fails to flash [M]!!</span>", "<span class='warning'>You fail to flash [M]!</span>")
+			return 0
+		else
+			add_logs(user, M, "flashed", src)
+			update_icon(1)
+			M.Weaken(9)
+			user.visible_message("<span class='disarm'>[user] overloads [M]'s sensors with the flash!</span>", "<span class='danger'>You overload [M]'s sensors with the flash!</span>")
+			return 1
 
 	user.visible_message("<span class='disarm'>[user] fails to blind [M] with the flash!</span>", "<span class='warning'>You fail to blind [M] with the flash!</span>")
 


### PR DESCRIPTION
death to autismo chainstunning

:cl: ShadowDeath6
tweak: Borgs can no longer be flashed while stunned.
tweak: To compensate for this, flashes now stun for ~10 seconds every time rather than a random amount between 5 and 10.
/:cl:
