### PR TITLE
Adds a global printing option to security records

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -246,7 +246,7 @@
 					else
 						dat += "Security Record Lost!<br>"
 						dat += text("<A href='?src=\ref[];choice=New Record (Security)'>New Security Record</A><br><br>", src)
-					dat += text("<A href='?src=\ref[];choice=Delete Record (ALL)'>Delete Record (ALL)</A><br><A href='?src=\ref[];choice=Print Record'>Print Record</A><BR><A href='?src=\ref[];choice=Print Poster'>Print Wanted Poster</A><BR><A href='?src=\ref[];choice=Return'>Back</A><BR>", src, src, src, src)
+					dat += text("<A href='?src=\ref[];choice=Delete Record (ALL)'>Delete Record (ALL)</A><br><A href='?src=\ref[];choice=Print Record'>Print Record</A><BR><A href='?src=\ref[];choice=Print Poster;global=0'>Print Wanted Poster</A><BR><A href='?src=\ref[];choice=Print Poster;global=1'>Print Wanted Poster Globally</A><BR><A href='?src=\ref[];choice=Return'>Back</A><BR>", src, src, src, src, src)
 				else
 		else
 			dat += text("<A href='?src=\ref[];choice=Log In'>{Log In}</A>", src)
@@ -425,6 +425,7 @@ What a mess.*/
 					printing = null
 			if("Print Poster")
 				if(!( printing ))
+					var/globalprint = locate(href_list["global"])
 					var/wanted_name = stripped_input(usr, "Please enter an alias for the criminal:", "Print Wanted Poster", active1.fields["name"])
 					if(wanted_name)
 						var/default_description = "A poster declaring [wanted_name] to be a dangerous individual, wanted by Nanotrasen. Report any sightings to security immediately."
@@ -450,7 +451,12 @@ What a mess.*/
 							sleep(30)
 							if((istype(active1, /datum/data/record) && data_core.general.Find(active1)))//make sure the record still exists.
 								var/obj/item/weapon/photo/photo = active1.fields["photo_front"]
-								new /obj/item/weapon/poster/legit/wanted(src.loc, photo.img, wanted_name, info)
+								if(globalprint)
+									for(var/obj/machinery/computer/secure_data/SD in SSmachine.processing)
+										if(SD.z == z)
+											new /obj/item/weapon/poster/legit/wanted(get_turf(SD), photo.img, wanted_name, info)
+								else
+									new /obj/item/weapon/poster/legit/wanted(get_turf(src), photo.img, wanted_name, info)
 							printing = 0
 
 //RECORD DELETE


### PR DESCRIPTION
Refer to issue https://github.com/yogstation13/yogstation/issues/754.

#### Intent of your Pull Request

Adds a global printing option to security records.
This will print a wanted poster to EVERY processing security console on that same z level.

##### Changelog

:cl:
rscadd: Security computers now have a global printing option.
/:cl: