### PR TITLE
Fixed security cyborg zipties not having limited charge

### DIFF
--- a/code/game/objects/items/weapons/handcuffs.dm
+++ b/code/game/objects/items/weapons/handcuffs.dm
@@ -107,27 +107,19 @@
 	origin_tech = "engineering=2"
 	breakouttime = 300 //Deciseconds = 30s
 	cuffsound = 'sound/weapons/cablecuff.ogg'
-	var/datum/robot_energy_storage/wirestorage = null
-
-/obj/item/weapon/restraints/handcuffs/cable/attack(mob/living/carbon/C, mob/living/carbon/human/user)
-	if(!istype(C))
-		return
-	if(wirestorage && wirestorage.energy < 15)
-		user << "<span class='warning'>You need at least 15 wire to restrain [C]!</span>"
-		return
-	return ..()
+	var/datum/robot_energy_storage/zipties/wirestorage = null
 
 /obj/item/weapon/restraints/handcuffs/cable/can_cuff(mob/living/carbon/target, mob/user)
-	if(wirestorage && (wirestorage.energy < 15))
+	if(wirestorage && (wirestorage.energy < 1))
 		if(user)
-			user << "<span class='warning'>You need at least 15 wire to restrain [target]!</span>"
+			user << "<span class='warning'>You need at least 1 ziptie to restrain [target]!</span>"
 		return FALSE
 	return ..(target, user)
 
 /obj/item/weapon/restraints/handcuffs/cable/apply_cuffs(mob/living/carbon/target, mob/user)
 	. = ..()
 	if(. && wirestorage)
-		wirestorage.use_charge(15)
+		wirestorage.use_charge(1)
 
 /obj/item/weapon/restraints/handcuffs/cable/attack_self(mob/user)
 		var/obj/item/stack/cable_coil/new_coil = new /obj/item/stack/cable_coil

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -76,7 +76,8 @@
 
 	if(istype(I, /obj/item/weapon/restraints/handcuffs/cable))
 		var/obj/item/weapon/restraints/handcuffs/cable/C = I
-		C.wirestorage = get_or_create_estorage(/datum/robot_energy_storage/wire)
+		world << "WEE WOO WOO WEE"
+		C.wirestorage = get_or_create_estorage(/datum/robot_energy_storage/zipties)
 
 	I.loc = src
 	modules += I
@@ -213,7 +214,7 @@
 
 /obj/item/weapon/robot_module/security/New()
 	..()
-	modules += new /obj/item/weapon/restraints/handcuffs/cable/zipties/cyborg(src)
+	add_module(new /obj/item/weapon/restraints/handcuffs/cable/zipties/cyborg(src))
 	modules += new /obj/item/weapon/melee/baton/loaded(src)
 	modules += new /obj/item/weapon/gun/energy/disabler/cyborg(src)
 	modules += new /obj/item/clothing/mask/gas/sechailer/cyborg(src)
@@ -432,3 +433,8 @@
 	max_energy = 2500
 	recharge_rate = 250
 	name = "Medical Synthesizer"
+
+/datum/robot_energy_storage/zipties
+	max_energy = 5
+	recharge_rate = 1
+	name = "Ziptie Synthesizer"

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -76,7 +76,6 @@
 
 	if(istype(I, /obj/item/weapon/restraints/handcuffs/cable))
 		var/obj/item/weapon/restraints/handcuffs/cable/C = I
-		world << "WEE WOO WOO WEE"
 		C.wirestorage = get_or_create_estorage(/datum/robot_energy_storage/zipties)
 
 	I.loc = src

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -475,11 +475,11 @@ By design, d1 is the smallest direction and d2 is the highest
 
 /obj/item/stack/cable_coil/attack_self(mob/user)
 	if(amount >= 15)
+		use(15)
 		var/obj/item/weapon/restraints/handcuffs/cable/O = new /obj/item/weapon/restraints/handcuffs/cable(src.loc)
 		user.put_in_hands(O)
 		O.item_color = item_color
 		O.update_icon()
-		use(15)
 
 
 /obj/item/stack/cable_coil/cyborg


### PR DESCRIPTION
Closes #1991

There was already code for this, but someone messed up ages ago and it was never used. I am putting this up as a feature rather than a fix because people are so used to security cyborgs having unlimited cuffs.

:cl:
fix: Security cyborg zipties now properly have a charge level, refillable at cyborg recharging stations.
/:cl:
