### PR TITLE
lavaland roles and every other role/spawner'd role now have their spawner name as their special_role

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -85,6 +85,7 @@
 				MM.objectives += new/datum/objective(objective)
 		special(M)
 		MM.name = M.real_name
+		MM.special_role = name
 	if(uses > 0)
 		uses--
 	if(!permanent && !uses)


### PR DESCRIPTION
more administrative bullshit ree.  Also someone if they really want to can remove flavor text from memories now but I think it's fine either way.

For bad admins, this information is in[if you view variables] mob/mind/special_role

I tested it and even though crap like abductors use this system, this procs first so the antag roles or whatever re-correct it if necessary.