### PR TITLE
Messed with changeling DNA handling

### DIFF
--- a/code/__HELPERS/lists.dm
+++ b/code/__HELPERS/lists.dm
@@ -391,6 +391,18 @@
 		if(islist(.[i]))
 			.[i] = .(.[i])
 
+//takes an input_key, as text, and the list of keys already used, outputting a replacement key in the format of "[input_key] ([number_of_duplicates])" if it finds a duplicate
+//use this for lists of things that might have the same name, like mobs or objects, that you plan on giving to a player as input
+/proc/avoid_assoc_duplicate_keys(input_key, list/used_key_list)
+	if(!input_key || !istype(used_key_list))
+		return
+	if(used_key_list[input_key])
+		used_key_list[input_key]++
+		input_key = "[input_key] ([used_key_list[input_key]])"
+	else
+		used_key_list[input_key] = 1
+	return input_key
+
 //Picks from the list, with some safeties, and returns the "default" arg if it fails
 #define DEFAULTPICK(L, default) ((istype(L, /list) && L:len) ? pick(L) : default)
 

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -12,6 +12,7 @@
 	var/list/temporary_mutations = list() //Timers for temporary mutations
 	var/list/previous = list() //For temporary name/ui/ue/blood_type modifications
 	var/mob/living/carbon/holder
+	var/sting_extractable = TRUE //whether the DNA can be retrieved by a changeling's DNA sting
 
 /datum/dna/New(mob/living/carbon/new_holder)
 	if(new_holder)
@@ -25,6 +26,7 @@
 	destination.dna.features = features
 	destination.dna.real_name = real_name
 	destination.dna.temporary_mutations = temporary_mutations
+	destination.dna.sting_extractable = sting_extractable
 	if(transfer_SE)
 		destination.dna.struc_enzymes = struc_enzymes
 

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -436,6 +436,7 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 	user.updateappearance(mutcolor_update=1)
 	user.update_body()
 	user.domutcheck()
+	user.dna.sting_extractable = FALSE
 
 	//vars hackery. not pretty, but better than the alternative.
 	for(var/slot in slots)


### PR DESCRIPTION
This is to fix the issue addressed in https://github.com/yogstation13/yogstation/pull/1936

Stole a proc from https://github.com/tgstation/tgstation/pull/22608

Incidentally this fixes the bug where you could not transform into a person if they were named "Drop Flesh Disguise"
:cl:
tweak: Using transformation sting or hive channel DNA as a changeling will remove the DNA from the changeling who used it.
tweak: Multiple changelings cannot extract DNA from the same person using extract DNA sting, and no changeling can use extract DNA sting on someone affected by transformation sting. Absorbing the person will always work.
/:cl:
