### PR TITLE
Added antag_weight to player table in feedback database

### DIFF
--- a/SQL/database_changelog.txt
+++ b/SQL/database_changelog.txt
@@ -1,3 +1,13 @@
+
+7 February 2017, by tomamoto
+
+Modified table 'player', adding column 'antag_weight', to bring it inline with the schema expected by the yogstation code.
+
+ALTER TABLE `feedback`.`player` ADD COLUMN `antag_weight` FLOAT DEFAULT NULL
+
+Remember to add a prefix to the table name if you use them
+
+----------------------------------------------------
 21 September 2015, by Jordie0608
 
 Modified table 'poll_question', adding columns 'createdby_ckey', 'createdby_ip' and 'for_trialmin' to bring it inline with the schema used by the tg servers.
@@ -34,7 +44,7 @@ Remember to add prefix to the table name if you use them.
 
 Modified table 'memo', removing 'id' column and making 'ckey' primary.
 
-ALTER TABLE `feedback`.`memo` DROP COLUMN `id`, DROP PRIMARY KEY, ADD PRIMARY KEY (`ckey`) 
+ALTER TABLE `feedback`.`memo` DROP COLUMN `id`, DROP PRIMARY KEY, ADD PRIMARY KEY (`ckey`)
 
 Remember to add prefix to the table name if you use them.
 

--- a/SQL/tgstation_schema.sql
+++ b/SQL/tgstation_schema.sql
@@ -222,6 +222,7 @@ CREATE TABLE `player` (
   `ip` varchar(18) NOT NULL,
   `computerid` varchar(32) NOT NULL,
   `lastadminrank` varchar(32) NOT NULL DEFAULT 'Player',
+  `antag_weight` float DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `ckey` (`ckey`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;

--- a/SQL/tgstation_schema_prefixed.sql
+++ b/SQL/tgstation_schema_prefixed.sql
@@ -217,6 +217,7 @@ CREATE TABLE `SS13_player` (
   `ip` varchar(18) NOT NULL,
   `computerid` varchar(32) NOT NULL,
   `lastadminrank` varchar(32) NOT NULL DEFAULT 'Player',
+  `antag_weight` float DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `ckey` (`ckey`)
 ) ENGINE=InnoDB DEFAULT CHARSET=latin1;


### PR DESCRIPTION
Note that this column was added as a float to stay on the safe side based on observing antag_weight being divided by other floating point numbers in the code.  Looking further through the code, I did notice this value is parsed using txt2num, so maybe I should be storing it as a string/varchar (as far as the code says, anyway). Or does the a database query in this case only return an array of strings? Please pardon my ignorance of DM. 

All I know is that adding this column to by database fixed a nasty bug on my server where antags were never being set while the database was enabled.  If you don't want to merge this as is, I would understand, but then please suggest and implement a solution using a more appropriate MySQL data type.