### PR TITLE
Adds AI law loging to Yogstats

### DIFF
--- a/code/datums/ai_laws.dm
+++ b/code/datums/ai_laws.dm
@@ -190,68 +190,94 @@
 			WARNING("Invalid custom AI laws, check silicon_laws.txt")
 
 /datum/ai_laws/proc/set_zeroth_law(law, law_borg = null)
-	src.zeroth = law
+	zeroth = law
 	if(law_borg) //Making it possible for slaved borgs to see a different law 0 than their AI. --NEO
-		src.zeroth_borg = law_borg
+		zeroth_borg = law_borg
 
 /datum/ai_laws/proc/add_inherent_law(law)
-	if (!(law in src.inherent))
-		src.inherent += law
+	if (!(law in inherent))
+		inherent += law
 
 /datum/ai_laws/proc/add_ion_law(law)
-	src.ion += law
+	ion += law
 
 /datum/ai_laws/proc/clear_inherent_laws()
-	qdel(src.inherent)
-	src.inherent = list()
+	qdel(inherent)
+	inherent = list()
 
 /datum/ai_laws/proc/add_supplied_law(number, law)
-	while (src.supplied.len < number + 1)
-		src.supplied += ""
+	while (supplied.len < number + 1)
+		supplied += ""
 
-	src.supplied[number + 1] = law
+	supplied[number + 1] = law
 
 /datum/ai_laws/proc/clear_supplied_laws()
-	src.supplied = list()
+	supplied = list()
 
 /datum/ai_laws/proc/clear_ion_laws()
-	src.ion = list()
+	ion = list()
 
 /datum/ai_laws/proc/show_laws(who)
 
-	if (src.zeroth)
-		who << "0. [src.zeroth]"
+	if (zeroth)
+		who << "0. [zeroth]"
 
-	for (var/index = 1, index <= src.ion.len, index++)
-		var/law = src.ion[index]
+	for (var/index = 1, index <= ion.len, index++)
+		var/law = ion[index]
 		var/num = ionnum()
 		who << "[num]. [law]"
 
 	var/number = 1
-	for (var/index = 1, index <= src.inherent.len, index++)
-		var/law = src.inherent[index]
+	for (var/index = 1, index <= inherent.len, index++)
+		var/law = inherent[index]
 
 		if (length(law) > 0)
 			who << "[number]. [law]"
 			number++
 
-	for (var/index = 1, index <= src.supplied.len, index++)
-		var/law = src.supplied[index]
+	for (var/index = 1, index <= supplied.len, index++)
+		var/law = supplied[index]
 		if (length(law) > 0)
 			who << "[number]. [law]"
 			number++
+
+/datum/ai_laws/proc/get_laws()
+
+	var/list/laws = list()
+
+	if (zeroth)
+		laws["0"] = zeroth
+
+	for (var/index = 1, index <= ion.len, index++)
+		laws[ionnum()] = ion[index]
+
+	var/number = 1
+	for (var/index = 1, index <= inherent.len, index++)
+		var/law = inherent[index]
+
+		if (length(law) > 0)
+			laws["[number]"] = inherent[index]
+			number++
+
+	for (var/index = 1, index <= supplied.len, index++)
+		var/law = supplied[index]
+		if (length(law) > 0)
+			laws["[number]"] = supplied[index]
+			number++
+
+	return laws
 
 /datum/ai_laws/proc/clear_zeroth_law(force) //only removes zeroth from antag ai if force is 1
 	if(force)
-		src.zeroth = null
-		src.zeroth_borg = null
+		zeroth = null
+		zeroth_borg = null
 		return
 	else
 		if(owner && owner.mind.special_role)
 			return
 		else
-			src.zeroth = null
-			src.zeroth_borg = null
+			zeroth = null
+			zeroth_borg = null
 			return
 
 /datum/ai_laws/proc/associate(mob/living/silicon/M)

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -285,6 +285,27 @@ var/obj/machinery/blackbox_recorder/blackbox
 	feedback_add_details("radio_usage","PDA-[pda_msg_amt]")
 	feedback_add_details("radio_usage","RC-[rc_msg_amt]")
 
+	for (var/mob/living/silicon/S in mob_list)
+		var/list/AI = list()
+
+		AI["typepath"] = S.type
+
+		if(S.laws)
+			AI["laws"] = S.laws.get_laws()
+
+		AI["lawchanges"] = S.law_change_counter
+
+		AI["name"] = S.name
+
+		if(S.mind)
+			AI["ckey"] = S.mind.key
+			if(S.stat != 2)
+				AI["survived"] = 1
+			else
+				AI["survived"] = 0
+
+		feedback_add_details("roundend_silicons", json_encode(AI))
+
 
 	feedback_set_details("round_end","[time2text(world.realtime)]") //This one MUST be the last one that gets set.
 

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -289,19 +289,17 @@ var/obj/machinery/blackbox_recorder/blackbox
 		var/list/AI = list()
 
 		AI["typepath"] = S.type
+		AI["lawchanges"] = S.law_change_counter
+		AI["name"] = S.name
+		AI["icon_state"] = S.icon_state
 
 		if(S.laws)
 			AI["laws"] = S.laws.get_laws()
-
-		AI["lawchanges"] = S.law_change_counter
-
-		AI["name"] = S.name
 
 		if(istype(S, /mob/living/silicon/robot))
 			var/mob/living/silicon/robot/R = S
 			if(R.connected_ai)
 				AI["slaved_to"] = R.connected_ai.name
-
 
 		if(S.mind)
 			AI["ckey"] = S.mind.key

--- a/code/modules/research/message_server.dm
+++ b/code/modules/research/message_server.dm
@@ -297,6 +297,12 @@ var/obj/machinery/blackbox_recorder/blackbox
 
 		AI["name"] = S.name
 
+		if(istype(S, /mob/living/silicon/robot))
+			var/mob/living/silicon/robot/R = S
+			if(R.connected_ai)
+				AI["slaved_to"] = R.connected_ai.name
+
+
 		if(S.mind)
 			AI["ckey"] = S.mind.key
 			if(S.stat != 2)


### PR DESCRIPTION
AI Laws are now logged to Yogstats.

This includes pAIs, borgs and AIs.

Example: http://stats.yogstation.net/index.php?page=round&id=19341