### PR TITLE
Reduced the ruin budget

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -352,4 +352,4 @@ BOMBCAP 20
 # a less lootfilled or smaller or less round effecting ruin costs less to
 # spawn, while the converse is true. Alter this number to affect the amount
 # of ruins.
-LAVALAND_BUDGET 125
+LAVALAND_BUDGET 60


### PR DESCRIPTION
Not only do our ruins have much more loot on average than those of tg's, we have more than twice as many spawn. Hopefully this will result in fewer miners coming back with ERT suits, banana staffs, and spells.