### PR TITLE
Shapechange now transfers the health of the user

### DIFF
--- a/code/modules/spells/spell_types/shapeshift.dm
+++ b/code/modules/spells/spell_types/shapeshift.dm
@@ -45,6 +45,9 @@
 	var/mob/living/shape = new shapeshift_type(caster.loc)
 	caster.loc = shape
 	caster.status_flags |= GODMODE
+	shape.maxHealth = caster.maxHealth
+	shape.adjustBruteLoss(-shape.maxHealth)
+	shape.adjustBruteLoss(caster.maxHealth - caster.health)
 
 	current_shapes |= shape
 	current_casters |= caster
@@ -62,7 +65,8 @@
 	if(!caster)
 		return
 	caster.loc = shape.loc
-	caster.status_flags -= GODMODE
+	caster.status_flags &= ~GODMODE
+	caster.adjustBruteLoss(caster.health - shape.health)
 
 	clothes_req = initial(clothes_req)
 	human_req = initial(human_req)


### PR DESCRIPTION
This means that mice will have 20 times their normal health and won't die in one second to vacuum, but juggernauts will only have 40% of their normal health. Of course, none of this matters, since the only form anyone ever chooses is the infinite taser stunbot, which has the same health as humans anyway.

It also means that hurting a shapechanged wizard actually means something.

:cl:
tweak: Using shapechange will transfer the health and maximum health of the original mob to the creature, and taking damage while transformed will affect the user when they revert to human.
/:cl:
