### PR TITLE
Comms consoles now only work on the station zlevel.

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -19,7 +19,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 	var/message_cooldown = 0
 	var/ai_message_cooldown = 0
 	var/tmp_alertlevel = 0
-	var/z_lock = 1//Var that admins can change to 0 if they need to use a comms console for some crap, I dunno.
+	var/z_lock = TRUE//Var that admins can change to 0 if they need to use a comms console for some crap, I dunno, because it's basically like I didn't change it.
 	var/const/STATE_DEFAULT = 1
 	var/const/STATE_CALLSHUTTLE = 2
 	var/const/STATE_CANCELSHUTTLE = 3
@@ -50,7 +50,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 	if(..())
 		return
 	if(z_lock) //Can only be used on SS13 unless z_lock is changed..
-		if(z != 1)
+		if(z != ZLEVEL_STATION)
 			usr << "<span class='boldannounce'>Unable to establish a connection</span>: \black You're too far away from the station!"
 			return
 	usr.set_machine(src)
@@ -340,7 +340,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 	if(..())
 		return
 	if(z_lock)
-		if (src.z != 1)
+		if (src.z != ZLEVEL_STATION)
 			user << "<span class='boldannounce'>Unable to establish a connection</span>: \black You're too far away from the station!"
 			return
 

--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -1,5 +1,3 @@
-//This file was auto-corrected by findeclaration.exe on 25.5.2012 20:42:31
-
 var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 
 // The communications computer
@@ -21,6 +19,7 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 	var/message_cooldown = 0
 	var/ai_message_cooldown = 0
 	var/tmp_alertlevel = 0
+	var/z_lock = 1//Var that admins can change to 0 if they need to use a comms console for some crap, I dunno.
 	var/const/STATE_DEFAULT = 1
 	var/const/STATE_CALLSHUTTLE = 2
 	var/const/STATE_CANCELSHUTTLE = 3
@@ -50,9 +49,10 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 /obj/machinery/computer/communications/Topic(href, href_list)
 	if(..())
 		return
-	if (src.z > ZLEVEL_CENTCOM) //Can only use on centcom and SS13
-		usr << "<span class='boldannounce'>Unable to establish a connection</span>: \black You're too far away from the station!"
-		return
+	if(z_lock) //Can only be used on SS13 unless z_lock is changed..
+		if(z != 1)
+			usr << "<span class='boldannounce'>Unable to establish a connection</span>: \black You're too far away from the station!"
+			return
 	usr.set_machine(src)
 
 	if(!href_list["operation"])
@@ -339,9 +339,10 @@ var/const/CALL_SHUTTLE_REASON_LENGTH = 12
 /obj/machinery/computer/communications/attack_hand(mob/user)
 	if(..())
 		return
-	if (src.z > 6)
-		user << "<span class='boldannounce'>Unable to establish a connection</span>: \black You're too far away from the station!"
-		return
+	if(z_lock)
+		if (src.z != 1)
+			user << "<span class='boldannounce'>Unable to establish a connection</span>: \black You're too far away from the station!"
+			return
 
 	user.set_machine(src)
 	var/dat = ""


### PR DESCRIPTION
Not technically a fix as opposed to an outright change, I guess.  but w/e

#1678


:cl:
tweak: We're shit and so are our communications consoles. They now only work on the station.
/:cl:
