### PR TITLE
Fixes a suit sensor exploit on lavaland

### DIFF
--- a/code/controllers/subsystem/minimap.dm
+++ b/code/controllers/subsystem/minimap.dm
@@ -7,7 +7,7 @@ var/datum/subsystem/minimap/SSminimap
 	var/const/MINIMAP_SIZE = 2048
 	var/const/TILE_SIZE = 8
 
-	var/list/z_levels = list(ZLEVEL_STATION, ZLEVEL_MINING)
+	var/list/z_levels = list(ZLEVEL_STATION)
 
 /datum/subsystem/minimap/New()
 	NEW_SS_GLOBAL(SSminimap)


### PR DESCRIPTION
Not really an exploit. 
Basicly, mining medic suit sensor console shows all the ruins, now it doesnt. 
It shows whatever you last saw, so thats either outdated ruins or something else. I like surprises.
@Super3222  pretty much came to me and told me this was a thing and told me exactly how to fix it.
:cl: Nanotrassen
fix: Local news reporter Roger Davis is on the scence where the mining medic has been arrested for abusing NT-tech,by having the miners find loot instead of ores. This software error has been fixed.
/:cl: