### PR TITLE
cult shit

### DIFF
--- a/code/game/turfs/simulated/walls_misc.dm
+++ b/code/game/turfs/simulated/walls_misc.dm
@@ -65,7 +65,9 @@
 			alpha = initial(src.alpha)
 			density = 1
 			opacity = 1
-	return
+		return
+	else
+		..()
 
 /turf/closed/wall/mineral/cult/artificer
 	name = "runed stone wall"

--- a/code/modules/mob/living/simple_animal/constructs.dm
+++ b/code/modules/mob/living/simple_animal/constructs.dm
@@ -29,7 +29,7 @@
 	deathmessage = "collapses in a shattered heap."
 	var/list/construct_spells = list()
 	var/playstyle_string = "<b>You are a generic construct! Your job is to not exist, and you should probably adminhelp this.</b>"
-	var/phaser = FALSE
+	var/phaser = TRUE
 	var/affiliation = "Cult" // Cult, Wizard and Neutral. Or a color.
 
 
@@ -174,7 +174,6 @@
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	construct_spells = list(/obj/effect/proc_holder/spell/targeted/ethereal_jaunt/shift)
 	playstyle_string = "<b>You are a Wraith. Though relatively fragile, you are fast, deadly, and even able to phase through walls.</b>"
-	phaser = TRUE
 
 /mob/living/simple_animal/hostile/construct/wraith/hostile //actually hostile, will move around, hit things
 	AIStatus = AI_ON
@@ -210,7 +209,6 @@
 						use magic missile, repair allied constructs (by clicking on them), \
 						</B><I>and most important of all create new constructs</I><B> \
 						(Use your Artificer spell to summon a new construct shell and Summon Soulstone to create a new soulstone).</B>"
-	phaser = TRUE
 
 /mob/living/simple_animal/hostile/construct/builder/Found(atom/A) //what have we found here?
 	if(isconstruct(A)) //is it a construct?
@@ -292,7 +290,6 @@
 							/obj/effect/proc_holder/spell/targeted/projectile/magic_missile/lesser)
 	playstyle_string = "<B>You are a Harvester. You are strong and fast. \
 						Bring those who still cling to this world of illusion back to the Geometer so they may know Truth.</B>"
-	phaser = TRUE
 
 /mob/living/simple_animal/hostile/construct/harvester/hostile //actually hostile, will move around, hit things
 	AIStatus = AI_ON


### PR DESCRIPTION
fixes the thing where jackhammers didn't work on cult walls, my bad
also makes juggs able to wallphase now because fuuuuuuuuuck juggs breaking open cult bases that's not fun
fixes #1893 

:cl: ShadowDeath6
rscadd: Juggernauts can phase through runed walls like every other cult construct now.
bugfix: Sonic jackhammers now correctly destroy runed walls.
/:cl:
