### PR TITLE
makes dismembering legs not stun- also makes blood bubble when slaughter demons use it

### DIFF
--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -70,7 +70,7 @@
 /mob/living/simple_animal/slaughter/phasein()
 	. = ..()
 	speed = 0
-	boost = world.time + 50
+	boost = world.time + 20
 
 
 //The loot from killing a slaughter demon - can be consumed to allow the user to blood crawl

--- a/code/modules/mob/living/bloodcrawl.dm
+++ b/code/modules/mob/living/bloodcrawl.dm
@@ -81,9 +81,9 @@
 	else if(victim.reagents && victim.reagents.has_reagent("demonsblood"))
 		visible_message("<span class='warning'>Something prevents [victim] from entering the pool!</span>", "<span class='warning'>A strange force is blocking [victim] from entering!</span>", "<span class='notice'>You hear a splash and a thud.</span>")
 	else
-		victim.forceMove(src)
 		victim.emote("scream")
 		src.visible_message("<span class='warning'><b>[src] drags [victim] into the pool of blood!</b></span>", null, "<span class='notice'>You hear a splash.</span>")
+		victim.forceMove(src)
 		kidnapped = TRUE
 
 	if(kidnapped)
@@ -161,16 +161,18 @@
 	if(src.notransform)
 		src << "<span class='warning'>Finish eating first!</span>"
 		return 0
-	src.loc = B.loc
-	src.client.eye = src
-	src.visible_message("<span class='warning'><B>[src] rises out of the pool of blood!</B>")
-	exit_blood_effect(B)
-	if(iscarbon(src))
-		var/mob/living/carbon/C = src
-		for(var/obj/item/weapon/bloodcrawl/BC in C)
-			BC.flags = null
-			C.unEquip(BC)
-			qdel(BC)
-	qdel(src.holder)
-	src.holder = null
+	B.visible_message("<span class='warning'>[B] begins to bubble...</B>")
+	if(do_after(src, 25, target = B))
+		src.loc = B.loc
+		src.client.eye = src
+		src.visible_message("<span class='warning'><B>[src] rises out of the pool of blood!</B>")
+		exit_blood_effect(B)
+		if(iscarbon(src))
+			var/mob/living/carbon/C = src
+			for(var/obj/item/weapon/bloodcrawl/BC in C)
+				BC.flags = null
+				C.unEquip(BC)
+				qdel(BC)
+		qdel(src.holder)
+		src.holder = null
 	return 1

--- a/code/modules/mob/living/bloodcrawl.dm
+++ b/code/modules/mob/living/bloodcrawl.dm
@@ -163,9 +163,9 @@
 		return 0
 	B.visible_message("<span class='warning'>[B] begins to bubble...</B>")
 	if(do_after(src, 25, target = B))
-		src.loc = B.loc
-		src.client.eye = src
-		src.visible_message("<span class='warning'><B>[src] rises out of the pool of blood!</B>")
+		forceMove(B)
+		client.eye = src
+		visible_message("<span class='warning'><B>[src] rises out of the pool of blood!</B>")
 		exit_blood_effect(B)
 		if(iscarbon(src))
 			var/mob/living/carbon/C = src
@@ -173,6 +173,6 @@
 				BC.flags = null
 				C.unEquip(BC)
 				qdel(BC)
-		qdel(src.holder)
-		src.holder = null
+		qdel(holder)
+		holder = null
 	return 1

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -169,7 +169,6 @@
 
 /obj/item/bodypart/r_leg/drop_limb(special)
 	if(owner && !special)
-		owner.Weaken(2)
 		if(owner.legcuffed)
 			owner.legcuffed.loc = owner.loc
 			owner.legcuffed.dropped(owner)
@@ -183,7 +182,6 @@
 
 /obj/item/bodypart/l_leg/drop_limb(special) //copypasta
 	if(owner && !special)
-		owner.Weaken(2)
 		if(owner.legcuffed)
 			owner.legcuffed.loc = owner.loc
 			owner.legcuffed.dropped(owner)


### PR DESCRIPTION
wow pseudo more like boohoodo
fixes #1898 somewhat

if you wanna get mad about dismembering leg thing not working remember that it already slows you down

:cl: ShadowDeath6
rscdel: Removed the stun from leg dismemberment.
rscadd: Blood bubbles when slaughter demons are about to pop out of it.
tweak: Slaughter demons now lose their speed boost from exiting blood much faster.
/:cl:
