### PR TITLE
Adds two zeroes to high-cap water tank capacity.

### DIFF
--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -83,6 +83,7 @@
 
 /obj/structure/reagent_dispensers/watertank/high/New()
 	..()
+	create_reagents(100000)
 	reagents.add_reagent("water",100000)
 
 /obj/structure/reagent_dispensers/fueltank


### PR DESCRIPTION
#1624 

I question  why nobody else ever did this

:cl:
fix: High capacity water tanks are now actually high capacity water tanks.
/:cl:
