### PR TITLE
Bolts the emergency shuttle airlocks during flight

### DIFF
--- a/_maps/map_files/Yogstation/yogstation.2.1.3.dmm
+++ b/_maps/map_files/Yogstation/yogstation.2.1.3.dmm
@@ -69173,6 +69173,12 @@
 	},
 /turf/open/space,
 /area/space)
+"cGp" = (
+/obj/machinery/door/airlock/glass{
+	name = "Emergency Shuttle Cargo"
+	},
+/turf/open/floor/plasteel/shuttle,
+/area/shuttle/escape)
 
 (1,1,1) = {"
 aaa
@@ -122760,7 +122766,7 @@ bfV
 bhe
 aIw
 aLq
-aYr
+cGp
 aLq
 aDB
 bqg

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -222,6 +222,18 @@ var/list/motion_alert_listeners = list()
 		var/datum/alert_listener/listener = L
 		listener.cancelAlarm("Burglar", src, trigger)
 
+/area/proc/shuttle_lockdown(trigger)
+	for(var/area/RA in related)
+		for (var/obj/machinery/door/DOOR in RA)
+			spawn(0)
+				DOOR.lock()
+
+/area/proc/shuttle_lockdown_reset(trigger)
+	for(var/area/RA in related)
+		for (var/obj/machinery/door/DOOR in RA)
+			spawn(0)
+				DOOR.unlock()
+
 /area/proc/set_fire_alarm_effect()
 	fire = 1
 	updateicon()

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -224,13 +224,13 @@ var/list/motion_alert_listeners = list()
 
 /area/proc/shuttle_lockdown(trigger)
 	for(var/area/RA in related)
-		for (var/obj/machinery/door/DOOR in RA)
+		for (var/obj/machinery/door/airlock/shuttle/DOOR in RA)
 			spawn(0)
 				DOOR.lock()
 
 /area/proc/shuttle_lockdown_reset(trigger)
 	for(var/area/RA in related)
-		for (var/obj/machinery/door/DOOR in RA)
+		for (var/obj/machinery/door/airlock/shuttle/DOOR in RA)
 			spawn(0)
 				DOOR.unlock()
 

--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -313,6 +313,8 @@
 				for(var/area/shuttle/escape/E in world)
 					E << 'sound/effects/hyperspace_progress.ogg'
 				enterTransit()
+				var/area/alarmed = get_area(src) //probably shitcode but it works
+				alarmed.shuttle_lockdown(src)
 				mode = SHUTTLE_ESCAPE
 				launch_status = ENDGAME_LAUNCHED
 				timer = world.time
@@ -334,6 +336,8 @@
 				dock(SSshuttle.getDock("emergency_away"))
 				mode = SHUTTLE_ENDGAME
 				timer = 0
+				var/area/alarmed = get_area(src)
+				alarmed.shuttle_lockdown_reset(src)
 				open_dock()
 
 /obj/docking_port/mobile/emergency/proc/open_dock()


### PR DESCRIPTION
I spent like 5 hours figuring this out and it's probably shitcode but it works, so whatever

This can MAYBE be applied to mining shuttles as well, but it would require some tinkering

Hopefully we'll see less "oops i spaced 5 people by accident" tickets

:cl:
tweak: The emergency shuttle airlocks are now bolted during flight.
/:cl:
