### PR TITLE
Implanting gangsters wont destroy the implant

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_loyality.dm
+++ b/code/game/objects/items/weapons/implants/implant_loyality.dm
@@ -27,14 +27,9 @@
 			removed(target, 1)
 			qdel(src)
 			return -1
-		if(target.mind in ticker.mode.get_gangsters())
-			ticker.mode.remove_gangster(target.mind)
-			target.visible_message("<span class='warning'>[src] was destroyed in the process!</span>", "<span class='notice'>You feel a sense of peace and security. You are now protected from brainwashing.</span>")
-			removed(target, 1)
-			qdel(src)
-			return -1
-		if(target.mind in ticker.mode.revolutionaries)
+		if(target.mind in ticker.mode.revolutionaries | ticker.mode.get_gangsters())
 			ticker.mode.remove_revolutionary(target.mind)
+			ticker.mode.remove_gangster(target.mind)
 		if(ticker.mode.is_cyberman(target.mind))
 			target << "<span class='notice'>Your cyberman body silenty disables the Nanotrasen nanobots as they enter your bloodstream. You appear to be implanted, but the implant has no effect.</span>"
 		if((target.mind in ticker.mode.cult) || (target.mind in ticker.mode.blue_deity_prophets|ticker.mode.red_deity_prophets|ticker.mode.red_deity_followers|ticker.mode.blue_deity_followers))


### PR DESCRIPTION
Before: One implant to deconvert and one to keep them implanted
This PR: One implant deconverts them and keeps them that way

This is up to debate
:cl:
tweak: Deconverting gangsters wont destroy the implant anymore
/:cl:
This has been tested and worked.