### PR TITLE
Fixes the mining medic airlock

### DIFF
--- a/_maps/map_files/generic/lavaland.dmm
+++ b/_maps/map_files/generic/lavaland.dmm
@@ -1264,8 +1264,8 @@
 /area/mine/production)
 "cy" = (
 /obj/machinery/door/airlock/glass_medical{
-	id_tag = "MedbayFoyer";
-	name = "Medbay";
+	id_tag = "MiningMedic";
+	name = "Mining Medic";
 	req_access_txt = "5"
 	},
 /turf/open/floor/plasteel/white{


### PR DESCRIPTION
Adds in a new name and ID so whenever the main medbay door is opened the mining airlock doesn't get opened as well

:cl:
bugfix: Fixed a bug where the mining medic airlock would be opened whenever the medbay airlock was opened.
/:cl:
