### PR TITLE
Removes a test object from the uplink

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1071,12 +1071,14 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	category = "Role-Restricted"
 	exclude_modes = list(/datum/game_mode/nuclear)
 
-
+/*
 /datum/uplink_item/role_restricted/dicks
 	name = "testobjyay"
 	item = /obj/item/weapon/storage/toolbox/syndicate
 	restricted_roles = list("Assistant")
-	cost = 5
+	cost = 1
+
+*/
 
 // Pointless
 /datum/uplink_item/badass

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1070,15 +1070,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 /datum/uplink_item/role_restricted
 	category = "Role-Restricted"
 	exclude_modes = list(/datum/game_mode/nuclear)
-
-/*
-/datum/uplink_item/role_restricted/dicks
-	name = "testobjyay"
-	item = /obj/item/weapon/storage/toolbox/syndicate
-	restricted_roles = list("Assistant")
-	cost = 1
-
-*/
+	//restricted_roles = list("Assistant")
 
 // Pointless
 /datum/uplink_item/badass


### PR DESCRIPTION
I used it to test the ported code, I forgot to remove it, honk.

(I commented it out for the sake of an example, keep it?)
:cl:
fix: Removes a test obj from the uplink
/:cl: