### PR TITLE
Spawning an academy teacher creates a central command announcement

### DIFF
--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -64,6 +64,7 @@
 	var/faction = "wizard"
 	var/broken = 0
 	var/braindead_check = 0
+	var/announce
 
 /obj/structure/academy_wizard_spawner/New()
 	START_PROCESSING(SSobj, src)
@@ -127,6 +128,17 @@
 	current_wizard = wizbody
 
 	give_control()
+
+	if(!announce)
+		announce = TRUE
+		addtimer(src, "announcement", 500)
+
+
+/obj/strucutre/academy_wizard_spawner/proc/announcement()
+	priority_announce("Attention! A derelict space ship controlled by the Wizard Federation has \
+		been detected in your star system. Designation to the ship can be controlled by this station's \
+		on-board teleporter.", null, \
+		'sound/machines/Alarm.ogg', "Central Command")
 
 /obj/structure/academy_wizard_spawner/proc/update_status()
 	if(health<0)


### PR DESCRIPTION
#### Intent of your Pull Request

Yogstation officially has """""away missions""""".

When the wizard academy spawner creates a wizard the system takes about 50 seconds until Central Command announces that there's a wizard controlled derelict in their start system.

Eventfully telling the crew to basically "pillage and conquer" the ship.

In the future we could do more things like this, and quite possibly expand on it. Who knows?
_Maybe we could disable the teleport until the wizard is spawned_

##### Changelog

:cl:
rscadd: Central Command will now tell you when there's an active wizard academy.
/:cl: