### PR TITLE
Slightly buffs the invisible touch ability.

### DIFF
--- a/code/modules/spells/spell_types/godhand.dm
+++ b/code/modules/spells/spell_types/godhand.dm
@@ -164,9 +164,9 @@
 					if(!user)
 						break
 					passes--
-					user.alpha = 0
+					animate(user, alpha = 0, time = 1)
 					sleep(3)
-					user.alpha = initial(user.alpha)
+					animate(user, alpha = initial(user.alpha), time = 1)
 					sleep(2)
 			else
 				user << "<span class='warning'>You have to be a mime to use this trick!</span>"
@@ -177,9 +177,9 @@
 		if(istype(target, /obj/structure/chair))
 			target.visible_message("[target] [target.alpha == 0 ? "reappears" : "vanishes"]!</span>")
 			if(target.alpha)
-				target.alpha = 0
+				animate(target, alpha = 0, time = 5)
 			else
-				target.alpha = initial(target.alpha)
+				animate(target, alpha = initial(target.alpha), time = 8)
 			if(!(target in things))// to be restored later
 				things += target
 			return
@@ -191,7 +191,7 @@
 		things += target
 		user << "<span class='warning'>You poke [target] extinguishing one of your charges.</span>"
 		uses--
-		target.alpha = 0
+		animate(target, alpha = 0, time = 5)
 		addtimer(src, "reverttarget",80, FALSE, target)
 
 /obj/item/weapon/melee/touch_attack/proc/reverttarget(atom/A)
@@ -199,15 +199,15 @@
 		var/initA = initial(A.alpha)
 		var/countleft = 10
 		while(countleft > 0)
-			if(!user)
+			if(!A)
 				break
 			countleft--
-			user.alpha = 0
-			sleep(3)
-			user.alpha = initA
-			sleep(1)
+			animate(A, alpha = initA, time = 5)
+			sleep(7) // yes, we want it slowly to relapse into reality
+			animate(A, alpha = 0, time = 2)
+			sleep(5)
 
-		A.alpha = initial(A.alpha)
+		A.alpha = initA
 
 /obj/item/weapon/melee/touch_attack/nothing/roundstart
 	useblacklist = TRUE

--- a/code/modules/spells/spell_types/godhand.dm
+++ b/code/modules/spells/spell_types/godhand.dm
@@ -111,13 +111,15 @@
 		..()
 		return
 
+#define MAX_INVIS_TOUCH_USES 5
+
 /obj/item/weapon/melee/touch_attack/nothing
 	name = "nothing"
 	catchphrase = "..."
 	desc = "There's nothing there"
 	icon_state = "nothing"
 	item_state = "nothing"
-	var/uses = 3
+	var/uses = 5
 	var/list/things = list()
 	var/list/blacklist = list (
 						/obj/item/weapon/bombcore,
@@ -127,7 +129,6 @@
 						/obj/item/weapon/gun/,
 						/obj/item/weapon/disk/nuclear,
 						/obj/item/weapon/storage,
-						/obj/structure/closet,
 						/obj/item/device/transfer_valve
 						)
 	var/useblacklist = FALSE
@@ -154,7 +155,7 @@
 	if(iscarbon(target))
 		if(target == user)
 			if(user.job == "Mime")
-				if(uses < 3)
+				if(uses < MAX_INVIS_TOUCH_USES)
 					user << "<span class='warning'>You've got to have more charges than that!</span>"
 					return
 				uses = 0 // we sacrifice all of our uses!
@@ -195,7 +196,20 @@
 
 /obj/item/weapon/melee/touch_attack/proc/reverttarget(atom/A)
 	if(A)
+		var/initA = initial(A.alpha)
+		var/countleft = 10
+		while(countleft > 0)
+			if(!user)
+				break
+			countleft--
+			user.alpha = 0
+			sleep(3)
+			user.alpha = initA
+			sleep(1)
+
 		A.alpha = initial(A.alpha)
 
 /obj/item/weapon/melee/touch_attack/nothing/roundstart
 	useblacklist = TRUE
+
+#undef MAX_INVIS_TOUCH_USES

--- a/code/modules/spells/spell_types/godhand.dm
+++ b/code/modules/spells/spell_types/godhand.dm
@@ -159,15 +159,9 @@
 					user << "<span class='warning'>You've got to have more charges than that!</span>"
 					return
 				uses = 0 // we sacrifice all of our uses!
-				var/passes = 5
-				while(passes > 0)
-					if(!user)
-						break
-					passes--
-					animate(user, alpha = 0, time = 1)
-					sleep(3)
-					animate(user, alpha = initial(user.alpha), time = 1)
-					sleep(2)
+				animate(user, alpha = initial(user.alpha), time = 80)
+				addtimer(src, "reverttarget", 85, FALSE, target)
+
 			else
 				user << "<span class='warning'>You have to be a mime to use this trick!</span>"
 		else
@@ -196,18 +190,7 @@
 
 /obj/item/weapon/melee/touch_attack/proc/reverttarget(atom/A)
 	if(A)
-		var/initA = initial(A.alpha)
-		var/countleft = 10
-		while(countleft > 0)
-			if(!A)
-				break
-			countleft--
-			animate(A, alpha = initA, time = 5)
-			sleep(7) // yes, we want it slowly to relapse into reality
-			animate(A, alpha = 0, time = 2)
-			sleep(5)
-
-		A.alpha = initA
+		animate(A, alpha = initial(A.alpha), time = 10)
 
 /obj/item/weapon/melee/touch_attack/nothing/roundstart
 	useblacklist = TRUE


### PR DESCRIPTION
### Intent of your Pull Request

Come on now, it's a simple trick that can barely cause any harm. Only confusion.

- It now has five uses instead of 3.
- You can use it on closets.
- When it's reverting it will vanish and reappear ten times before finally recovering.

Things that stay the same
- You can't use it on the same thing twice.
- Everything else not mentioned.

#### Changelog

:cl:
rscadd: The Mime's invisible touch can be used on more objects (3 -> 5), can be used on closets, and has a cool reversion effect on objects.
/:cl:
