### PR TITLE
Fixes a bug with the global print option

### DIFF
--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -425,7 +425,7 @@ What a mess.*/
 					printing = null
 			if("Print Poster")
 				if(!( printing ))
-					var/globalprint = locate(href_list["global"])
+					var/globalprint = href_list["global"]
 					var/wanted_name = stripped_input(usr, "Please enter an alias for the criminal:", "Print Wanted Poster", active1.fields["name"])
 					if(wanted_name)
 						var/default_description = "A poster declaring [wanted_name] to be a dangerous individual, wanted by Nanotrasen. Report any sightings to security immediately."


### PR DESCRIPTION
### Intent of your Pull Request

Fixes the global print option on security computers.
I think we all learned an important lesson today. Never locate() numerical values.

#### Changelog

:cl:
fix: The global print option on security computers has been restored.
/:cl:

![](http://image.prntscr.com/image/72057e4d10cc4650bc740e48d53b2ef3.png)