### PR TITLE
Using the charter with no admins on increases the expiration date.

### DIFF
--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -10,7 +10,7 @@
 	var/mob/living/scripter
 	var/additional_time
 	var/cooldown // that's not needed, but hey. can stop spam.
-	var/cooldownLEN = 60
+	var/cooldownLEN = 600
 
 /obj/item/station_charter/attack_self(mob/living/user)
 	..()

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -8,18 +8,26 @@
 	var/pending_name
 	var/admin_controlled
 	var/mob/living/scripter
+	var/additional_time
+	var/cooldown // that's not needed, but hey. can stop spam.
+	var/cooldownLEN = 60
 
 /obj/item/station_charter/attack_self(mob/living/user)
 	..()
-	var/admins_number = admins.len
-	if(!admins_number)
-		user << "You hear something crackle in your ears for a moment before a voice speaks. \"Central Command is currently inactive, please check in again later before attempting to change the station's name.\""
-		return
 	if(used)
 		user << "The station has already been named."
 		return
+	if(cooldown > world.time)
+		user << "<span class='notice'>The charter is recharging.</span>"
+		return
+	cooldown = world.time + cooldownLEN // six seconds sounds fine, right?
+	var/admins_number = admins.len
+	if(!admins_number)
+		user << "You hear something crackle in your ears for a moment before a voice speaks. \"Central Command is currently inactive, please check in again later before attempting to change the station's name.\""
+		additional_time += 600
+		return
 	used = TRUE
-	if(world.time > CHALLENGE_TIME_LIMIT) //5 minutes
+	if(world.time > CHALLENGE_TIME_LIMIT+additional_time) //5 minutes + whatever
 		user << "The crew has already settled into the shift. It probably wouldn't be good to rename the station right now."
 		return
 

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -58,6 +58,11 @@ Captain
 
 	minor_announce("Captain [H.real_name] on deck!")
 
+	if(world.time >  CHALLENGE_TIME_LIMIT) // latejoin captain?
+		var/obj/item/station_charter/C = locate() in H
+		if(C)
+			C.additional_time = world.time
+
 /*
 Head of Personnel
 */

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -1,3 +1,5 @@
+#define LATEJOINCHARTERCAP 12000
+
 /*
 Captain
 */
@@ -61,7 +63,10 @@ Captain
 	if(world.time >  CHALLENGE_TIME_LIMIT) // latejoin captain?
 		var/obj/item/station_charter/C = locate() in H
 		if(C)
-			C.additional_time = world.time
+			var/worldtimer = world.time
+			if(worldtimer > LATEJOINCHARTERCAP)
+				worldtimer = LATEJOINCHARTERCAP
+			C.additional_time = worldtimer
 
 /*
 Head of Personnel
@@ -115,3 +120,6 @@ Head of Personnel
 		return
 
 	announce_head(H, list("Supply", "Service"))
+
+
+#undef LATEJOINCHARTERCAP


### PR DESCRIPTION
#### Intent of your Pull Request

Attempting to use the charter w/no admins online will increase it's expiration date. This is done so players can have a chance to at least  wait awhile until an admin comes online to change the station name.

Latejoin Captains will have the opportunity to change the station name.

##### Changelog

:cl:
rscadd: Attempting to change the station name without admins online increases the time it takes to reach it's expiration date.
rscadd: Latejoin Captains now have the opportunity to change the station name! After joining you will have an additional 20 minutes to change the name before the charter expires.
/:cl: