### PR TITLE
Protects arrivals and escape shuttle from radstorms

### DIFF
--- a/code/datums/weather/weather_types.dm
+++ b/code/datums/weather/weather_types.dm
@@ -136,7 +136,7 @@
 	//end_overlay = "light_ash"
 
 	area_type = /area
-	protected_areas = list(/area/maintenance, /area/turret_protected/ai_upload, /area/turret_protected/ai_upload_foyer, /area/turret_protected/ai)
+	protected_areas = list(/area/maintenance, /area/turret_protected/ai_upload, /area/turret_protected/ai_upload_foyer, /area/turret_protected/ai, /area/shuttle)
 	target_z = ZLEVEL_STATION
 
 	immunity_type = "rad"


### PR DESCRIPTION
Protects the arrivals and escape pods from radiation storms.
Also protects pods.
Fixes: https://github.com/yogstation13/yogstation/issues/1846
:cl:
tweak: Arrivals and escape shutte are protected from radiation storms.
/:cl: