### PR TITLE
You can now transfer AI's into potatos

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -103,10 +103,19 @@
 	targetitem = /obj/item/device/aicard
 	difficulty = 20 //beyond the impossible
 
-/datum/objective_item/steal/functionalai/check_special_completion(obj/item/device/aicard/C)
-	for(var/mob/living/silicon/ai/A in C)
-		if(istype(A, /mob/living/silicon/ai) && A.stat != 2) //See if any AI's are alive inside that card.
-			return 1
+/datum/objective_item/steal/functionalai/check_special_completion(obj/item/I)
+	var/obj/item/device/aicard/C
+
+	if(istype(I, /obj/item/weapon/stock_parts/cell/potato))
+		var/obj/item/weapon/stock_parts/cell/potato/P = I
+		C = P.storage // storage is defined as an intellicard
+	else
+		C = I
+
+	if(istype(C, /obj/item/device/aicard))
+		for(var/mob/living/silicon/ai/A in C)
+			if(istype(A, /mob/living/silicon/ai) && A.stat != 2) //See if any AI's are alive inside that card.
+				return 1
 	return 0
 
 /datum/objective_item/steal/blueprints

--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -22,6 +22,18 @@
 		target.transfer_ai(AI_TRANS_TO_CARD, user, null, src)
 	update_icon() //Whatever happened, update the card's state (icon, name) to match.
 
+/obj/item/device/aicard/attackby(obj/item/W, mob/user, params)
+	if(istype(W, /obj/item/weapon/stock_parts/cell/potato))
+		var/obj/item/weapon/stock_parts/cell/potato/P = W
+		if(P.storage)
+			if(P.storage.AI)
+				P.transfer_ai(AI_TRANS_TO_CARD, user, P.storage.AI, src)
+				P.storage.AI = null // since that proc works normally for [Core] -> [Intellicard] we have to manually turn off this var
+				P.name = initial(P.name)
+				P.desc = initial(P.desc)
+				return 0
+	return ..()
+
 /obj/item/device/aicard/update_icon()
 	if(AI)
 		name = "[initial(name)]- [AI.name]"

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -24,3 +24,5 @@
 	new /obj/item/device/laser_pointer(src)
 	new /obj/item/weapon/door_remote/research_director(src)
 	new /obj/item/weapon/storage/box/firingpins(src)
+	var/obj/item/weapon/stock_parts/cell/potato/P = new(src)
+	P.desc = "We do what we must because we can."

--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -25,4 +25,4 @@
 	new /obj/item/weapon/door_remote/research_director(src)
 	new /obj/item/weapon/storage/box/firingpins(src)
 	var/obj/item/weapon/stock_parts/cell/potato/P = new(src)
-	P.desc = "We do what we must because we can."
+	P.desc = "You can transfer AI's into potato batteries by using an intellicard."

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -806,15 +806,13 @@ var/list/ai_list = list()
 /mob/living/silicon/ai/attack_slime(mob/living/simple_animal/slime/user)
 	return
 
-/mob/living/silicon/ai/transfer_ai(interaction, mob/user, mob/living/silicon/ai/AI, obj/item/device/aicard/card, var/spawndeadAI = TRUE)
+/mob/living/silicon/ai/transfer_ai(interaction, mob/user, mob/living/silicon/ai/AI, obj/item/device/aicard/card)
 	if(!..())
 		return
 	if(interaction == AI_TRANS_TO_CARD)//The only possible interaction. Upload AI mob to a card.
 		if(!mind)
 			user << "<span class='warning'>No intelligence patterns detected.</span>"    //No more magical carding of empty cores, AI RETURN TO BODY!!!11
 			return
-		if(spawndeadAI)
-			new /obj/structure/AIcore/deactivated(loc)//Spawns a deactivated terminal at AI location.
 		ai_restore_power()//So the AI initially has power.
 		control_disabled = 1//Can't control things remotely if you're stuck in a card!
 		radio_enabled = 0 	//No talking on the built-in radio for you either!

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -806,21 +806,23 @@ var/list/ai_list = list()
 /mob/living/silicon/ai/attack_slime(mob/living/simple_animal/slime/user)
 	return
 
-/mob/living/silicon/ai/transfer_ai(interaction, mob/user, mob/living/silicon/ai/AI, obj/item/device/aicard/card)
+/mob/living/silicon/ai/transfer_ai(interaction, mob/user, mob/living/silicon/ai/AI, obj/item/device/aicard/card, var/spawndeadAI = TRUE)
 	if(!..())
 		return
 	if(interaction == AI_TRANS_TO_CARD)//The only possible interaction. Upload AI mob to a card.
 		if(!mind)
 			user << "<span class='warning'>No intelligence patterns detected.</span>"    //No more magical carding of empty cores, AI RETURN TO BODY!!!11
 			return
-		new /obj/structure/AIcore/deactivated(loc)//Spawns a deactivated terminal at AI location.
+		if(spawndeadAI)
+			new /obj/structure/AIcore/deactivated(loc)//Spawns a deactivated terminal at AI location.
 		ai_restore_power()//So the AI initially has power.
 		control_disabled = 1//Can't control things remotely if you're stuck in a card!
 		radio_enabled = 0 	//No talking on the built-in radio for you either!
-		loc = card//Throw AI into the card.
+		forceMove(card)
 		card.AI = src
 		src << "You have been downloaded to a mobile storage device. Remote device connection severed."
 		user << "<span class='boldnotice'>Transfer successful</span>: [name] ([rand(1000,9999)].exe) removed from host terminal and stored within local memory."
+		card.update_icon()
 
 /mob/living/silicon/ai/flash_eyes(intensity = 1, override_blindness_check = 0, affect_silicon = 0)
 	return // no eyes, no flashing

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -813,10 +813,11 @@ var/list/ai_list = list()
 		if(!mind)
 			user << "<span class='warning'>No intelligence patterns detected.</span>"    //No more magical carding of empty cores, AI RETURN TO BODY!!!11
 			return
+		new /obj/structure/AIcore/deactivated(loc)//Spawns a deactivated terminal at AI location.
 		ai_restore_power()//So the AI initially has power.
 		control_disabled = 1//Can't control things remotely if you're stuck in a card!
 		radio_enabled = 0 	//No talking on the built-in radio for you either!
-		forceMove(card)
+		loc = card//Throw AI into the card.
 		card.AI = src
 		src << "You have been downloaded to a mobile storage device. Remote device connection severed."
 		user << "<span class='boldnotice'>Transfer successful</span>: [name] ([rand(1000,9999)].exe) removed from host terminal and stored within local memory."

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -296,6 +296,13 @@
 	if(storage.AI)
 		return
 
+	if(!card)
+		return
+
+	if(!AI.mind)
+		user << "<span class='warning'>No intelligence patterns detected.</span>"    //No more magical carding of empty cores, AI RETURN TO BODY!!!11
+		return
+
 	if(interaction == AI_TRANS_FROM_CARD)
 		storage.AI = AI
 		AI.control_disabled = 1
@@ -308,13 +315,23 @@
 		card.AI = null
 		card.update_icon()
 
+	else if(interaction == AI_TRANS_TO_CARD)
+		AI.ai_restore_power()//So the AI initially has power.
+		AI.control_disabled = 1//Can't control things remotely if you're stuck in a card!
+		AI.radio_enabled = 0 	//No talking on the built-in radio for you either!
+		AI.forceMove(card)
+		card.AI = src
+		AI << "You have been downloaded to a mobile storage device. Remote device connection severed."
+		user << "<span class='boldnotice'>Transfer successful</span>: [name] ([rand(1000,9999)].exe) removed from host terminal and stored within local memory."
+		card.update_icon()
+
 /obj/item/weapon/stock_parts/cell/potato/afterattack(atom/target, mob/user, proximity) // for potato -> card
 	..()
 	if(istype(target, /obj/item/device/aicard))
 		var/obj/item/device/aicard/A = target
 		if(storage)
 			if(storage.AI)
-				storage.AI.transfer_ai(AI_TRANS_TO_CARD, user, null, A, spawndeadAI = FALSE)
+				transfer_ai(AI_TRANS_TO_CARD, user, storage.AI, A)
 				storage.AI = null // since that proc works normally for [Core] -> [Intellicard] we have to manually turn off this var
 				name = initial(name)
 				desc = initial(desc)

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -274,7 +274,7 @@
 
 /obj/item/weapon/stock_parts/cell/potato
 	name = "potato battery"
-	desc = "A rechargable starch based power cell."
+	desc = "A rechargable starch based power cell. Surprisingly, it's powerful enough to hold an entire AI."
 	icon = 'icons/obj/power.dmi' //'icons/obj/hydroponics/harvest.dmi'
 	icon_state = "potato_cell" //"potato_battery"
 	origin_tech = "powerstorage=1;biotech=1"
@@ -282,6 +282,42 @@
 	maxcharge = 300
 	materials = list()
 	rating = 1
+	var/obj/item/device/aicard/storage
+
+/obj/item/weapon/stock_parts/cell/potato/New()
+	. = ..()
+	storage = new(src)
+
+/obj/item/weapon/stock_parts/cell/potato/transfer_ai(interaction, mob/user, mob/living/silicon/ai/AI, obj/item/device/aicard/card)
+	if(!..())
+		return
+	if(!AI)
+		return
+	if(storage.AI)
+		return
+
+	if(interaction == AI_TRANS_FROM_CARD)
+		storage.AI = AI
+		AI.control_disabled = 1
+		AI.radio_enabled = 0
+		AI.forceMove(src)
+		AI << "You are a potato."
+		name = AI.name
+		desc = "This isn't your average potato..."
+		user << "<span class='boldnotice'>Transfer successful</span>: [AI.name] ([rand(1000,9999)].exe) installed and executed successfully. Local copy has been removed."
+		card.AI = null
+		card.update_icon()
+
+/obj/item/weapon/stock_parts/cell/potato/afterattack(atom/target, mob/user, proximity) // for potato -> card
+	..()
+	if(istype(target, /obj/item/device/aicard))
+		var/obj/item/device/aicard/A = target
+		if(storage)
+			if(storage.AI)
+				storage.AI.transfer_ai(AI_TRANS_TO_CARD, user, null, A, spawndeadAI = FALSE)
+				storage.AI = null // since that proc works normally for [Core] -> [Intellicard] we have to manually turn off this var
+				name = initial(name)
+				desc = initial(desc)
 
 /obj/item/weapon/stock_parts/cell/high/slime
 	name = "charged slime core"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -293,17 +293,15 @@
 		return
 	if(!AI)
 		return
-	if(storage.AI)
-		return
-
 	if(!card)
 		return
-
 	if(!AI.mind)
 		user << "<span class='warning'>No intelligence patterns detected.</span>"    //No more magical carding of empty cores, AI RETURN TO BODY!!!11
 		return
 
 	if(interaction == AI_TRANS_FROM_CARD)
+		if(storage.AI)
+			return
 		storage.AI = AI
 		AI.control_disabled = 1
 		AI.radio_enabled = 0
@@ -311,30 +309,20 @@
 		AI << "You are a potato."
 		name = AI.name
 		desc = "This isn't your average potato..."
-		user << "<span class='boldnotice'>Transfer successful</span>: [AI.name] ([rand(1000,9999)].exe) installed and executed successfully. Local copy has been removed."
+		user << "<span class='boldnotice'>Transfer successful</span>: [AI.name] ([rand(1000,9999)].exe) installed and executed successfully in a potato."
 		card.AI = null
 		card.update_icon()
 
-	else if(interaction == AI_TRANS_TO_CARD)
+	else if(interaction == AI_TRANS_TO_CARD) //  [potato] -> [card]. handled in aicard.dm
 		AI.ai_restore_power()//So the AI initially has power.
 		AI.control_disabled = 1//Can't control things remotely if you're stuck in a card!
 		AI.radio_enabled = 0 	//No talking on the built-in radio for you either!
 		AI.forceMove(card)
-		card.AI = card
+		AI.loc = card
+		card.AI = AI
 		AI << "You have been downloaded to a mobile storage device. Remote device connection severed."
 		user << "<span class='boldnotice'>Transfer successful</span>: [name] ([rand(1000,9999)].exe) removed from host terminal and stored within local memory."
 		card.update_icon()
-
-/obj/item/weapon/stock_parts/cell/potato/afterattack(atom/target, mob/user, proximity) // for potato -> card
-	..()
-	if(istype(target, /obj/item/device/aicard))
-		var/obj/item/device/aicard/A = target
-		if(storage)
-			if(storage.AI)
-				transfer_ai(AI_TRANS_TO_CARD, user, storage.AI, A)
-				storage.AI = null // since that proc works normally for [Core] -> [Intellicard] we have to manually turn off this var
-				name = initial(name)
-				desc = initial(desc)
 
 /obj/item/weapon/stock_parts/cell/high/slime
 	name = "charged slime core"

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -320,7 +320,7 @@
 		AI.control_disabled = 1//Can't control things remotely if you're stuck in a card!
 		AI.radio_enabled = 0 	//No talking on the built-in radio for you either!
 		AI.forceMove(card)
-		card.AI = src
+		card.AI = card
 		AI << "You have been downloaded to a mobile storage device. Remote device connection severed."
 		user << "<span class='boldnotice'>Transfer successful</span>: [name] ([rand(1000,9999)].exe) removed from host terminal and stored within local memory."
 		card.update_icon()


### PR DESCRIPTION
when game references go 2 far
![](http://image.prntscr.com/image/9389488f5dcb4db89c6b8b1979ce1518.png)
![](http://image.prntscr.com/image/70d47008087547e8b89b50bc2685a079.png)

:cl: 
rscadd: You can now transfer AI's into potato's. It must be from an intellicard however.
/:cl: