### PR TITLE
CTF is enabled when the round ends

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -498,6 +498,11 @@ var/datum/subsystem/ticker/ticker
 			dellog += "Failures : [SSgarbage.didntgc[path]] \n"
 		world.log << dellog
 
+	for(var/obj/machinery/capture_the_flag/CTF in machines)
+		if(!CTF.ctf_enabled)
+			CTF.ctf_enabled = !CTF.ctf_enabled
+			CTF.TellGhost()
+
 	return 1
 
 /datum/subsystem/ticker/proc/send_random_tip()


### PR DESCRIPTION
#### Intent of your Pull Request

This PR > https://github.com/yogstation13/yogstation/pull/280

##### Changelog

:cl:
rscadd: CTF starts when the round ends.
/:cl:
