### PR TITLE
[s]Fixes an exploit with recalling and destroy engines

### DIFF
--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -210,9 +210,6 @@ var/datum/subsystem/shuttle/SSshuttle
 			if(!ignoreCD)
 				return 3
 
-
-/datum/subsystem/shuttle/proc/moveShuttle(shuttleId, dockId, timed)
-	var/obj/docking_port/mobile/M = getShuttle(shuttleId)
 	var/obj/docking_port/stationary/D = getDock(dockId)
 
 	if(!M)

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -210,6 +210,7 @@ var/datum/subsystem/shuttle/SSshuttle
 			if(!ignoreCD)
 				return 3
 
+	var/obj/docking_port/mobile/M = getShuttle(shuttleId)
 	var/obj/docking_port/stationary/D = getDock(dockId)
 
 	if(!M)

--- a/code/controllers/subsystem/shuttles.dm
+++ b/code/controllers/subsystem/shuttles.dm
@@ -18,6 +18,7 @@ var/datum/subsystem/shuttle/SSshuttle
 	var/emergencyEscapeTime = 1200	//time taken for emergency shuttle to reach a safe distance after leaving station (in deciseconds)
 	var/area/emergencyLastCallLoc
 	var/emergencyNoEscape
+	var/canRecall = TRUE
 
 		//supply shuttle stuff
 	var/obj/docking_port/mobile/supply/supply
@@ -34,6 +35,7 @@ var/datum/subsystem/shuttle/SSshuttle
 	var/datum/round_event/shuttle_loan/shuttle_loan
 
 	var/list/cooldown_ids = list()
+
 
 /datum/subsystem/shuttle/New()
 	NEW_SS_GLOBAL(SSshuttle)
@@ -149,6 +151,8 @@ var/datum/subsystem/shuttle/SSshuttle
 /datum/subsystem/shuttle/proc/canRecall()
 	if(emergency.mode != SHUTTLE_CALL)
 		return
+	if(!canRecall)
+		return
 	if(ticker.mode.name == "meteor")
 		return
 	if(seclevel2num(get_security_level()) == SEC_LEVEL_RED)
@@ -200,13 +204,14 @@ var/datum/subsystem/shuttle/SSshuttle
 			return 2
 	return 0	//dock successful
 
-
 /datum/subsystem/shuttle/proc/moveShuttle(shuttleId, dockId, timed, ignoreCD)
 	for(var/a in cooldown_ids)
 		if(a == shuttleId)
 			if(!ignoreCD)
 				return 3
 
+
+/datum/subsystem/shuttle/proc/moveShuttle(shuttleId, dockId, timed)
 	var/obj/docking_port/mobile/M = getShuttle(shuttleId)
 	var/obj/docking_port/stationary/D = getDock(dockId)
 
@@ -250,3 +255,4 @@ var/datum/subsystem/shuttle/SSshuttle
 	centcom_message = SSshuttle.centcom_message
 	ordernum = SSshuttle.ordernum
 	points = SSshuttle.points
+

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -828,7 +828,9 @@
 			timer += more_minutes
 			priority_announce("Major system failure aboard the emergency shuttle. This will extend its arrival time by approximately 15 minutes..", "System Failure", 'sound/misc/notice1.ogg')
 			SSshuttle.emergency.setTimer(timer)
+			SSshuttle.canRecall = FALSE
 		user.mind.spell_list.Remove(src) //Can only be used once!
+
 		qdel(src)
 
 


### PR DESCRIPTION
There was an exploit wich keek would use and instantly recall and call again to nullify destroy engines.

This prevents recalling after destroy engines has been used. Suggested here: https://github.com/yogstation13/yogstation/issues/1821

:cl:
fix: Fixes recalling after destroy engines
/:cl: