### PR TITLE
Orebox capsules can fit inside of explorer webbing

### DIFF
--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -185,7 +185,7 @@
 		/obj/item/weapon/ore/bluespace_crystal,
 		/obj/item/weapon/reagent_containers/food/drinks,
 		/obj/item/device/barometer,
-
+		/obj/item/orecapsule
 
 		)
 


### PR DESCRIPTION
### Intent of your Pull Request

https://github.com/yogstation13/yogstation/issues/1865 request

#### Changelog

:cl:
tweak: Orebox capsules can fit in explorer webbing
/:cl:
