### PR TITLE
Disables lavaland atmos

### DIFF
--- a/code/modules/mining/lavaland/lavaland_areas.dm
+++ b/code/modules/mining/lavaland/lavaland_areas.dm
@@ -27,6 +27,7 @@
 /area/lavaland/surface/outdoors
 	name = "Lavaland Wastes"
 	outdoors = 1
+	atmos = 0
 
 /area/lavaland/surface/outdoors/mapgen_protected
 	mapgen_protected = 1


### PR DESCRIPTION
Disables atmos from updating on lavaland.
Hopefully cuts down on the lag.

I failed to actually notice a difference gameplay wise, so that's good. 
:cl:
experiment: Disables lavaland atmos
/:cl: