### PR TITLE
Porting Old Apollo Station "Supermatter Implosion"

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -297,7 +297,7 @@
 /obj/machinery/power/supermatter_shard/proc/supermatter_pull()
 	//following is adapted from singulo code
 	// Let's just make this one loop.
-	for(var/atom/X in orange(15), src )
+	for(var/atom/X in orange(15,src))
 		X.singularity_pull(src, STAGE_FIVE)
 
 	return

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -298,7 +298,7 @@
 /obj/machinery/power/supermatter/proc/supermatter_pull()
 	//following is adapted from singulo code
 	// Let's just make this one loop.
-	for(var/atom/X in orange(15), src ))
+	for(var/atom/X in orange(15), src )
 		X.singularity_pull(src, STAGE_FIVE)
 
 	return

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -93,7 +93,6 @@
 		qdel(src)
 		return
 	
-
 /obj/machinery/power/supermatter_shard/process()
 	var/turf/L = loc
 
@@ -295,7 +294,7 @@
 			R.receive_pulse(power/10)
 	return
 
-/obj/machinery/power/supermatter/proc/supermatter_pull()
+/obj/machinery/power/supermatter_shard/proc/supermatter_pull()
 	//following is adapted from singulo code
 	// Let's just make this one loop.
 	for(var/atom/X in orange(15), src )

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -87,7 +87,7 @@
 	grav_pulling = 1
 	exploded = 1
 
-	spawn(15 * TICKS_IN_SECOND )
+	spawn(1500)
 		explosion(get_turf(src), explosion_power, explosion_power * 2, explosion_power * 3, explosion_power * 4, 1, 1)
 		
 		qdel(src)


### PR DESCRIPTION
Apollo station had one of the coolest mechanics with the supermatter, where upon exploding the supermatter would pull in all objects around before imploding. It was beautiful, and so I've ported it over to our code.


### Intent of my Pull Request

As I stated before, this pull request ports over a very cool mechanic that would not only be spooky when engineers try to set up a new engine, it also makes for a sexy traitor cargo strategy. This mechanic would be very cool, but it takes up a minimal footprint.

#### Changelog

:cl:
rscadd: I've ported over a gravitation pull mechanic that activates on explosion- this is based on singularity code.
rscadd: I also added the "exploded" variable to stop admin log spam on exploding supermatters.
rscadd: I updated the explode proc and the general process with the new mechanics.
/:cl:
