### PR TITLE
Adds job specific traitor items framework

### DIFF
--- a/code/modules/uplink/uplink.dm
+++ b/code/modules/uplink/uplink.dm
@@ -54,6 +54,13 @@ var/global/list/uplinks = list()
 		)
 		for(var/item in uplink_items[category])
 			var/datum/uplink_item/I = uplink_items[category][item]
+			if(I.restricted_roles.len)
+				var/is_inaccessible = 1
+				for(var/R in I.restricted_roles)
+					if(R == user.mind.assigned_role)
+						is_inaccessible = 0
+				if(is_inaccessible)
+					continue
 			cat["items"] += list(list(
 				"name" = I.name,
 				"cost" = I.cost,

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -50,6 +50,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	var/list/include_modes = list() // Game modes to allow this item in.
 	var/list/exclude_modes = list() // Game modes to disallow this item from.
 	var/player_minimum //The minimum crew size needed for this item to be added to uplinks.
+	var/list/restricted_roles = list() //The jobs allow to buy this weapon.
 
 /datum/uplink_item/proc/spawn_item(turf/loc, obj/item/device/uplink/U)
 	if(item)
@@ -1062,6 +1063,20 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			They must be implanted via surgery."
 	item = /obj/item/weapon/storage/box/cyber_implants/bundle
 	cost = 40
+
+
+
+// Role-specific items
+/datum/uplink_item/role_restricted
+	category = "Role-Restricted"
+	exclude_modes = list(/datum/game_mode/nuclear)
+
+
+/datum/uplink_item/role_restricted/dicks
+	name = "testobjyay"
+	item = /obj/item/weapon/storage/toolbox/syndicate
+	restricted_roles = list("Assistant")
+	cost = 5
 
 // Pointless
 /datum/uplink_item/badass


### PR DESCRIPTION
Ported from:  https://github.com/tgstation/tgstation/pull/23227 by @Xhuis 

:cl: Xhuis
rscadd: Adds job specific traitor items. It's just the framework actually. 
/:cl:
It pulls from the mind, not the ID. No idea what that was about on the original PR...