### PR TITLE
Revert "Buffs transform sting, makes mutesting use reagents, changes hallucinogen pathogen sting" Or How I Learned To Actually Read Adam's PR's Before APPROVING THEM

### DIFF
--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -63,10 +63,11 @@
 /obj/effect/proc_holder/changeling/sting/transformation
 	name = "Transformation Sting"
 	desc = "We silently sting a human, injecting a retrovirus that forces them to transform."
-	helptext = "The victim will transform much like a changeling would. The effects will be obvious to the victim."
+	helptext = "The victim will transform much like a changeling would. The effects will be obvious to the victim, and the process will damage our genomes."
 	sting_icon = "sting_transform"
-	chemical_cost = 30
-	dna_cost = 1
+	chemical_cost = 40
+	dna_cost = 3
+	genetic_damage = 100
 	var/datum/changelingprofile/selected_dna = null
 
 /obj/effect/proc_holder/changeling/sting/transformation/Click()
@@ -101,6 +102,8 @@
 		var/mob/living/carbon/C = target
 		if(CANWEAKEN in C.status_flags)
 			C.do_jitter_animation(500)
+			C.take_organ_damage(20, 0) //The process is extremely painful
+
 		target.visible_message("<span class='danger'>[target] begins to violenty convulse!</span>","<span class='userdanger'>You feel a tiny prick and a begin to uncontrollably convulse!</span>")
 		spawn(10)
 			C.real_name = NewDNA.real_name
@@ -198,8 +201,7 @@
 
 /obj/effect/proc_holder/changeling/sting/mute/sting_action(mob/user, mob/living/carbon/target)
 	add_logs(user, target, "stung", "mute sting")
-	if(target.reagents)
-		target.reagents.add_reagent("mutetoxin", 20)
+	target.silent += 30
 	feedback_add_details("changeling_powers","MS")
 	return 1
 
@@ -221,17 +223,20 @@
 	return 1
 
 /obj/effect/proc_holder/changeling/sting/LSD
-	name = "Hallucinogenic Sting"
+	name = "Hallucinogenic Pathogen Sting"
 	desc = "Causes terror in the target."
-	helptext = "We evolve the ability to sting a target with a powerful hallucinogenic chemical. The target does not notice they have been stung, and the effect occurs very quickly."
+	helptext = "We evolve the ability to sting a target with a powerful hallucinogenic chemical. The target does not notice they have been stung, and the effect occurs after 30 to 60 seconds."
 	sting_icon = "sting_lsd"
-	chemical_cost = 20
-	dna_cost = 1
+	chemical_cost = 50
+	dna_cost = 5
 
 /obj/effect/proc_holder/changeling/sting/LSD/sting_action(mob/user, mob/living/carbon/target)
 	add_logs(user, target, "stung", "LSD sting")
-	if(target.reagents)
-		target.reagents.add_reagent("mindbreaker", 30)
+	spawn(rand(300,600))
+		if(target)
+			if(!target.resistances.Find(/datum/disease/lingvirus))
+				var/datum/disease/welp = new /datum/disease/lingvirus(0)
+				target.ContractDisease(welp)
 	feedback_add_details("changeling_powers","HS")
 	return 1
 


### PR DESCRIPTION
Reverts yogstation13/yogstation#1886

Appalled this passed, and not for the reasons you'd might think.

Genome damaging is basically IC/changeling flavour for adding a cooldown to abilities to prevent them from being spammed. I just finished a round where a Changeling spam transformed four people in about a second and a half because Adam's a fucking halfwit and removed the cooldown from the sting because "muh genomes".

The Mutetoxin change is good, we should keep that one.

We can look at **REDUCING** the transform sting cooldown and cost, but this was just absolute fucking insanity. We can also maybe rework the virus to be NOSPREAD and simulate the transformation over time, giving people a means to counter a FULL IDENTITY change outside of getting their gene encoding stored by a Geneticist at round start, because who the fuck does that?

Stop approving Adam's PR's without thinking about them first. All of you should know better.