### PR TITLE
Makes lavaland babymode; stuff no longer spawns within a 5x5 radius of labor or mining

### DIFF
--- a/code/modules/mining/mine_turfs.dm
+++ b/code/modules/mining/mine_turfs.dm
@@ -343,6 +343,10 @@
 		if(istype(loc, /area/mine/explored))
 			return
 		for(var/atom/A in urange(12,T))//Lowers chance of mob clumps
+			if(T.x < 75)
+				return
+			if(T.y < 55)
+				return
 			if(istype(A, /mob/living/simple_animal/hostile/asteroid))
 				return
 		var/randumb = pickweight(mob_spawn_list)


### PR DESCRIPTION
no longer will we be spawnfucked by ash ketchem, wrigley and avion.
:cl:
tweak: New anti-bullshit shielding has been installed near the mining station and labor camp. Now dangerous dangerocities will not.. I aint got an IC word for spawn, so close to them.
/:cl:
