### PR TITLE
Killer (Emagged) Photocopiers

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -328,6 +328,10 @@
 			new /obj/effect/decal/cleanable/oil(get_turf(src))
 			toner = 0
 
+/obj/machinery/photocopier/emag_act(mob/user)
+	if(!emagged)
+		emagged = 1
+
 /obj/machinery/photocopier/MouseDrop_T(mob/target, mob/user)
 	check_ass() //Just to make sure that you can re-drag somebody onto it after they moved off.
 	if (!istype(target) || target.anchored || target.buckled || !Adjacent(user) || !Adjacent(target) || !user.canUseTopic(src, 1) || target == ass || copier_blocked())
@@ -349,7 +353,20 @@
 
 		target.loc = get_turf(src)
 		ass = target
-
+		if(emagged)
+			target.gib()
+			visible_message("<span class='warning'>[target] is crushed in a tragic photocopying accident!</span>")
+			if(toner <= 0 || !isCarbon(ass))
+				return
+			
+			else
+				if(prob(90)) //90%
+					/obj/item/target/syndicate = new(src.loc)  //photocopier spews out a blood red paper person
+					return
+				else
+					/obj/item/weapon/paper/talisman/malformed = new(src.loc)
+					return
+			
 		if(photocopy)
 			photocopy.loc = src.loc
 			visible_message("<span class='warning'>[photocopy] is shoved out of the way by [ass]!</span>")
@@ -359,6 +376,7 @@
 			copy.loc = src.loc
 			visible_message("<span class='warning'>[copy] is shoved out of the way by [ass]!</span>")
 			copy = null
+			
 	updateUsrDialog()
 
 /obj/machinery/photocopier/proc/check_ass() //I'm not sure wether I made this proc because it's good form or because of the name.

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -329,8 +329,10 @@
 			toner = 0
 
 /obj/machinery/photocopier/emag_act(mob/user)
+	src.add_fingerprint(user)
 	if(!emagged)
 		emagged = 1
+	
 
 /obj/machinery/photocopier/MouseDrop_T(mob/target, mob/user)
 	check_ass() //Just to make sure that you can re-drag somebody onto it after they moved off.
@@ -353,7 +355,7 @@
 
 		target.loc = get_turf(src)
 		ass = target
-		if(emagged)
+		if(emagged && (target != user))
 			target.gib()
 			visible_message("<span class='warning'>[target] is crushed in a tragic photocopying accident!</span>")
 			if(toner <= 0 || !isCarbon(ass))
@@ -363,6 +365,7 @@
 				if(prob(90)) //90%
 					/obj/item/target/syndicate = new(src.loc)  //photocopier spews out a blood red paper person
 					return
+				
 				else
 					/obj/item/weapon/paper/talisman/malformed = new(src.loc)
 					return

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -27,6 +27,7 @@
 	var/greytoggle = "Greyscale"
 	var/mob/living/ass //i can't believe i didn't write a stupid-ass comment about this var when i first coded asscopy.
 	var/busy = 0
+	var/emagged = 0
 
 /obj/machinery/photocopier/attack_ai(mob/user)
 	return attack_hand(user)


### PR DESCRIPTION
Photocopiers should be emaggable, so why not let them do something horrific to people shoved in them? That's the question I think I solved with this pull request- finally, you can murder people with paperwork.


### Intent of your Pull Request

Photocopiers weren't able to be emagged, and I thought that was sad. Now, photocopiers can be used by traitors to brutally crush people and get a neat souvenir.

#### Changelog

:cl:
rscadd: -Photocopiers can now be emagged
rscadd: -Emagged photocopiers now gib people dragged into them
rscadd: -After gibbing, produces either a blood-red cutout of the person or a less-than-useless talisman
/:cl:
