### PR TITLE
Security Ghosts

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -59,6 +59,8 @@ var/datum/subsystem/ticker/ticker
 	var/total_deaths = 0
 	var/maprotatechecked = 0
 
+	var/project_security = FALSE					// if antagonists lose all of security becomes a visible mirage of their former self.
+
 
 /datum/subsystem/ticker/New()
 	NEW_SS_GLOBAL(ticker)
@@ -503,6 +505,9 @@ var/datum/subsystem/ticker/ticker
 			CTF.ctf_enabled = !CTF.ctf_enabled
 			CTF.TellGhost()
 
+	if(ticker.project_security)
+		project_security()
+
 	return 1
 
 /datum/subsystem/ticker/proc/send_random_tip()
@@ -593,3 +598,16 @@ var/datum/subsystem/ticker/ticker
 	queued_players = ticker.queued_players
 	cinematic = ticker.cinematic
 	maprotatechecked = ticker.maprotatechecked
+
+/datum/subsystem/ticker/proc/project_security()
+	var/list/security = list("Security Officer", "Detective", "Warden", "Head of Security", "Captain")
+	for(var/mob/dead/observer/G in player_list)
+		if(G.mind)
+			if(G.mind.current)
+				if(G.mind.current.job in security)
+					if(G.client) // our final sanity check
+						G.ghost_accs = GHOST_ACCS_FULL
+						G.update_icon(update_client = FALSE)
+						G.invisibility = 0
+						G.desc = "It's the [G.mind.current.job]!"
+						G << "<span class='notice'>You slowly begin to reappear. Security has won the day! Peace has been restored!</span>"

--- a/code/game/gamemodes/blob/blob_finish.dm
+++ b/code/game/gamemodes/blob/blob_finish.dm
@@ -36,6 +36,7 @@
 		world << "<FONT size = 3><B>The staff has won!</B></FONT>"
 		world << "<B>The alien organism has been eradicated from the station</B>"
 		log_game("Blob mode completed with a crew victory.")
+		ticker.project_security = TRUE
 	..()
 	return 1
 

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -243,6 +243,7 @@ This file's folder contains:
 			else
 				text += "<span class='userdanger'>Ratvar's servants have failed!</span>"
 				feedback_set_details("round_end_result", "loss - servants failed their objective ([clockwork_objective])")
+				ticker.project_security = TRUE
 		text += "<br><b>The servants' objective was:</b> <br>[clockwork_explanation]<br>"
 	if(servants_of_ratvar.len)
 		text += "<b>Ratvar's servants were:</b>"

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -238,6 +238,7 @@
 		feedback_set_details("round_end_result","loss - staff stopped the cult")
 		feedback_set("round_end_result",acolytes_survived)
 		world << "<span class='redtext'>The staff managed to stop the cult! Dark words and heresy are no match for Nanotrasen's finest!</span>"
+		ticker.project_security = TRUE
 
 	var/text = ""
 

--- a/code/game/gamemodes/cybermen/cybermen.dm
+++ b/code/game/gamemodes/cybermen/cybermen.dm
@@ -184,6 +184,7 @@ var/datum/cyberman_network/cyberman_network
 	else
 		world << "<span class='redtext'>The Cybermen have failed!</span>"
 		//log_yogstat_data("gamemode.php?gamemode=cybermen&value=crewwin&action=add&changed=1")
+		ticker.project_security = TRUE
 	return 1
 
 /datum/game_mode/proc/auto_declare_completion_cybermen()

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -264,6 +264,7 @@ var/list/gang_colors_pool = list("red","orange","yellow","green","blue","purple"
 		if(!winner)
 			world << "<span class='redtext'>The station was [station_was_nuked ? "destroyed!" : "evacuated before a gang could claim it! The loyalists win!"]</span><br>"
 			feedback_set_details("round_end_result","loss - gangs failed takeover")
+			ticker.project_security = TRUE
 		else
 			world << "<span class='redtext'>The [winner.name] Gang successfully performed a hostile takeover of the station!</span><br>"
 			feedback_set_details("round_end_result","win - gang domination complete")

--- a/code/game/gamemodes/handofgod/_handofgod.dm
+++ b/code/game/gamemodes/handofgod/_handofgod.dm
@@ -435,6 +435,7 @@ var/global/list/global_handofgod_structuretypes = list()
 			else
 				text += "<BR><font color='red'><B>The blue cult and deity have failed!</B></font>"
 				feedback_add_details("god_success","FAIL")
+				ticker.project_security = TRUE
 
 			text += "<BR>"
 

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -222,11 +222,13 @@
 		feedback_set_details("round_end_result","loss - evacuation - disk secured - syndi team dead")
 		world << "<FONT size = 3><B>Crew Major Victory!</B></FONT>"
 		world << "<B>The Research Staff has saved the disc and killed the [syndicate_name()] Operatives</B>"
+		ticker.project_security = TRUE
 
 	else if (disk_rescued)
 		feedback_set_details("round_end_result","loss - evacuation - disk secured")
 		world << "<FONT size = 3><B>Crew Major Victory</B></FONT>"
 		world << "<B>The Research Staff has saved the disc and stopped the [syndicate_name()] Operatives!</B>"
+		ticker.project_security = TRUE
 
 	else if (!disk_rescued && are_operatives_dead())
 		feedback_set_details("round_end_result","halfwin - evacuation - disk not secured")

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -350,6 +350,7 @@
 	else if(finished == 2)
 		feedback_set_details("round_end_result","loss - rev heads killed")
 		world << "<span class='redtext'>The heads of staff managed to stop the revolution!</span>"
+		ticker.project_security = TRUE
 	..()
 	return 1
 

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -224,10 +224,13 @@ Made by Xhuis
 		world << "<span class='greentext'>The shadowlings have ascended and taken over the station!</span>"
 	else if(shadowling_dead && !check_shadow_victory()) //If the shadowlings have ascended, they can not lose the round
 		world << "<span class='redtext'>The shadowlings have been killed by the crew!</span>"
+		ticker.project_security = TRUE
 	else if(!check_shadow_victory() && EMERGENCY_ESCAPED_OR_ENDGAMED)
 		world << "<span class='redtext'>The crew escaped the station before the shadowlings could ascend!</span>"
+		ticker.project_security = TRUE
 	else
 		world << "<span class='redtext'>The shadowlings have failed!</span>"
+		ticker.project_security = TRUE
 	..()
 	return 1
 

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -196,6 +196,7 @@
 	killer.show_laws()
 
 /datum/game_mode/proc/auto_declare_completion_traitor()
+	var/traitorwincount
 	if(traitors.len)
 		var/text = "<br><font size=3><b>The [traitor_name]s were:</b></font>"
 		for(var/datum/mind/traitor in traitors)
@@ -242,6 +243,7 @@
 			if(traitorwin)
 				text += "<br><font color='green'><B>The [special_role_text] was successful!</B></font>"
 				feedback_add_details("traitor_success","SUCCESS")
+				traitorwincount++
 			else
 				text += "<br><font color='red'><B>The [special_role_text] has failed!</B></font>"
 				feedback_add_details("traitor_success","FAIL")
@@ -251,6 +253,8 @@
 		text += "<br><b>The code phrases were:</b> <font color='red'>[syndicate_code_phrase]</font><br>\
 		<b>The code responses were:</b> <font color='red'>[syndicate_code_response]</font><br>"
 		world << text
+	if(!traitorwincount)
+		ticker.project_security = TRUE
 
 	return 1
 

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -187,11 +187,13 @@
 	if(finished)
 		feedback_set_details("round_end_result","loss - wizard killed")
 		world << "<span class='userdanger'>The wizard[(wizards.len>1)?"s":""] has been killed by the crew! The Space Wizards Federation has been taught a lesson they will not soon forget!</span>"
+		ticker.project_security = TRUE
 	..()
 	return 1
 
 
 /datum/game_mode/proc/auto_declare_completion_wizard()
+	var/wincount
 	if(wizards.len)
 		var/text = "<br><font size=3><b>the wizards/witches were:</b></font>"
 
@@ -215,6 +217,7 @@
 				if(objective.check_completion())
 					text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='green'><B>Success!</B></font>"
 					feedback_add_details("wizard_objective","[objective.type]|SUCCESS")
+					wincount++
 				else
 					text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <font color='red'>Fail.</font>"
 					feedback_add_details("wizard_objective","[objective.type]|FAIL")
@@ -238,6 +241,8 @@
 			text += "<br>"
 
 		world << text
+		if(!wincount) // 0 wizards won.
+			ticker.project_security = TRUE
 	return 1
 
 //OTHER PROCS

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -146,10 +146,11 @@ var/list/image/ghost_images_simple = list() //this is a list of all ghost images
  * Hair will always update its dir, so if your sprite has no dirs the haircut will go all over the place.
  * |- Ricotez
  */
-/mob/dead/observer/proc/update_icon(new_form)
-	if(client) //We update our preferences in case they changed right before update_icon was called.
-		ghost_accs = client.prefs.ghost_accs
-		ghost_others = client.prefs.ghost_others
+/mob/dead/observer/proc/update_icon(new_form, update_client = TRUE)
+	if(update_client)
+		if(client) //We update our preferences in case they changed right before update_icon was called.
+			ghost_accs = client.prefs.ghost_accs
+			ghost_others = client.prefs.ghost_others
 
 	if(hair_image)
 		overlays -= hair_image

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-extended
+secret


### PR DESCRIPTION
### Intent of your Pull Request

# WIP 

for now until I can talk with coders that have already done this sorta thing.
Here's the basis of the idea:
- On the occurrence that the antagonists LOSE, the ghosts of the HoS, Captain, Warden, Security Officers, and even the Detective will become see able and become virtual representations of their old selves.
- This will ALSO work on single-antagonist modes like traitor whenever EVERY LAST antagonist has red-texted.
- So IF the antagonists LOSE then security officers that won the good fight will be able to celebrate with their no-longer living coworkers. Or at least see them to know that they were there the entire time. For that emotional effect

So virtually this:
![](https://s-media-cache-ak0.pinimg.com/originals/7b/46/82/7b46822b22d390f174cbaafaf0166fed.jpg)

This works for:
- Blob
- Clockwork
- Cult
- Cybermen
- Gang
- Hand of God
- Nuclear
- Revolution
- Shadowling
- Traitor
- Wizard

#### Changelog

:cl:
rscadd: When the antagonists lose the ghosts of security will become seeable. So basically the ending of Return of the Jedi.
/:cl: