### PR TITLE
removes stimulants from adrenal implants

### DIFF
--- a/code/game/objects/items/weapons/implants/implant_misc.dm
+++ b/code/game/objects/items/weapons/implants/implant_misc.dm
@@ -44,7 +44,7 @@
 
 	imp_in.reagents.add_reagent("synaptizine", 10)
 	imp_in.reagents.add_reagent("omnizine", 10)
-	imp_in.reagents.add_reagent("stimulants", 10)
+	imp_in.reagents.add_reagent("ephedrine", 10)
 	if(!uses)
 		qdel(src)
 


### PR DESCRIPTION
this is a fix because it was never intended to be buffed
fixes #1882
:cl: ShadowDeath6
rscdel: Removes stimulant reagent from adrenal implants.
/:cl:
