### PR TITLE
[s] Adds delay to preference preview icon generation

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -14,6 +14,7 @@ var/list/preferences_datums = list()
 	var/afreeze = 0
 	var/last_ip
 	var/last_id
+	var/is_updating_icon = 0
 
 	//game-preferences
 	var/lastchangelog = ""				//Saved changlog filesize to detect if there was a change

--- a/code/modules/mob/new_player/preferences_setup.dm
+++ b/code/modules/mob/new_player/preferences_setup.dm
@@ -22,6 +22,9 @@
 	age = rand(AGE_MIN,AGE_MAX)
 
 /datum/preferences/proc/update_preview_icon()
+	if(is_updating_icon)
+		return
+	is_updating_icon = 1
 	// Silicons only need a very basic preview since there is no customization for them.
 	if(job_engsec_high)
 		switch(job_engsec_high)
@@ -88,3 +91,4 @@
 	preview_icon.Scale(preview_icon.Width() * 2, preview_icon.Height() * 2) // Scaling here to prevent blurring in the browser.
 	CHECK_TICK
 	qdel(mannequin)
+	is_updating_icon = 0


### PR DESCRIPTION
Prevents a DDOS that relies on generating tons of these.
All credit to @monster860 
https://github.com/FTL13/FTL13/commit/3a14e54cabf9ab05f4a4d2c33ca2cf147c01f190
https://github.com/FTL13/FTL13/commit/58cc107678792350897b02b43abc4631226aa914
