### PR TITLE
Fixes stock prices wildly skyrocketing

### DIFF
--- a/code/modules/stock_market/stocks.dm
+++ b/code/modules/stock_market/stocks.dm
@@ -91,7 +91,7 @@
 /datum/stock/proc/frc(amt)
 	var/shares = available_shares + outside_shareholders * average_shares
 	var/fr = amt / 100 / shares * fluctuational_coefficient * fluctuation_rate * max(-(current_trend / 100), 1)
-	if (fr < 0 && speculation < 0 || fr > 0 && speculation > 0)
+	if ( (fr < 0 && speculation < 0) || (fr > 0 && speculation > 0) )
 		fr *= max(abs(speculation) / 5, 1)
 	else
 		fr /= max(abs(speculation) / 5, 1)


### PR DESCRIPTION
Fixed this on /tg/ ages ago and forgot to port it over...my bad.

|| and && have precedence issues in BYOND if you don't bracket them properly.