### PR TITLE
Makes syndie base unescapable, adds some flavour

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_syndicate_base1.dmm
@@ -1,218 +1,3019 @@
-"aa" = (/turf/template_noop,/area/template_noop)
-"ab" = (/turf/open/floor/plating/lava/smooth/lava_land_surface,/area/lavaland/surface/outdoors)
-"ac" = (/turf/open/floor/plating/asteroid/basalt/lava_land_surface,/area/lavaland/surface/outdoors)
-"ad" = (/turf/closed/wall/r_wall,/area/ruin/powered/syndicate_lava_base)
-"ae" = (/obj/structure/closet/secure_closet/bar{req_access = null; req_access_txt = "150"},/turf/open/floor/plasteel/podhatch{dir = 10},/area/ruin/powered/syndicate_lava_base)
-"af" = (/obj/structure/table/wood,/obj/item/weapon/reagent_containers/food/snacks/syndicake,/obj/item/weapon/reagent_containers/food/snacks/syndicake,/obj/item/weapon/reagent_containers/food/snacks/syndicake,/obj/structure/sign/barsign{pixel_y = 32; req_access = null; req_access_txt = "150"},/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
-"ag" = (/obj/structure/table/wood,/obj/item/weapon/reagent_containers/food/snacks/salad/validsalad,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (SOUTHEAST)"; icon_state = "podhatch"; dir = 6},/area/ruin/powered/syndicate_lava_base)
-"ah" = (/obj/structure/rack{icon = 'icons/obj/stationobjs.dmi'; icon_state = "minibar_left"; name = "skeletal minibar"},/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,/turf/open/floor/wood,/area/ruin/powered/syndicate_lava_base)
-"ai" = (/obj/structure/rack{icon = 'icons/obj/stationobjs.dmi'; icon_state = "minibar_right"; name = "skeletal minibar"},/obj/item/weapon/reagent_containers/food/drinks/bottle/gin,/turf/open/floor/wood,/area/ruin/powered/syndicate_lava_base)
-"aj" = (/obj/structure/dresser,/obj/structure/mirror{desc = "Mirror mirror on the wall, who is the most robust of them all?"; pixel_x = -26},/turf/open/floor/plasteel/vault,/area/ruin/powered/syndicate_lava_base)
-"ak" = (/obj/structure/flora/kirbyplants{icon_state = "plant-01"; layer = 4.1},/turf/open/floor/plasteel/vault,/area/ruin/powered/syndicate_lava_base)
-"al" = (/obj/structure/flora/kirbyplants{icon_state = "plant-01"},/turf/open/floor/plasteel/vault,/area/ruin/powered/syndicate_lava_base)
-"am" = (/obj/structure/table/wood,/obj/item/weapon/clipboard,/obj/item/toy/figure/syndie,/turf/open/floor/plasteel/vault,/area/ruin/powered/syndicate_lava_base)
-"an" = (/obj/machinery/portable_atmospherics/canister/air,/turf/open/floor/plasteel/podhatch{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"ao" = (/turf/open/floor/plasteel/black,/area/ruin/powered/syndicate_lava_base)
-"ap" = (/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"aq" = (/obj/item/stack/sheet/metal{amount = 30},/obj/item/stack/rods{amount = 50},/obj/structure/table/reinforced,/turf/open/floor/plasteel/podhatch{dir = 9},/area/ruin/powered/syndicate_lava_base)
-"ar" = (/turf/open/floor/wood,/area/ruin/powered/syndicate_lava_base)
-"as" = (/obj/effect/mob_spawn/human/lavaland_syndicate{tag = "icon-sleeper_s (EAST)"; icon_state = "sleeper_s"; dir = 4},/turf/open/floor/plasteel/grimy,/area/ruin/powered/syndicate_lava_base)
-"at" = (/turf/open/floor/plasteel/grimy,/area/ruin/powered/syndicate_lava_base)
-"au" = (/obj/machinery/syndicatebomb/badmin/varplosion{anchored = 1; name = "Self Destruct Device"},/turf/open/floor/plasteel/grimy,/area/ruin/powered/syndicate_lava_base)
-"av" = (/obj/effect/mob_spawn/human/lavaland_syndicate{tag = "icon-sleeper_s (WEST)"; icon_state = "sleeper_s"; dir = 8},/turf/open/floor/plasteel/grimy,/area/ruin/powered/syndicate_lava_base)
-"aw" = (/obj/structure/reagent_dispensers/watertank,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (EAST)"; icon_state = "podhatch"; dir = 4},/area/ruin/powered/syndicate_lava_base)
-"ax" = (/obj/item/stack/cable_coil/white,/obj/item/stack/cable_coil/white,/obj/item/stack/packageWrap,/obj/item/weapon/hand_labeler,/obj/structure/table/reinforced,/turf/open/floor/plasteel/podhatch{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"ay" = (/obj/structure/table/wood,/obj/item/ammo_box/magazine/m10mm,/obj/item/ammo_box/magazine/m10mm,/obj/item/ammo_box/magazine/m10mm,/obj/item/ammo_box/magazine/m10mm,/turf/open/floor/plasteel/grimy,/area/ruin/powered/syndicate_lava_base)
-"az" = (/obj/structure/reagent_dispensers/fueltank,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (SOUTHEAST)"; icon_state = "podhatch"; dir = 6},/area/ruin/powered/syndicate_lava_base)
-"aA" = (/obj/item/stack/sheet/metal{amount = 50},/obj/item/stack/sheet/glass{amount = 50},/obj/structure/table/reinforced,/obj/item/weapon/wrench,/turf/open/floor/plasteel/podhatch{dir = 10},/area/ruin/powered/syndicate_lava_base)
-"aB" = (/obj/structure/table/wood,/obj/item/weapon/paper_bin,/obj/item/weapon/pen,/turf/open/floor/wood{icon_state = "wood-broken4"},/area/ruin/powered/syndicate_lava_base)
-"aC" = (/obj/structure/table/wood,/obj/item/weapon/storage/box/drinkingglasses,/turf/open/floor/wood,/area/ruin/powered/syndicate_lava_base)
-"aD" = (/obj/structure/table/wood,/obj/item/toy/nuke,/obj/item/weapon/book/manual/nuclear,/turf/open/floor/wood,/area/ruin/powered/syndicate_lava_base)
-"aE" = (/obj/structure/table/wood,/obj/item/weapon/lighter{pixel_y = 3},/obj/item/weapon/storage/fancy/cigarettes/cigpack_syndicate,/turf/open/floor/wood,/area/ruin/powered/syndicate_lava_base)
-"aF" = (/obj/structure/table/wood,/obj/item/weapon/storage/fancy/donut_box,/turf/open/floor/wood,/area/ruin/powered/syndicate_lava_base)
-"aG" = (/obj/structure/extinguisher_cabinet{pixel_x = 26},/turf/open/floor/wood,/area/ruin/powered/syndicate_lava_base)
-"aH" = (/obj/effect/mob_spawn/human/lavaland_syndicate/comms{tag = "icon-sleeper_s (EAST)"; icon_state = "sleeper_s"; dir = 4},/turf/open/floor/plasteel/grimy,/area/ruin/powered/syndicate_lava_base)
-"aI" = (/obj/structure/sign/nosmoking_2,/turf/closed/wall/r_wall,/area/ruin/powered/syndicate_lava_base)
-"aJ" = (/obj/machinery/syndicatebomb/badmin/varplosion{anchored = 1; name = "Self Destruct Device"},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"aK" = (/obj/structure/closet/crate/bin,/obj/item/trash/syndi_cakes,/turf/open/floor/plasteel/black,/area/ruin/powered/syndicate_lava_base)
-"aL" = (/obj/structure/chair/stool/bar,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"aM" = (/obj/structure/chair/stool/bar,/turf/open/floor/plasteel/black,/area/ruin/powered/syndicate_lava_base)
-"aN" = (/obj/structure/table/wood,/obj/item/weapon/lipstick/random{pixel_x = 3; pixel_y = 3},/obj/item/weapon/lipstick/random{pixel_x = -3; pixel_y = -3},/obj/item/weapon/lipstick/random,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"aO" = (/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"aP" = (/obj/structure/dresser,/obj/structure/mirror{desc = "Mirror mirror on the wall, who is the most robust of them all?"; pixel_x = 26},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"aQ" = (/obj/item/target,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"aR" = (/obj/structure/closet/emcloset{anchored = 1},/obj/item/weapon/tank/internals/emergency_oxygen/engi,/obj/item/device/flashlight/seclite,/obj/item/clothing/mask/gas,/turf/open/floor/plasteel/podhatch{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"aS" = (/obj/structure/flora/kirbyplants{icon_state = "plant-01"; layer = 4.1},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"aT" = (/obj/machinery/door/airlock/hatch{name = "Dormitories"; req_access_txt = null},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"aU" = (/obj/structure/closet/emcloset,/obj/item/weapon/tank/internals/emergency_oxygen/engi,/obj/item/device/flashlight/seclite,/obj/item/clothing/mask/gas,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (EAST)"; icon_state = "podhatch"; dir = 4},/area/ruin/powered/syndicate_lava_base)
-"aV" = (/obj/machinery/door/airlock/hatch{name = "Storage Closet"; req_access_txt = null},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"aW" = (/obj/machinery/door/airlock/hatch{name = "Dormitories"; req_access_txt = null},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"aX" = (/obj/machinery/door/airlock/hatch{name = "Restroom"; req_access_txt = null},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"aY" = (/obj/structure/mirror{desc = "Mirror mirror on the wall, who is the most robust of them all?"; pixel_x = 28},/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 11; pixel_y = 0},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"aZ" = (/turf/open/floor/plasteel/podhatch{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"ba" = (/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (EAST)"; icon_state = "podhatch"; dir = 4},/area/ruin/powered/syndicate_lava_base)
-"bb" = (/obj/structure/closet/emcloset{anchored = 1},/obj/item/weapon/tank/internals/emergency_oxygen/engi,/obj/item/device/flashlight/seclite,/obj/item/clothing/mask/gas,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (SOUTHEAST)"; icon_state = "podhatch"; dir = 6},/area/ruin/powered/syndicate_lava_base)
-"bc" = (/obj/structure/flora/kirbyplants{icon_state = "plant-01"},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"bd" = (/obj/structure/bookcase/random,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"be" = (/obj/structure/flora/kirbyplants{icon_state = "plant-01"; layer = 4.1},/turf/open/floor/plasteel/black,/area/ruin/powered/syndicate_lava_base)
-"bf" = (/obj/structure/bookcase/random,/turf/open/floor/plasteel/black,/area/ruin/powered/syndicate_lava_base)
-"bg" = (/obj/structure/toilet{tag = "icon-toilet00 (WEST)"; icon_state = "toilet00"; dir = 8},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"bh" = (/obj/machinery/door/airlock/hatch{name = "Lounge"; req_access_txt = null},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bi" = (/obj/machinery/chem_dispenser,/turf/open/floor/plasteel/podhatch{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bj" = (/obj/structure/table/reinforced,/obj/item/weapon/reagent_containers/glass/beaker/large,/obj/item/weapon/reagent_containers/glass/beaker,/obj/item/weapon/reagent_containers/dropper,/obj/item/weapon/reagent_containers/syringe,/obj/structure/sign/nosmoking_2{pixel_y = 32},/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (NORTH)"; icon_state = "podhatch"; dir = 1},/area/ruin/powered/syndicate_lava_base)
-"bk" = (/obj/machinery/chem_master,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (EAST)"; icon_state = "podhatch"; dir = 4},/area/ruin/powered/syndicate_lava_base)
-"bl" = (/obj/structure/noticeboard{pixel_y = 32},/obj/machinery/reagentgrinder{desc = "Used to grind things up into raw materials and liquids."; pixel_y = 5},/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bm" = (/obj/structure/table/reinforced,/obj/item/weapon/clipboard,/obj/item/weapon/folder/white,/obj/item/weapon/book/manual/wiki/chemistry,/obj/item/weapon/book/manual/wiki/chemistry,/obj/item/device/assembly/signaler,/obj/item/device/assembly/signaler,/obj/item/device/assembly/voice,/obj/item/device/assembly/voice,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bn" = (/obj/structure/table/reinforced,/obj/item/weapon/storage/box/beakers{pixel_x = 3; pixel_y = 3},/obj/item/weapon/storage/box/syringes,/obj/item/weapon/gun/syringe/syndicate,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bo" = (/turf/open/floor/plasteel/podhatch{dir = 9},/area/ruin/powered/syndicate_lava_base)
-"bp" = (/turf/open/floor/plasteel/podhatch{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"bq" = (/obj/structure/table/reinforced,/obj/machinery/reagentgrinder{desc = "Used to grind things up into raw materials and liquids."; pixel_y = 5},/obj/structure/noticeboard{pixel_y = 32},/turf/open/floor/plasteel/podhatch/corner,/area/ruin/powered/syndicate_lava_base)
-"br" = (/obj/structure/reagent_dispensers/virusfood{pixel_y = 32},/obj/structure/table/reinforced,/obj/item/device/healthanalyzer,/obj/item/stack/sheet/mineral/plasma{amount = 5; layer = 3.1},/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
-"bs" = (/obj/structure/extinguisher_cabinet{pixel_x = 0; pixel_y = 32},/obj/machinery/computer/pandemic,/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
-"bt" = (/obj/structure/table/reinforced,/obj/item/weapon/storage/box/beakers{pixel_x = 3; pixel_y = 3},/obj/item/weapon/storage/box/syringes,/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
-"bu" = (/obj/structure/bed/roller,/obj/machinery/iv_drip,/obj/item/weapon/reagent_containers/blood/random,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (SOUTHEAST)"; icon_state = "podhatch"; dir = 6},/area/ruin/powered/syndicate_lava_base)
-"bv" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/turf/open/floor/plating,/area/ruin/powered/syndicate_lava_base)
-"bw" = (/mob/living/carbon/monkey,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bx" = (/obj/structure/bed/roller,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"by" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"bz" = (/mob/living/carbon/monkey,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"bA" = (/obj/structure/window/reinforced,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"bB" = (/obj/machinery/door/window/brigdoor,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bC" = (/obj/machinery/chem_heater,/obj/structure/extinguisher_cabinet{pixel_x = -26},/turf/open/floor/plasteel/podhatch{dir = 10},/area/ruin/powered/syndicate_lava_base)
-"bD" = (/obj/structure/chair/office/dark{dir = 1},/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
-"bE" = (/obj/structure/closet/crate/bin,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (SOUTHEAST)"; icon_state = "podhatch"; dir = 6},/area/ruin/powered/syndicate_lava_base)
-"bF" = (/turf/open/floor/plasteel/vault,/area/ruin/powered/syndicate_lava_base)
-"bG" = (/obj/item/device/assembly/igniter,/obj/item/device/assembly/igniter,/obj/item/device/assembly/igniter,/obj/item/device/assembly/timer{pixel_x = 3; pixel_y = 3},/obj/item/device/assembly/timer{pixel_x = 3; pixel_y = 3},/obj/item/device/assembly/timer{pixel_x = 3; pixel_y = 3},/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bH" = (/obj/structure/table/reinforced,/obj/item/weapon/book/manual/wiki/infections,/obj/item/stack/sheet/mineral/silver{amount = 10},/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (EAST)"; icon_state = "podhatch"; dir = 4},/area/ruin/powered/syndicate_lava_base)
-"bI" = (/obj/structure/chair/office/dark{dir = 8},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"bJ" = (/obj/machinery/door/airlock/hatch{name = "Monkey Pen"; req_access_txt = null},/turf/open/floor/plasteel/black,/area/ruin/powered/syndicate_lava_base)
-"bK" = (/obj/structure/table/reinforced,/obj/item/weapon/gun/projectile/automatic/sniper_rifle{pixel_x = -5},/obj/item/weapon/gun/projectile/automatic/sniper_rifle{pixel_x = 5},/obj/item/weapon/gun/projectile/automatic/sniper_rifle,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bL" = (/obj/structure/flora/kirbyplants{icon_state = "plant-01"; layer = 4.1},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bM" = (/obj/structure/table/reinforced,/obj/item/clothing/gloves/color/latex,/obj/item/clothing/gloves/color/latex,/obj/item/clothing/suit/toggle/labcoat,/obj/item/clothing/suit/toggle/labcoat,/obj/item/clothing/glasses/science,/obj/item/clothing/glasses/science,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bN" = (/obj/machinery/smartfridge/chemistry/virology,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (EAST)"; icon_state = "podhatch"; dir = 4},/area/ruin/powered/syndicate_lava_base)
-"bO" = (/obj/machinery/syndicatebomb/badmin/varplosion{anchored = 1; name = "Self Destruct Device"},/turf/open/floor/plasteel/black,/area/ruin/powered/syndicate_lava_base)
-"bP" = (/obj/machinery/iv_drip,/obj/item/weapon/reagent_containers/blood/random,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"bQ" = (/obj/structure/closet/crate/bin,/turf/open/floor/plasteel/podhatch{dir = 9},/area/ruin/powered/syndicate_lava_base)
-"bR" = (/obj/structure/chair/office/dark,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (NORTH)"; icon_state = "podhatch"; dir = 1},/area/ruin/powered/syndicate_lava_base)
-"bS" = (/obj/machinery/chem_heater,/turf/open/floor/plasteel/podhatch{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"bT" = (/obj/structure/table/reinforced,/obj/item/weapon/reagent_containers/glass/beaker/large,/obj/item/weapon/reagent_containers/glass/beaker,/obj/item/weapon/reagent_containers/dropper,/obj/item/weapon/reagent_containers/syringe,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (EAST)"; icon_state = "podhatch"; dir = 4},/area/ruin/powered/syndicate_lava_base)
-"bU" = (/obj/structure/chair/office/dark,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"bV" = (/obj/machinery/door/airlock/hatch{name = "Monkey Pen"; req_access_txt = null},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"bW" = (/obj/structure/table/reinforced,/obj/item/weapon/folder,/obj/item/clothing/ears/earmuffs,/obj/item/clothing/ears/earmuffs,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bX" = (/obj/structure/table/reinforced,/obj/item/weapon/gun/projectile/automatic/m90/unrestricted{pixel_y = -5},/obj/item/weapon/gun/projectile/automatic/c20r/unrestricted,/obj/item/weapon/gun/projectile/automatic/shotgun/bulldog/unrestricted{pixel_y = 7},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bY" = (/obj/machinery/chem_master,/turf/open/floor/plasteel/podhatch{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"bZ" = (/obj/structure/table/reinforced,/obj/item/weapon/reagent_containers/glass/beaker/large,/obj/item/weapon/reagent_containers/glass/beaker,/obj/item/weapon/reagent_containers/dropper,/obj/item/weapon/reagent_containers/syringe,/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
-"ca" = (/obj/machinery/chem_dispenser,/obj/structure/extinguisher_cabinet{pixel_x = 26},/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (EAST)"; icon_state = "podhatch"; dir = 4},/area/ruin/powered/syndicate_lava_base)
-"cb" = (/obj/structure/table/reinforced,/obj/item/clothing/suit/bio_suit/general,/obj/item/clothing/mask/surgical,/obj/item/clothing/head/bio_hood/general,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (SOUTHEAST)"; icon_state = "podhatch"; dir = 6},/area/ruin/powered/syndicate_lava_base)
-"cc" = (/obj/machinery/shower{dir = 4; icon_state = "shower"; name = "emergency shower"},/obj/machinery/shower{dir = 8; icon_state = "shower"; name = "emergency shower"},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"cd" = (/obj/structure/table/reinforced,/obj/item/weapon/paper_bin,/obj/item/weapon/pen,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (NORTH)"; icon_state = "podhatch"; dir = 1},/area/ruin/powered/syndicate_lava_base)
-"ce" = (/obj/structure/table/reinforced,/obj/item/weapon/folder/white,/obj/item/stack/sheet/mineral/gold{amount = 10},/obj/item/stack/sheet/mineral/uranium{amount = 10},/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (NORTH)"; icon_state = "podhatch"; dir = 1},/area/ruin/powered/syndicate_lava_base)
-"cf" = (/obj/structure/bed/roller,/mob/living/carbon/monkey,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cg" = (/obj/structure/sign/securearea,/turf/closed/wall/r_wall,/area/ruin/powered/syndicate_lava_base)
-"ch" = (/obj/machinery/door/airlock/hatch{name = "Firing Range"; req_access_txt = null},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"ci" = (/obj/machinery/door/airlock/hatch{name = "Chemistry Lab"; req_access_txt = null},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cj" = (/obj/structure/sign/chemistry,/turf/closed/wall/r_wall,/area/ruin/powered/syndicate_lava_base)
-"ck" = (/obj/structure/sign/biohazard,/turf/closed/wall/r_wall,/area/ruin/powered/syndicate_lava_base)
-"cl" = (/obj/machinery/door/airlock/hatch{name = "Virology Lab"; req_access_txt = null},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cm" = (/obj/structure/rack,/obj/item/ammo_box/magazine/sniper_rounds{pixel_x = 3; pixel_y = 3},/obj/item/ammo_box/magazine/sniper_rounds{pixel_x = -3; pixel_y = -3},/obj/item/ammo_box/magazine/sniper_rounds,/obj/item/ammo_box/magazine/sniper_rounds{pixel_x = -3; pixel_y = -3},/obj/item/ammo_box/magazine/sniper_rounds{pixel_x = -3; pixel_y = -3},/obj/item/ammo_box/magazine/sniper_rounds{pixel_x = -3; pixel_y = -3},/obj/item/ammo_box/magazine/sniper_rounds{pixel_x = -3; pixel_y = -3},/obj/item/ammo_box/magazine/m12g/buckshot,/obj/item/ammo_box/magazine/m12g/buckshot,/obj/item/ammo_box/magazine/m12g/buckshot,/obj/item/ammo_box/magazine/m12g/buckshot,/obj/item/ammo_box/magazine/m12g/buckshot,/obj/item/ammo_box/magazine/m12g/buckshot,/obj/item/ammo_box/magazine/m556,/obj/item/ammo_box/magazine/m556,/obj/item/ammo_box/magazine/m556,/obj/item/ammo_box/magazine/m556,/obj/item/ammo_box/magazine/m556,/obj/item/ammo_box/magazine/smgm45,/obj/item/ammo_box/magazine/smgm45,/obj/item/ammo_box/magazine/smgm45,/obj/item/ammo_box/magazine/smgm45,/obj/item/ammo_box/magazine/smgm45,/obj/item/ammo_box/magazine/smgm45,/turf/open/floor/plasteel/podhatch{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"cn" = (/obj/structure/flora/kirbyplants{icon_state = "plant-01"},/turf/open/floor/plasteel/podhatch{dir = 9},/area/ruin/powered/syndicate_lava_base)
-"co" = (/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (NORTH)"; icon_state = "podhatch"; dir = 1},/area/ruin/powered/syndicate_lava_base)
-"cp" = (/obj/machinery/syndicatebomb/badmin/varplosion{anchored = 1; name = "Self Destruct Device"},/turf/open/floor/plasteel/podhatch/corner{tag = "icon-podhatchcorner (EAST)"; icon_state = "podhatchcorner"; dir = 4},/area/ruin/powered/syndicate_lava_base)
-"cq" = (/obj/machinery/syndicatebomb/badmin/varplosion{anchored = 1; name = "Self Destruct Device"},/turf/open/floor/plasteel/podhatch/corner{tag = "icon-podhatchcorner (WEST)"; icon_state = "podhatchcorner"; dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cr" = (/obj/structure/flora/kirbyplants{icon_state = "plant-01"; layer = 4.1},/turf/open/floor/plasteel/podhatch{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"cs" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/obj/structure/sign/bluecross_2,/turf/open/floor/plating,/area/ruin/powered/syndicate_lava_base)
-"ct" = (/obj/structure/table,/obj/item/weapon/storage/firstaid/regular{pixel_x = 3; pixel_y = 3},/obj/item/weapon/storage/firstaid/fire,/obj/item/weapon/storage/firstaid/regular{pixel_x = -3; pixel_y = -3},/turf/open/floor/plasteel/vault,/area/ruin/powered/syndicate_lava_base)
-"cu" = (/obj/machinery/sleeper/syndie{dir = 8},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cv" = (/obj/structure/closet/crate/secure,/obj/item/target,/obj/item/target,/obj/item/target/alien,/obj/item/target/alien,/obj/item/target/clown,/obj/item/target/clown,/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (SOUTHEAST)"; icon_state = "podhatch"; dir = 6},/area/ruin/powered/syndicate_lava_base)
-"cw" = (/obj/machinery/door/airlock/hatch{name = "Firing Range"; req_access_txt = null},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cx" = (/turf/open/floor/plasteel/podhatch{dir = 10},/area/ruin/powered/syndicate_lava_base)
-"cy" = (/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
-"cz" = (/obj/structure/extinguisher_cabinet{pixel_y = -32},/turf/open/floor/plasteel/podhatch,/area/ruin/powered/syndicate_lava_base)
-"cA" = (/obj/machinery/syndicatebomb/badmin/varplosion{anchored = 1; name = "Self Destruct Device"},/turf/open/floor/plasteel/podhatch/corner{tag = "icon-podhatchcorner (NORTH)"; icon_state = "podhatchcorner"; dir = 1},/area/ruin/powered/syndicate_lava_base)
-"cB" = (/obj/machinery/syndicatebomb/badmin/varplosion{anchored = 1; name = "Self Destruct Device"},/turf/open/floor/plasteel/podhatch/corner,/area/ruin/powered/syndicate_lava_base)
-"cC" = (/turf/open/floor/plasteel/podhatch{tag = "icon-podhatch (SOUTHEAST)"; icon_state = "podhatch"; dir = 6},/area/ruin/powered/syndicate_lava_base)
-"cD" = (/obj/machinery/door/airlock/hatch{name = "Infirmary"; req_access_txt = null},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cE" = (/obj/structure/bed/roller,/obj/machinery/iv_drip,/obj/item/weapon/reagent_containers/blood/random,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cF" = (/obj/structure/grille,/obj/structure/window/reinforced/fulltile,/obj/machinery/door/poddoor/preopen{id = "lavalandsyndi"; name = "Syndicate Research Experimentor Shutters"},/turf/open/floor/plating,/area/ruin/powered/syndicate_lava_base)
-"cG" = (/obj/machinery/door/airlock/hatch{name = "Experimentation Room"; req_access_txt = null},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cH" = (/obj/machinery/door/airlock/hatch{name = "Telecommunications Control"; req_access_txt = null},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cI" = (/turf/open/floor/engine,/area/ruin/powered/syndicate_lava_base)
-"cJ" = (/obj/structure/noticeboard{pixel_y = 32},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"cK" = (/obj/structure/table,/obj/item/weapon/storage/toolbox/syndicate,/obj/item/device/multitool,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cL" = (/obj/item/weapon/surgicaldrill,/obj/item/weapon/circular_saw,/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cM" = (/obj/structure/sink{dir = 4; icon_state = "sink"; pixel_x = 11; pixel_y = 0},/obj/structure/mirror{pixel_x = 30},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"cN" = (/obj/item/stack/cable_coil/white{pixel_x = 3; pixel_y = 3},/obj/structure/table/reinforced,/obj/item/weapon/storage/toolbox/syndicate,/obj/item/stack/cable_coil/white,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cO" = (/obj/structure/table/reinforced,/obj/item/device/flashlight/lamp,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cP" = (/obj/structure/table/reinforced,/obj/item/device/radio/intercom{broadcasting = 0; dir = 8; freerange = 1; listening = 1; name = "Pirate Radio Listening Channel"; pixel_x = 0},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cQ" = (/obj/machinery/computer/camera_advanced,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"cR" = (/obj/structure/filingcabinet/chestdrawer,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cS" = (/obj/item/weapon/cautery,/obj/item/weapon/scalpel,/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cT" = (/obj/structure/table/optable,/obj/item/weapon/surgical_drapes,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cU" = (/obj/item/weapon/retractor,/obj/item/weapon/hemostat,/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cV" = (/obj/structure/sign/nosmoking_2{pixel_x = 32},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"cW" = (/obj/structure/flora/kirbyplants{icon_state = "plant-01"},/obj/structure/extinguisher_cabinet{pixel_x = -26},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"cX" = (/obj/structure/table/reinforced,/obj/item/device/radio/intercom{broadcasting = 1; dir = 8; freerange = 1; listening = 0; name = "Pirate Radio Broadcast Channel"; pixel_x = 0},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"cY" = (/obj/structure/sign/fire{pixel_x = -32},/turf/open/floor/engine,/area/ruin/powered/syndicate_lava_base)
-"cZ" = (/obj/structure/table/reinforced,/obj/item/device/assembly/signaler,/obj/item/device/assembly/signaler,/obj/item/device/assembly/voice,/obj/item/device/assembly/voice,/obj/item/weapon/screwdriver/nuke,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"da" = (/obj/structure/table/reinforced,/obj/item/stack/sheet/plasteel{amount = 15},/obj/item/device/electropack,/obj/item/device/taperecorder,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"db" = (/obj/structure/filingcabinet/security,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"dc" = (/obj/structure/table/reinforced,/obj/item/weapon/paper_bin,/obj/item/weapon/pen,/obj/item/weapon/card/id/syndicate/unrestricted,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"dd" = (/obj/machinery/computer/message_monitor,/obj/item/weapon/paper/monitorkey,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"de" = (/obj/machinery/door/airlock/hatch{name = "Telecommunications Control"; req_access_txt = null},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"df" = (/turf/open/floor/plasteel/vault{tag = "icon-vault (NORTHEAST)"; dir = 5},/area/ruin/powered/syndicate_lava_base)
-"dg" = (/obj/machinery/button/door{id = "lavalandsyndi"; name = "Syndicate Experimentor Lockdown Control"; pixel_x = 26; req_access_txt = null},/turf/open/floor/engine,/area/ruin/powered/syndicate_lava_base)
-"dh" = (/obj/machinery/button/door{id = "lavalandsyndi"; name = "Syndicate Experimentor Lockdown Control"; pixel_x = -26; req_access_txt = null},/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"di" = (/obj/item/stack/sheet/metal{amount = 30},/obj/item/stack/rods{amount = 50},/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"dj" = (/obj/structure/filingcabinet/medical,/turf/open/floor/plasteel/vault{dir = 5},/area/ruin/powered/syndicate_lava_base)
-"dk" = (/turf/open/floor/plasteel/circuit/gcircuit,/area/ruin/powered/syndicate_lava_base)
-"dl" = (/obj/machinery/syndicatebomb/badmin/varplosion{anchored = 1; name = "Self Destruct Device"},/turf/open/floor/plasteel/circuit/gcircuit,/area/ruin/powered/syndicate_lava_base)
-"dm" = (/obj/machinery/door/poddoor/preopen{id = "lavalandsyndi"; name = "Syndicate Research Experimentor Shutters"},/obj/machinery/door/airlock/hatch{name = "Experimentation Room"; req_access_txt = null},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"dn" = (/obj/item/stack/sheet/metal{amount = 50},/obj/item/weapon/grenade/chem_grenade,/obj/item/weapon/grenade/chem_grenade,/obj/item/weapon/grenade/chem_grenade,/obj/structure/table/reinforced,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"do" = (/obj/machinery/telecomms/relay/preset/ruskie{use_power = 0},/turf/open/floor/plasteel/vault{tag = "icon-vault (NORTHEAST)"; dir = 5},/area/ruin/powered/syndicate_lava_base)
-"dp" = (/obj/machinery/door/airlock/hatch{name = "Syndicate Recon Outpost"; req_access_txt = null},/obj/structure/fans/tiny,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"dq" = (/obj/machinery/door/airlock/hatch{name = "Monkey Pen"; req_access_txt = null},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"dr" = (/obj/structure/sign/vacuum{pixel_x = -32},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"ds" = (/obj/structure/sign/xeno_warning_mining{pixel_x = 32},/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"dt" = (/obj/structure/bed/roller,/obj/machinery/iv_drip,/mob/living/carbon/monkey,/turf/open/floor/plasteel/vault{dir = 8},/area/ruin/powered/syndicate_lava_base)
-"du" = (/obj/structure/sign/securearea{pixel_y = 32},/turf/open/floor/plating/lava/smooth/lava_land_surface,/area/lavaland/surface/outdoors)
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+"aa" = (
+/turf/template_noop,
+/area/template_noop)
+"ab" = (
+/turf/open/floor/plating/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ac" = (
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"ad" = (
+/turf/closed/wall/r_wall,
+/area/ruin/powered/syndicate_lava_base)
+"ae" = (
+/obj/structure/closet/secure_closet/bar{
+	req_access = null;
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/podhatch{
+	dir = 10
+	},
+/area/ruin/powered/syndicate_lava_base)
+"af" = (
+/obj/structure/table/wood,
+/obj/item/weapon/reagent_containers/food/snacks/syndicake,
+/obj/item/weapon/reagent_containers/food/snacks/syndicake,
+/obj/item/weapon/reagent_containers/food/snacks/syndicake,
+/obj/structure/sign/barsign{
+	pixel_y = 32;
+	req_access = null;
+	req_access_txt = "150"
+	},
+/turf/open/floor/plasteel/podhatch,
+/area/ruin/powered/syndicate_lava_base)
+"ag" = (
+/obj/structure/table/wood,
+/obj/item/weapon/reagent_containers/food/snacks/salad/validsalad,
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (SOUTHEAST)";
+	icon_state = "podhatch";
+	dir = 6
+	},
+/area/ruin/powered/syndicate_lava_base)
+"ah" = (
+/obj/structure/rack{
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "minibar_left";
+	name = "skeletal minibar"
+	},
+/obj/item/weapon/reagent_containers/food/drinks/bottle/vodka,
+/turf/open/floor/wood,
+/area/ruin/powered/syndicate_lava_base)
+"ai" = (
+/obj/structure/rack{
+	icon = 'icons/obj/stationobjs.dmi';
+	icon_state = "minibar_right";
+	name = "skeletal minibar"
+	},
+/obj/item/weapon/reagent_containers/food/drinks/bottle/gin,
+/turf/open/floor/wood,
+/area/ruin/powered/syndicate_lava_base)
+"aj" = (
+/obj/structure/dresser,
+/obj/structure/mirror{
+	desc = "Mirror mirror on the wall, who is the most robust of them all?";
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/vault,
+/area/ruin/powered/syndicate_lava_base)
+"ak" = (
+/obj/structure/flora/kirbyplants{
+	icon_state = "plant-01";
+	layer = 4.1
+	},
+/turf/open/floor/plasteel/vault,
+/area/ruin/powered/syndicate_lava_base)
+"al" = (
+/obj/structure/flora/kirbyplants{
+	icon_state = "plant-01"
+	},
+/turf/open/floor/plasteel/vault,
+/area/ruin/powered/syndicate_lava_base)
+"am" = (
+/obj/structure/table/wood,
+/obj/item/weapon/clipboard,
+/obj/item/toy/figure/syndie,
+/turf/open/floor/plasteel/vault,
+/area/ruin/powered/syndicate_lava_base)
+"an" = (
+/obj/machinery/portable_atmospherics/canister/air,
+/turf/open/floor/plasteel/podhatch{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"ao" = (
+/turf/open/floor/plasteel/black,
+/area/ruin/powered/syndicate_lava_base)
+"ap" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"aq" = (
+/obj/item/stack/sheet/metal{
+	amount = 30
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/podhatch{
+	dir = 9
+	},
+/area/ruin/powered/syndicate_lava_base)
+"ar" = (
+/turf/open/floor/wood,
+/area/ruin/powered/syndicate_lava_base)
+"as" = (
+/obj/effect/mob_spawn/human/lavaland_syndicate{
+	tag = "icon-sleeper_s (EAST)";
+	icon_state = "sleeper_s";
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/powered/syndicate_lava_base)
+"at" = (
+/turf/open/floor/plasteel/grimy,
+/area/ruin/powered/syndicate_lava_base)
+"au" = (
+/obj/machinery/syndicatebomb/badmin/varplosion{
+	anchored = 1;
+	name = "Self Destruct Device"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/powered/syndicate_lava_base)
+"av" = (
+/obj/effect/mob_spawn/human/lavaland_syndicate{
+	tag = "icon-sleeper_s (WEST)";
+	icon_state = "sleeper_s";
+	dir = 8
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/powered/syndicate_lava_base)
+"aw" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (EAST)";
+	icon_state = "podhatch";
+	dir = 4
+	},
+/area/ruin/powered/syndicate_lava_base)
+"ax" = (
+/obj/item/stack/cable_coil/white,
+/obj/item/stack/cable_coil/white,
+/obj/item/stack/packageWrap,
+/obj/item/weapon/hand_labeler,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/podhatch{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"ay" = (
+/obj/structure/table/wood,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/m10mm,
+/obj/item/ammo_box/magazine/m10mm,
+/turf/open/floor/plasteel/grimy,
+/area/ruin/powered/syndicate_lava_base)
+"az" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (SOUTHEAST)";
+	icon_state = "podhatch";
+	dir = 6
+	},
+/area/ruin/powered/syndicate_lava_base)
+"aA" = (
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/stack/sheet/glass{
+	amount = 50
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/wrench,
+/turf/open/floor/plasteel/podhatch{
+	dir = 10
+	},
+/area/ruin/powered/syndicate_lava_base)
+"aB" = (
+/obj/structure/table/wood,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/ruin/powered/syndicate_lava_base)
+"aC" = (
+/obj/structure/table/wood,
+/obj/item/weapon/storage/box/drinkingglasses,
+/turf/open/floor/wood,
+/area/ruin/powered/syndicate_lava_base)
+"aD" = (
+/obj/structure/table/wood,
+/obj/item/toy/nuke,
+/obj/item/weapon/book/manual/nuclear,
+/turf/open/floor/wood,
+/area/ruin/powered/syndicate_lava_base)
+"aE" = (
+/obj/structure/table/wood,
+/obj/item/weapon/lighter{
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/fancy/cigarettes/cigpack_syndicate,
+/turf/open/floor/wood,
+/area/ruin/powered/syndicate_lava_base)
+"aF" = (
+/obj/structure/table/wood,
+/obj/item/weapon/storage/fancy/donut_box,
+/turf/open/floor/wood,
+/area/ruin/powered/syndicate_lava_base)
+"aG" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26
+	},
+/turf/open/floor/wood,
+/area/ruin/powered/syndicate_lava_base)
+"aH" = (
+/obj/effect/mob_spawn/human/lavaland_syndicate/comms{
+	tag = "icon-sleeper_s (EAST)";
+	icon_state = "sleeper_s";
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ruin/powered/syndicate_lava_base)
+"aI" = (
+/obj/structure/sign/nosmoking_2,
+/turf/closed/wall/r_wall,
+/area/ruin/powered/syndicate_lava_base)
+"aJ" = (
+/obj/machinery/syndicatebomb/badmin/varplosion{
+	anchored = 1;
+	name = "Self Destruct Device"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"aK" = (
+/obj/structure/closet/crate/bin,
+/obj/item/trash/syndi_cakes,
+/turf/open/floor/plasteel/black,
+/area/ruin/powered/syndicate_lava_base)
+"aL" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"aM" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/plasteel/black,
+/area/ruin/powered/syndicate_lava_base)
+"aN" = (
+/obj/structure/table/wood,
+/obj/item/weapon/lipstick/random{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/lipstick/random{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/weapon/lipstick/random,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"aO" = (
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"aP" = (
+/obj/structure/dresser,
+/obj/structure/mirror{
+	desc = "Mirror mirror on the wall, who is the most robust of them all?";
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"aQ" = (
+/obj/item/target,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"aR" = (
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
+/obj/item/weapon/tank/internals/emergency_oxygen/engi,
+/obj/item/device/flashlight/seclite,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/podhatch{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"aS" = (
+/obj/structure/flora/kirbyplants{
+	icon_state = "plant-01";
+	layer = 4.1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"aT" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Dormitories";
+	req_access_txt = null
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"aU" = (
+/obj/structure/closet/emcloset,
+/obj/item/weapon/tank/internals/emergency_oxygen/engi,
+/obj/item/device/flashlight/seclite,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (EAST)";
+	icon_state = "podhatch";
+	dir = 4
+	},
+/area/ruin/powered/syndicate_lava_base)
+"aV" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Storage Closet";
+	req_access_txt = null
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"aW" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Dormitories";
+	req_access_txt = null
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"aX" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Restroom";
+	req_access_txt = null
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"aY" = (
+/obj/structure/mirror{
+	desc = "Mirror mirror on the wall, who is the most robust of them all?";
+	pixel_x = 28
+	},
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"aZ" = (
+/turf/open/floor/plasteel/podhatch{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"ba" = (
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (EAST)";
+	icon_state = "podhatch";
+	dir = 4
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bb" = (
+/obj/structure/closet/emcloset{
+	anchored = 1
+	},
+/obj/item/weapon/tank/internals/emergency_oxygen/engi,
+/obj/item/device/flashlight/seclite,
+/obj/item/clothing/mask/gas,
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (SOUTHEAST)";
+	icon_state = "podhatch";
+	dir = 6
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bc" = (
+/obj/structure/flora/kirbyplants{
+	icon_state = "plant-01"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bd" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"be" = (
+/obj/structure/flora/kirbyplants{
+	icon_state = "plant-01";
+	layer = 4.1
+	},
+/turf/open/floor/plasteel/black,
+/area/ruin/powered/syndicate_lava_base)
+"bf" = (
+/obj/structure/bookcase/random,
+/turf/open/floor/plasteel/black,
+/area/ruin/powered/syndicate_lava_base)
+"bg" = (
+/obj/structure/toilet{
+	tag = "icon-toilet00 (WEST)";
+	icon_state = "toilet00";
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bh" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Lounge";
+	req_access_txt = null
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bi" = (
+/obj/machinery/chem_dispenser,
+/turf/open/floor/plasteel/podhatch{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bj" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/glass/beaker,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/weapon/reagent_containers/syringe,
+/obj/structure/sign/nosmoking_2{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (NORTH)";
+	icon_state = "podhatch";
+	dir = 1
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bk" = (
+/obj/machinery/chem_master,
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (EAST)";
+	icon_state = "podhatch";
+	dir = 4
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bl" = (
+/obj/structure/noticeboard{
+	pixel_y = 32
+	},
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 5
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bm" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/clipboard,
+/obj/item/weapon/folder/white,
+/obj/item/weapon/book/manual/wiki/chemistry,
+/obj/item/weapon/book/manual/wiki/chemistry,
+/obj/item/device/assembly/signaler,
+/obj/item/device/assembly/signaler,
+/obj/item/device/assembly/voice,
+/obj/item/device/assembly/voice,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bn" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/box/beakers{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/box/syringes,
+/obj/item/weapon/gun/syringe/syndicate,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bo" = (
+/turf/open/floor/plasteel/podhatch{
+	dir = 9
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bp" = (
+/turf/open/floor/plasteel/podhatch{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bq" = (
+/obj/structure/table/reinforced,
+/obj/machinery/reagentgrinder{
+	desc = "Used to grind things up into raw materials and liquids.";
+	pixel_y = 5
+	},
+/obj/structure/noticeboard{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/podhatch/corner,
+/area/ruin/powered/syndicate_lava_base)
+"br" = (
+/obj/structure/reagent_dispensers/virusfood{
+	pixel_y = 32
+	},
+/obj/structure/table/reinforced,
+/obj/item/device/healthanalyzer,
+/obj/item/stack/sheet/mineral/plasma{
+	amount = 5;
+	layer = 3.1
+	},
+/turf/open/floor/plasteel/podhatch,
+/area/ruin/powered/syndicate_lava_base)
+"bs" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
+	pixel_y = 32
+	},
+/obj/machinery/computer/pandemic,
+/turf/open/floor/plasteel/podhatch,
+/area/ruin/powered/syndicate_lava_base)
+"bt" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/box/beakers{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/box/syringes,
+/turf/open/floor/plasteel/podhatch,
+/area/ruin/powered/syndicate_lava_base)
+"bu" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/item/weapon/reagent_containers/blood/random,
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (SOUTHEAST)";
+	icon_state = "podhatch";
+	dir = 6
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bv" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plating,
+/area/ruin/powered/syndicate_lava_base)
+"bw" = (
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bx" = (
+/obj/structure/bed/roller,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"by" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bz" = (
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bA" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bB" = (
+/obj/machinery/door/window/brigdoor,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bC" = (
+/obj/machinery/chem_heater,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/podhatch{
+	dir = 10
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bD" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel/podhatch,
+/area/ruin/powered/syndicate_lava_base)
+"bE" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (SOUTHEAST)";
+	icon_state = "podhatch";
+	dir = 6
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bF" = (
+/turf/open/floor/plasteel/vault,
+/area/ruin/powered/syndicate_lava_base)
+"bG" = (
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/igniter,
+/obj/item/device/assembly/timer{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/device/assembly/timer{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/device/assembly/timer{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bH" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/book/manual/wiki/infections,
+/obj/item/stack/sheet/mineral/silver{
+	amount = 10
+	},
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (EAST)";
+	icon_state = "podhatch";
+	dir = 4
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bI" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bJ" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Monkey Pen";
+	req_access_txt = null
+	},
+/turf/open/floor/plasteel/black,
+/area/ruin/powered/syndicate_lava_base)
+"bK" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/gun/projectile/automatic/sniper_rifle{
+	pixel_x = -5
+	},
+/obj/item/weapon/gun/projectile/automatic/sniper_rifle{
+	pixel_x = 5
+	},
+/obj/item/weapon/gun/projectile/automatic/sniper_rifle,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bL" = (
+/obj/structure/flora/kirbyplants{
+	icon_state = "plant-01";
+	layer = 4.1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bM" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/clothing/suit/toggle/labcoat,
+/obj/item/clothing/suit/toggle/labcoat,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bN" = (
+/obj/machinery/smartfridge/chemistry/virology,
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (EAST)";
+	icon_state = "podhatch";
+	dir = 4
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bO" = (
+/obj/machinery/syndicatebomb/badmin/varplosion{
+	anchored = 1;
+	name = "Self Destruct Device"
+	},
+/turf/open/floor/plasteel/black,
+/area/ruin/powered/syndicate_lava_base)
+"bP" = (
+/obj/machinery/iv_drip,
+/obj/item/weapon/reagent_containers/blood/random,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bQ" = (
+/obj/structure/closet/crate/bin,
+/turf/open/floor/plasteel/podhatch{
+	dir = 9
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bR" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (NORTH)";
+	icon_state = "podhatch";
+	dir = 1
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bS" = (
+/obj/machinery/chem_heater,
+/turf/open/floor/plasteel/podhatch{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bT" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/glass/beaker,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/weapon/reagent_containers/syringe,
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (EAST)";
+	icon_state = "podhatch";
+	dir = 4
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bU" = (
+/obj/structure/chair/office/dark,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bV" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Monkey Pen";
+	req_access_txt = null
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bW" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/folder,
+/obj/item/clothing/ears/earmuffs,
+/obj/item/clothing/ears/earmuffs,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bX" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/gun/projectile/automatic/m90/unrestricted{
+	pixel_y = -5
+	},
+/obj/item/weapon/gun/projectile/automatic/c20r/unrestricted,
+/obj/item/weapon/gun/projectile/automatic/shotgun/bulldog/unrestricted{
+	pixel_y = 7
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bY" = (
+/obj/machinery/chem_master,
+/turf/open/floor/plasteel/podhatch{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"bZ" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/reagent_containers/glass/beaker/large,
+/obj/item/weapon/reagent_containers/glass/beaker,
+/obj/item/weapon/reagent_containers/dropper,
+/obj/item/weapon/reagent_containers/syringe,
+/turf/open/floor/plasteel/podhatch,
+/area/ruin/powered/syndicate_lava_base)
+"ca" = (
+/obj/machinery/chem_dispenser,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 26
+	},
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (EAST)";
+	icon_state = "podhatch";
+	dir = 4
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cb" = (
+/obj/structure/table/reinforced,
+/obj/item/clothing/suit/bio_suit/general,
+/obj/item/clothing/mask/surgical,
+/obj/item/clothing/head/bio_hood/general,
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (SOUTHEAST)";
+	icon_state = "podhatch";
+	dir = 6
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cc" = (
+/obj/machinery/shower{
+	dir = 4;
+	icon_state = "shower";
+	name = "emergency shower"
+	},
+/obj/machinery/shower{
+	dir = 8;
+	icon_state = "shower";
+	name = "emergency shower"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cd" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (NORTH)";
+	icon_state = "podhatch";
+	dir = 1
+	},
+/area/ruin/powered/syndicate_lava_base)
+"ce" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/folder/white,
+/obj/item/stack/sheet/mineral/gold{
+	amount = 10
+	},
+/obj/item/stack/sheet/mineral/uranium{
+	amount = 10
+	},
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (NORTH)";
+	icon_state = "podhatch";
+	dir = 1
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cf" = (
+/obj/structure/bed/roller,
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cg" = (
+/obj/structure/sign/securearea,
+/turf/closed/wall/r_wall,
+/area/ruin/powered/syndicate_lava_base)
+"ch" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Firing Range";
+	req_access_txt = null
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"ci" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Chemistry Lab";
+	req_access_txt = null
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cj" = (
+/obj/structure/sign/chemistry,
+/turf/closed/wall/r_wall,
+/area/ruin/powered/syndicate_lava_base)
+"ck" = (
+/obj/structure/sign/biohazard,
+/turf/closed/wall/r_wall,
+/area/ruin/powered/syndicate_lava_base)
+"cl" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Virology Lab";
+	req_access_txt = null
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cm" = (
+/obj/structure/rack,
+/obj/item/ammo_box/magazine/sniper_rounds{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/ammo_box/magazine/sniper_rounds{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/ammo_box/magazine/sniper_rounds,
+/obj/item/ammo_box/magazine/sniper_rounds{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/ammo_box/magazine/sniper_rounds{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/ammo_box/magazine/sniper_rounds{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/ammo_box/magazine/sniper_rounds{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/item/ammo_box/magazine/m12g/buckshot,
+/obj/item/ammo_box/magazine/m12g/buckshot,
+/obj/item/ammo_box/magazine/m12g/buckshot,
+/obj/item/ammo_box/magazine/m12g/buckshot,
+/obj/item/ammo_box/magazine/m12g/buckshot,
+/obj/item/ammo_box/magazine/m12g/buckshot,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/m556,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/ammo_box/magazine/smgm45,
+/obj/item/ammo_box/magazine/smgm45,
+/turf/open/floor/plasteel/podhatch{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cn" = (
+/obj/structure/flora/kirbyplants{
+	icon_state = "plant-01"
+	},
+/turf/open/floor/plasteel/podhatch{
+	dir = 9
+	},
+/area/ruin/powered/syndicate_lava_base)
+"co" = (
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (NORTH)";
+	icon_state = "podhatch";
+	dir = 1
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cp" = (
+/obj/machinery/syndicatebomb/badmin/varplosion{
+	anchored = 1;
+	name = "Self Destruct Device"
+	},
+/turf/open/floor/plasteel/podhatch/corner{
+	tag = "icon-podhatchcorner (EAST)";
+	icon_state = "podhatchcorner";
+	dir = 4
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cq" = (
+/obj/machinery/syndicatebomb/badmin/varplosion{
+	anchored = 1;
+	name = "Self Destruct Device"
+	},
+/turf/open/floor/plasteel/podhatch/corner{
+	tag = "icon-podhatchcorner (WEST)";
+	icon_state = "podhatchcorner";
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cr" = (
+/obj/structure/flora/kirbyplants{
+	icon_state = "plant-01";
+	layer = 4.1
+	},
+/turf/open/floor/plasteel/podhatch{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cs" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/structure/sign/bluecross_2,
+/turf/open/floor/plating,
+/area/ruin/powered/syndicate_lava_base)
+"ct" = (
+/obj/structure/table,
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/weapon/storage/firstaid/fire,
+/obj/item/weapon/storage/firstaid/regular{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/vault,
+/area/ruin/powered/syndicate_lava_base)
+"cu" = (
+/obj/machinery/sleeper/syndie{
+	dir = 8
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cv" = (
+/obj/structure/closet/crate/secure,
+/obj/item/target,
+/obj/item/target,
+/obj/item/target/alien,
+/obj/item/target/alien,
+/obj/item/target/clown,
+/obj/item/target/clown,
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (SOUTHEAST)";
+	icon_state = "podhatch";
+	dir = 6
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cw" = (
+/turf/closed/indestructible/riveted,
+/area/ruin/powered/syndicate_lava_base)
+"cx" = (
+/turf/open/floor/plasteel/podhatch{
+	dir = 10
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cy" = (
+/turf/open/floor/plasteel/podhatch,
+/area/ruin/powered/syndicate_lava_base)
+"cz" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/podhatch,
+/area/ruin/powered/syndicate_lava_base)
+"cA" = (
+/obj/machinery/syndicatebomb/badmin/varplosion{
+	anchored = 1;
+	name = "Self Destruct Device"
+	},
+/turf/open/floor/plasteel/podhatch/corner{
+	tag = "icon-podhatchcorner (NORTH)";
+	icon_state = "podhatchcorner";
+	dir = 1
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cB" = (
+/obj/machinery/syndicatebomb/badmin/varplosion{
+	anchored = 1;
+	name = "Self Destruct Device"
+	},
+/turf/open/floor/plasteel/podhatch/corner,
+/area/ruin/powered/syndicate_lava_base)
+"cC" = (
+/turf/open/floor/plasteel/podhatch{
+	tag = "icon-podhatch (SOUTHEAST)";
+	icon_state = "podhatch";
+	dir = 6
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cD" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Infirmary";
+	req_access_txt = null
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cE" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/obj/item/weapon/reagent_containers/blood/random,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cF" = (
+/obj/structure/grille,
+/obj/structure/window/reinforced/fulltile,
+/obj/machinery/door/poddoor/preopen{
+	id = "lavalandsyndi";
+	name = "Syndicate Research Experimentor Shutters"
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/syndicate_lava_base)
+"cG" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Experimentation Room";
+	req_access_txt = null
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cH" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Telecommunications Control";
+	req_access_txt = null
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cI" = (
+/turf/open/floor/engine,
+/area/ruin/powered/syndicate_lava_base)
+"cJ" = (
+/obj/structure/noticeboard{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cK" = (
+/obj/structure/table,
+/obj/item/weapon/storage/toolbox/syndicate,
+/obj/item/device/multitool,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cL" = (
+/obj/item/weapon/surgicaldrill,
+/obj/item/weapon/circular_saw,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cM" = (
+/obj/structure/sink{
+	dir = 4;
+	icon_state = "sink";
+	pixel_x = 11;
+	pixel_y = 0
+	},
+/obj/structure/mirror{
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cN" = (
+/obj/item/stack/cable_coil/white{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/structure/table/reinforced,
+/obj/item/weapon/storage/toolbox/syndicate,
+/obj/item/stack/cable_coil/white,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cO" = (
+/obj/structure/table/reinforced,
+/obj/item/device/flashlight/lamp,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cP" = (
+/obj/structure/table/reinforced,
+/obj/item/device/radio/intercom{
+	broadcasting = 0;
+	dir = 8;
+	freerange = 1;
+	listening = 1;
+	name = "Pirate Radio Listening Channel";
+	pixel_x = 0
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cQ" = (
+/obj/machinery/computer/camera_advanced,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cR" = (
+/obj/structure/filingcabinet/chestdrawer,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cS" = (
+/obj/item/weapon/cautery,
+/obj/item/weapon/scalpel,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cT" = (
+/obj/structure/table/optable,
+/obj/item/weapon/surgical_drapes,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cU" = (
+/obj/item/weapon/retractor,
+/obj/item/weapon/hemostat,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cV" = (
+/obj/structure/sign/nosmoking_2{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cW" = (
+/obj/structure/flora/kirbyplants{
+	icon_state = "plant-01"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -26
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cX" = (
+/obj/structure/table/reinforced,
+/obj/item/device/radio/intercom{
+	broadcasting = 1;
+	dir = 8;
+	freerange = 1;
+	listening = 0;
+	name = "Pirate Radio Broadcast Channel";
+	pixel_x = 0
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"cY" = (
+/obj/structure/sign/fire{
+	pixel_x = -32
+	},
+/turf/open/floor/engine,
+/area/ruin/powered/syndicate_lava_base)
+"cZ" = (
+/obj/structure/table/reinforced,
+/obj/item/device/assembly/signaler,
+/obj/item/device/assembly/signaler,
+/obj/item/device/assembly/voice,
+/obj/item/device/assembly/voice,
+/obj/item/weapon/screwdriver/nuke,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"da" = (
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/plasteel{
+	amount = 15
+	},
+/obj/item/device/electropack,
+/obj/item/device/taperecorder,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"db" = (
+/obj/structure/filingcabinet/security,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"dc" = (
+/obj/structure/table/reinforced,
+/obj/item/weapon/paper_bin,
+/obj/item/weapon/pen,
+/obj/item/weapon/card/id/syndicate/unrestricted,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"dd" = (
+/obj/machinery/computer/message_monitor,
+/obj/item/weapon/paper/monitorkey,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"de" = (
+/obj/item/weapon/paper/crumpled/bloody/syndie,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"df" = (
+/turf/open/floor/plasteel/vault{
+	tag = "icon-vault (NORTHEAST)";
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"dg" = (
+/obj/machinery/button/door{
+	id = "lavalandsyndi";
+	name = "Syndicate Experimentor Lockdown Control";
+	pixel_x = 26;
+	req_access_txt = null
+	},
+/turf/open/floor/engine,
+/area/ruin/powered/syndicate_lava_base)
+"dh" = (
+/obj/machinery/button/door{
+	id = "lavalandsyndi";
+	name = "Syndicate Experimentor Lockdown Control";
+	pixel_x = -26;
+	req_access_txt = null
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"di" = (
+/obj/item/stack/sheet/metal{
+	amount = 30
+	},
+/obj/item/stack/rods{
+	amount = 50
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"dj" = (
+/obj/structure/filingcabinet/medical,
+/turf/open/floor/plasteel/vault{
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"dk" = (
+/turf/open/floor/plasteel/circuit/gcircuit,
+/area/ruin/powered/syndicate_lava_base)
+"dl" = (
+/obj/machinery/syndicatebomb/badmin/varplosion{
+	anchored = 1;
+	name = "Self Destruct Device"
+	},
+/turf/open/floor/plasteel/circuit/gcircuit,
+/area/ruin/powered/syndicate_lava_base)
+"dm" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "lavalandsyndi";
+	name = "Syndicate Research Experimentor Shutters"
+	},
+/obj/machinery/door/airlock/hatch{
+	name = "Experimentation Room";
+	req_access_txt = null
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"dn" = (
+/obj/item/stack/sheet/metal{
+	amount = 50
+	},
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/item/weapon/grenade/chem_grenade,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"do" = (
+/obj/machinery/telecomms/relay/preset/ruskie{
+	use_power = 0
+	},
+/turf/open/floor/plasteel/vault{
+	tag = "icon-vault (NORTHEAST)";
+	dir = 5
+	},
+/area/ruin/powered/syndicate_lava_base)
+"dp" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Syndicate Recon Outpost";
+	req_access_txt = null
+	},
+/obj/structure/fans/tiny,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"dq" = (
+/obj/machinery/door/airlock/hatch{
+	name = "Monkey Pen";
+	req_access_txt = null
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"dr" = (
+/obj/structure/sign/vacuum{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"ds" = (
+/obj/structure/sign/xeno_warning_mining{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"dt" = (
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
+/mob/living/carbon/monkey,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ruin/powered/syndicate_lava_base)
+"du" = (
+/obj/structure/sign/securearea{
+	pixel_y = 32
+	},
+/turf/open/floor/plating/lava/smooth/lava_land_surface,
+/area/lavaland/surface/outdoors)
 
 (1,1,1) = {"
-aaaaaaaaabaaaaabababababababababababababababababababababababababababababaaaa
-aaaaabababababababababababababababababababababababababababababababababababaa
-aaaaabababababababababababababababababababababababababababababababababababab
-aaaaabababababababababababababababababababababababababababababababababababaa
-aaababababababababababababababababababababababababababababababababababababab
-ababababababababababacababababacacadadadadadadadadadadadadadadabacababababab
-abababababacababababababadadadadadadaeafagadahaiadajakadalamadababababababab
-abababababababababababacadanaoapaqadararararararadasatadauavadacabababababab
-abababababababacacababacadawapaoaxadararararararadayatadatayadacabababababab
-abababababababacadadadadadazaoapaAadaBaCaDaEaFaGadaHatadatavadababacabababab
-abababababababacadapapapadaIaJaoadadaKaLaMaLaoapadaNaOadaOaPadacabacabababab
-ababababababababadapaQapadaRapaoaSadapaoaJaoapaoadadaTadaTadadadadababababab
-abababababacababadapaOapadaUaoapapaVaoapaoapaoapaWapapapaJapaXaYadababababab
-abababababababacadaZaObaadbbapaobcadbdbeapaobcbfadaSapapapaSadbgadacabababab
-abababababababacadaJaOapadadadadadadadadbhbhadadadadadadadadadadadadadababab
-abababababababacadaZaObaadbibjbkblbmbnadbobpadbqbrbsbtbubvbwbxbybxbzadababab
-abababababacabacadbAbBbAadbCbDbEbFbFbGbvaZbabvbHbIapapapbvbJbybybJbyadababab
-abababababacababadbKaObLadaSapaJapapbMbvaZbabvbNapaoaobOaoaoaoaoaobOadababab
-abababababacabacadapapapadbPaoapbQbRbSbvaZbabvbTapapapbUbybJbybybVbyadababab
-abababababababacadbWapbXadbPapapbYbZcaadaZbaadcbccbQcdcebyaOcfbyaOcfadababab
-ababababababacabadcgchadadcgcicjadbvadadaZbaadckcladbvbvadadadadadadadababab
-ababababababababadcmapaSbvcncococococococpcqcococococococrcsctapcuadabababab
-aaabababababacacadcvaJapcwcxcyczcycycycycAcBcycycycycycycCcDapaJcEadabababab
-aaabababababacadadadcFadadadadadadcGcgadaZbaadadcHcgadadadadapapcuadabababab
-abababababababadcIcIcIcIcIcIcIcgaSapapadaZbaadaSapapcJapcKadcLapcMadabababab
-abababababababadcIcIcIcIcIcIcIcFcNapapadaZbaadapaocOcPcQcRadcScTcUadabababab
-abababababababadcIcIcIcIcIcIcIcFbGapcVadaZbaadcWaocXbIaJaOadadadadadabababab
-ababababababacadcYcIcIcIcIcIcIcFcZapdaadaZbaaddbaodcddapaOdedfdfdfadabababab
-abababababababadcIcIcIcIcIcIdgaddhapdiadaZbaaddjapapapapbLaddkdldkadabababab
-ababababababacadcIcIcIcIcIcIcIdmapaJdnadcxcCadadadadadadadaddkdodkadabababab
-ababababababacadcIcIcIcIcIcIcIadcWapaSaddpdpadacacacacacabadadadadadabababab
-ababababababacadadadadadadadadadbvdqbvaddrdsadacacacababababababacacabababab
-ababababababacacacabababacacacaddtaOdtadaOaOadacababababacababababababababab
-ababababababababababababababacadadadadaddpdpadababacacababababababababababab
-abababababababababababababababababababduababduababababababababababababababab
-abababababababababababababababababababababababababababababababababababababaa
-aaababababababababababababababababababababababababababababababababababababaa
-aaaaabaaababababababababababababababababababababababababababababababaaaaaaaa
+aa
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+"}
+(2,1,1) = {"
+aa
+aa
+aa
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(3,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(4,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(5,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(6,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ac
+ab
+ab
+ab
+ab
+ab
+ac
+ab
+ab
+ab
+ac
+ac
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(7,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+ab
+ac
+ac
+ab
+ab
+ab
+ac
+ab
+ac
+ac
+ac
+ac
+ab
+ab
+ab
+ab
+ab
+"}
+(8,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+ac
+ac
+ab
+ab
+ac
+ac
+ac
+ac
+ab
+ac
+ac
+ab
+ab
+ac
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+ac
+ab
+ab
+ab
+ab
+ab
+"}
+(9,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cI
+cI
+cI
+cY
+cI
+cI
+cI
+cw
+ac
+ab
+ab
+ab
+ab
+ab
+"}
+(10,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+cw
+ap
+ap
+ap
+aZ
+aJ
+aZ
+bA
+bK
+ap
+bW
+cg
+cm
+cv
+ad
+cI
+cI
+cI
+cI
+cI
+cI
+cI
+cw
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(11,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ac
+ab
+ab
+ab
+cw
+ap
+aQ
+aO
+aO
+aO
+aO
+bB
+aO
+ap
+ap
+ch
+ap
+aJ
+cF
+cI
+cI
+cI
+cI
+cI
+cI
+cI
+cw
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(12,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+ac
+cw
+ap
+ap
+ap
+ba
+ap
+ba
+bA
+bL
+ap
+bX
+ad
+aS
+ap
+ad
+cI
+cI
+cI
+cI
+cI
+cI
+cI
+cw
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(13,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ab
+cw
+cw
+cw
+cw
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+bv
+ch
+ad
+cI
+cI
+cI
+cI
+cI
+cI
+cI
+cw
+ac
+ab
+ab
+ab
+ab
+ab
+"}
+(14,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ab
+cw
+an
+aw
+az
+aI
+aR
+aU
+bb
+ad
+bi
+bC
+aS
+bP
+bP
+cg
+cn
+cx
+ad
+cI
+cI
+cI
+cI
+cI
+cI
+cI
+cw
+ac
+ab
+ab
+ab
+ab
+ab
+"}
+(15,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ab
+cw
+ao
+ap
+ao
+aJ
+ap
+ao
+ap
+ad
+bj
+bD
+ap
+ao
+ap
+ci
+co
+cy
+ad
+cI
+cI
+cI
+cI
+dg
+cI
+cI
+cw
+ac
+ac
+ab
+ab
+ab
+ab
+"}
+(16,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ac
+cw
+ap
+ao
+ap
+ao
+ao
+ap
+ao
+ad
+bk
+bE
+aJ
+ap
+ap
+cj
+co
+cz
+ad
+cg
+cF
+cF
+cF
+ad
+dm
+ad
+cw
+cw
+cw
+ab
+ab
+ab
+ab
+"}
+(17,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ac
+cw
+aq
+ax
+aA
+ad
+aS
+ap
+bc
+ad
+bl
+bF
+ap
+bQ
+bY
+ad
+co
+cy
+ad
+aS
+cN
+bG
+cZ
+dh
+ap
+cW
+bv
+dt
+cw
+ab
+ab
+ab
+ab
+"}
+(18,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+cw
+cw
+ad
+ad
+ad
+ad
+ad
+aV
+ad
+ad
+bm
+bF
+ap
+bR
+bZ
+bv
+co
+cy
+cG
+ap
+ap
+ap
+ap
+ap
+aJ
+ap
+dq
+aO
+cw
+ab
+ab
+ab
+ab
+"}
+(19,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+cw
+ae
+ar
+ar
+aB
+aK
+ap
+ao
+bd
+ad
+bn
+bG
+bM
+bS
+ca
+ad
+co
+cy
+cg
+ap
+ap
+cV
+da
+di
+dn
+aS
+bv
+dt
+cw
+ab
+ab
+ab
+ab
+"}
+(20,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+cw
+af
+ar
+ar
+aC
+aL
+ao
+ap
+be
+ad
+ad
+bv
+bv
+bv
+ad
+ad
+co
+cy
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+ad
+cw
+du
+ab
+ab
+ab
+"}
+(21,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+cw
+ag
+ar
+ar
+aD
+aM
+aJ
+ao
+ap
+bh
+bo
+aZ
+aZ
+aZ
+aZ
+aZ
+cp
+cA
+aZ
+aZ
+aZ
+aZ
+aZ
+aZ
+cx
+dp
+dr
+de
+cw
+ab
+ab
+ab
+ab
+"}
+(22,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+cw
+ad
+ar
+ar
+aE
+aL
+ao
+ap
+ao
+bh
+bp
+ba
+ba
+ba
+ba
+ba
+cq
+cB
+ba
+ba
+ba
+ba
+ba
+ba
+cC
+dp
+ds
+aO
+cw
+ab
+ab
+ab
+ab
+"}
+(23,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+cw
+ah
+ar
+ar
+aF
+ao
+ap
+ao
+bc
+ad
+ad
+bv
+bv
+bv
+ad
+ad
+co
+cy
+ad
+ad
+ad
+ad
+ad
+ad
+cw
+cw
+cw
+cw
+cw
+du
+ab
+ab
+ab
+"}
+(24,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+cw
+ai
+ar
+ar
+aG
+ap
+ao
+ap
+bf
+ad
+bq
+bH
+bN
+bT
+cb
+ck
+co
+cy
+ad
+aS
+ap
+cW
+db
+dj
+cw
+ac
+ac
+ac
+ab
+ab
+ab
+ab
+ab
+"}
+(25,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+cw
+ad
+ad
+ad
+ad
+ad
+ad
+aT
+ad
+ad
+br
+bI
+ap
+ap
+cc
+cl
+co
+cy
+cH
+ap
+ao
+ao
+ao
+ap
+cw
+ac
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(26,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+cw
+aj
+as
+ay
+aH
+aN
+ad
+ap
+aS
+ad
+bs
+ap
+ao
+ap
+bQ
+ad
+co
+cy
+cg
+ap
+cO
+cX
+dc
+ap
+cw
+ac
+ac
+ab
+ac
+ab
+ab
+ab
+ab
+"}
+(27,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+cw
+ak
+at
+at
+at
+aO
+aT
+ap
+ap
+ad
+bt
+ap
+ao
+ap
+cd
+bv
+co
+cy
+ad
+cJ
+cP
+bI
+dd
+ap
+cw
+ac
+ab
+ab
+ac
+ab
+ab
+ab
+ab
+"}
+(28,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+cw
+ad
+ad
+ad
+ad
+ad
+ad
+ap
+ap
+ad
+bu
+ap
+bO
+bU
+ce
+bv
+co
+cy
+ad
+ap
+cQ
+aJ
+ap
+ap
+cw
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(29,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+cw
+al
+au
+at
+at
+aO
+aT
+aJ
+ap
+ad
+bv
+bv
+ao
+by
+by
+ad
+cr
+cC
+ad
+cK
+cR
+aO
+aO
+bL
+cw
+ab
+ab
+ac
+ab
+ab
+ab
+ab
+ab
+"}
+(30,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+cw
+am
+av
+ay
+av
+aP
+ad
+ap
+aS
+ad
+bw
+bJ
+ao
+bJ
+aO
+ad
+cs
+cD
+ad
+ad
+ad
+ad
+cH
+ad
+cw
+cw
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(31,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+aX
+ad
+ad
+bx
+by
+ao
+by
+cf
+ad
+ct
+ap
+ap
+cL
+cS
+ad
+df
+dk
+dk
+cw
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(32,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+ac
+ab
+ac
+cw
+aY
+bg
+ad
+by
+by
+ao
+by
+by
+ad
+ap
+aJ
+ap
+ap
+cT
+ad
+df
+dl
+do
+cw
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(33,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ac
+ab
+ab
+ab
+ab
+ab
+cw
+cw
+cw
+cw
+bx
+bJ
+ao
+bV
+aO
+ad
+cu
+cE
+cu
+cM
+cU
+ad
+df
+dk
+dk
+cw
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(34,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ac
+ac
+ab
+ab
+ac
+cw
+bz
+by
+bO
+by
+cf
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+ac
+ab
+ab
+ab
+ab
+ab
+ab
+"}
+(35,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+cw
+cw
+cw
+cw
+cw
+cw
+cw
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(36,1,1) = {"
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(37,1,1) = {"
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+"}
+(38,1,1) = {"
+aa
+aa
+ab
+aa
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+aa
+aa
+aa
 "}

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -402,6 +402,9 @@
 /obj/item/weapon/paper/crumpled/bloody
 	icon_state = "scrap_bloodied"
 
+/obj/item/weapon/paper/crumpled/bloody/syndie
+	info = "<i>The following is written in shaky handwriting...</i> <br> <br> You fuckers... you left the base too many times... Now those corporate jackasses have walled us up! We're trapped, and it seems like they're intent on letting us do our research here 'till the bitter end. <br> <br> I'm not sacrificing one more hour for those slavers... I'll rather put a bullet in my head. This is the last personal log of Dr. Thomas Spacer. If someone ever reads this, make sure to follow the damn orders you're given, before it's too late..."
+
 /obj/item/weapon/paper/bombcollars
 	name = "Bomb Collar User's Guide"
 	info = "<i>How to activate, apply, and control bomb collars without blowing yourself up.</i><br>\

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -110,7 +110,7 @@ var/list/barometers = list()
 	death = FALSE
 	icon = 'icons/obj/Cryogenic2.dmi'
 	icon_state = "sleeper_s"
-	flavour_text = "<font size=3>You are a syndicate agent, employed in a top secret research facility developing biological weapons. Unfortunatley, your hated enemy, Nanotrasen, has begun mining in this sector. <b>Continue your research as best you can, and try to keep a low profile. Do not abandon the base unless it is uninhabitable.</b> The base is rigged with explosives should the worst happen, do not let the base fall into enemy hands!</b>"
+	flavour_text = "<font size=3>You are a syndicate agent, employed in a top secret research facility developing biological weapons. Unfortunately, your hated enemy, Nanotrasen, has begun mining in this sector. <b>Continue your research as best you can, and try to keep a low profile.</b> The base is rigged with explosives should the worst happen, do not let the base fall into enemy hands!</b>"
 
 
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms


### PR DESCRIPTION
Replaces r-walls with riveted walls, blocks the airlocks

Also adds some dank flavour, you know I like to make paper scraps

:cl:
tweak: The Syndicate have reinforced the walls in the chemistry and virology lavaland base! Unfortunately some concrete was spilled onto the escape airlocks...
/:cl:
