### PR TITLE
redoes construct wall phasing

### DIFF
--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -102,7 +102,7 @@
 
 /turf/closed/wall/attack_animal(mob/living/simple_animal/M)
 	if(istype(M,/mob/living/simple_animal/hostile/construct/builder)||istype(M,/mob/living/simple_animal/hostile/construct/harvester))
-		if(istype(src, /turf/closed/wall/mineral/cult)||istype(src, /turf/closed/wall/mineral/cult/artificer))
+		if(istype(src, /turf/closed/wall/mineral/cult))
 			return
 		src.ChangeTurf(/turf/closed/wall/mineral/cult/artificer)
 		M <<"<span class='notice'>You transfer some of your corrupt energy into the wall, causing it to transform.</span>"

--- a/code/game/turfs/simulated/walls.dm
+++ b/code/game/turfs/simulated/walls.dm
@@ -102,9 +102,9 @@
 
 /turf/closed/wall/attack_animal(mob/living/simple_animal/M)
 	if(istype(M,/mob/living/simple_animal/hostile/construct/builder)||istype(M,/mob/living/simple_animal/hostile/construct/harvester))
-		if(istype(src, /turf/closed/wall/mineral/cult))
+		if(istype(src, /turf/closed/wall/mineral/cult)||istype(src, /turf/closed/wall/mineral/cult/artificer))
 			return
-		src.ChangeTurf(/turf/closed/wall/mineral/cult)
+		src.ChangeTurf(/turf/closed/wall/mineral/cult/artificer)
 		M <<"<span class='notice'>You transfer some of your corrupt energy into the wall, causing it to transform.</span>"
 		playsound(src, 'sound/items/Welder.ogg', 100, 1)
 		return

--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -35,23 +35,13 @@
 		alertthreshold--
 
 /turf/closed/wall/mineral/cult/Bumped(atom/movable/C as mob)
-	var/phasable=0
 	if(istype(C,/mob/living/simple_animal/hostile/construct))
 		var/mob/living/simple_animal/hostile/construct/construct = C
 		if(!construct.phaser)
 			return
-		phasable = 2
-		while(phasable>0)
-			if(construct.pulling)
-				construct.stop_pulling()
-			src.density = 0
-			src.alpha = 60
-			src.opacity = 0
-			sleep(10)
-			phasable--
-		src.density = 1
-		src.alpha = initial(src.alpha)
-		src.opacity = 1
+		if(construct.pulling)
+			construct.stop_pulling()
+		construct.forceMove(get_turf(src))
 	return
 
 /turf/closed/wall/mineral/cult/attackby(obj/item/weapon/W, mob/user, params)


### PR DESCRIPTION
no more ugly phasing, it's kinda glitchy
also fixes an infinite runed metal exploit, don't tell nobody

:cl: ShadowDeath6
tweak: Constructs don't make walls phasable anymore, they just go through them like shadowlings.
bugfix: Constructs can't pull things through walls anymore.
/:cl:
