### PR TITLE
The slime management console must be researched

### DIFF
--- a/_maps/map_files/Yogstation/yogstation.2.1.3.dmm
+++ b/_maps/map_files/Yogstation/yogstation.2.1.3.dmm
@@ -2017,26 +2017,6 @@
 	icon_state = "dark"
 	},
 /area/ai_monitored/security/armory)
-"adU" = (
-/obj/machinery/light{
-	dir = 4;
-	icon_state = "tube1"
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	icon_state = "alarm0";
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel{
-	icon_state = "dark"
-	},
-/area/ai_monitored/security/armory)
-"adV" = (
-/obj/structure/closet/wardrobe/red,
-/turf/open/floor/plasteel{
-	icon_state = "showroomfloor"
-	},
-/area/security/main)
 "adW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump{
 	on = 1
@@ -50240,15 +50220,6 @@
 	icon_state = "white"
 	},
 /area/toxins/xenobiology)
-"bVw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/computer/camera_advanced/xenobio,
-/turf/open/floor/plasteel{
-	icon_state = "white"
-	},
-/area/toxins/xenobiology)
 "bVx" = (
 /obj/machinery/light,
 /obj/structure/disposalpipe/segment{
@@ -68444,6 +68415,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"zEx" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/frame/computer,
+/turf/open/floor/plasteel{
+	icon_state = "white"
+	},
+/area/toxins/xenobiology)
 "ABd" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -111770,7 +111750,7 @@ bQx
 bRD
 bSU
 byH
-bVw
+zEx
 bPp
 bYg
 bJt
@@ -112284,7 +112264,7 @@ bQz
 bRD
 bSU
 bUp
-bVw
+zEx
 bPp
 bYh
 bZl

--- a/code/game/machinery/computer/buildandrepair.dm
+++ b/code/game/machinery/computer/buildandrepair.dm
@@ -307,6 +307,10 @@
 	name = "circuit board (Mech Bay Power Control Console)"
 	build_path = /obj/machinery/computer/mech_bay_power_console
 	origin_tech = "programming=3;powerstorage=3"
+/obj/item/weapon/circuitboard/computer/xenocamera
+	name = "circuit board (Slime Management Console)"
+	build_path = /obj/machinery/computer/camera_advanced/xenobio
+	origin_tech = "programming=3"
 
 /obj/item/weapon/circuitboard/computer/cargo
 	name = "circuit board (Supply Console)"

--- a/code/modules/research/designs/comp_board_designs.dm
+++ b/code/modules/research/designs/comp_board_designs.dm
@@ -259,3 +259,11 @@
 	req_tech = list("programming" = 1)
 	build_path = /obj/item/weapon/circuitboard/computer/libraryconsole
 	category = list("Computer Boards")
+
+/datum/design/board/xenocamera
+	name = "Computer Design (Slime Management Console)"
+	desc = "Allows for the construction of circuit boards used to build slime management consoles."
+	id = "xenocamera"
+	req_tech = list("bluespace" = 6, "biotech" = 3)
+	build_path = /obj/item/weapon/circuitboard/computer/xenocamera
+	category = list("Computer Boards")

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -98,6 +98,7 @@
 
 /obj/item/slime_extract/bluespace
 	name = "bluespace slime extract"
+	origin_tech = "bluespace=5;biotech=3"
 	icon_state = "bluespace slime extract"
 
 /obj/item/slime_extract/pyrite


### PR DESCRIPTION
The slime management console is now a regular deconstructable computer with a board, requiring bluespace 6 and biotech 3 to research. Bluespace slimecores now have a high enough bluespace tech level to fulfill both of these, otherwise you will typically need bluespace crystals.

When a console is destroyed, it will drop all the monkey cubes it is carrying. All slimes it is carrying will be dropped wherever the camera is, or deleted if they cannot be dropped.

Xenobiology became mind-numbingly easy with the introduction of the management consoles. Now they have to either wait for miners to bring back crystals, or do it the old fashioned way until they get bluespace slimes.

:cl:
tweak: Slime Management Consoles no longer spawn in xenobiology, they must be researched and built in R&D. Bluespace slime cores can now be deconstructed to fill all requirements to build slime management console boards.
/:cl:
