### PR TITLE
Lavaland Overhaul: Part 5 - GPS

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -46,6 +46,7 @@
 	new /obj/item/clothing/glasses/meson(src)
 	new /obj/item/weapon/survivalcapsule(src)
 	new /obj/item/stack/sheet/mineral/sandbags(src, 5)
+	new /obj/item/device/gps/mining(src)
 
 
 /**********************Shuttle Computer**************************/

--- a/code/modules/telesci/gps.dm
+++ b/code/modules/telesci/gps.dm
@@ -15,6 +15,16 @@ var/list/GPS_list = list()
 	var/channel = "common"
 	var/emagged = 0
 	var/savedlocation // preferably filled with x,y,z
+	var/intelligent
+
+
+/obj/item/device/gps/examine(mob/user)
+	..()
+	if(intelligent)
+		user << "<span class='notice'>This GPS is upgraded with intelligent software. It will label other GPS's with a tag based on it's location from you.</span>"
+		user << "<span class='red'>The \[Adjacent\] tag means they are within 20 feet.</span>"
+		user << "<span class='blue'>The \[Close-By\] tag means they are within 40 feet.</span>"
+		user << "<span class='white'>The \[Away\] tag means they are anywhere farther than that.</span>"
 
 /obj/item/device/gps/New()
 	..()
@@ -81,7 +91,16 @@ var/list/GPS_list = list()
 			if((G.emagged || G.emped) == 1)
 				t += "<BR>[tracked_gpstag]: ERROR"
 			else if(G.tracking)
-				t += "<BR>[tracked_gpstag]: [format_text(gps_area.name)] ([pos.x], [pos.y], [pos.z])"
+				var/code
+				if(intelligent)
+					if(get_dist(get_turf(user), pos) <= 20)
+						code = "\[Adjacent\]"
+					else if (get_dist(get_turf(user), pos) <= 40)
+						code = "\[Close-By\]"
+					else
+						code = "\[Away\]"
+					code += " | " // so we have room.
+				t += "<BR>[code][tracked_gpstag]: [format_text(gps_area.name)] ([pos.x], [pos.y], [pos.z])"
 			else
 				continue
 	var/datum/browser/popup = new(user, "GPS", name, 360, min(gps_window_height, 350))
@@ -126,6 +145,7 @@ var/list/GPS_list = list()
 /obj/item/device/gps/medical
 	gpstag = "MED0"
 	channel = "medical"
+	intelligent = TRUE
 
 /obj/item/device/gps/science
 	icon_state = "gps-s"
@@ -142,6 +162,7 @@ var/list/GPS_list = list()
 	gpstag = "MINE0"
 	desc = "A positioning system helpful for rescuing trapped or injured miners, keeping one on you at all times while mining might just save your life."
 	channel = "lavaland"
+	intelligent = TRUE
 
 /obj/item/device/gps/internal
 	icon_state = null


### PR DESCRIPTION
https://github.com/yogstation13/yogstation/pull/1773

#### Intent of your Pull Request

Mining GPS devices now spawn inside of mining lockers.

GPS's WOULD'VE been color-coded if colors were supported in the GPS window.

Instead a tag is put on GPS's depending on their location from you
There's [Adjacent] for within 20 meters.
[Close-By] for 40.
[Away] for anything more than that.

![](http://image.prntscr.com/image/ac81e15a56744bfa8afb2b8f7a762d7b.png)

Examine your GPS if you're ever questioning how far away something is; examining the GPS tells you the ranges I've mentioned earlier.

The same update was given to medical GPS's (paramedics).

##### Changelog

:cl:
rscadd: Mining GPS's have been upgraded! They now display whether something is adjacent / closeby / or away. (20 / 40 / 40+)
rscadd: Examine your GPS if you're ever curious on what a distance tag is telling you.
rscadd: Medical GPS's are smart as well. That means YOU, Paramedics.
/:cl:
