### PR TITLE
Removes Gang Mode

### DIFF
--- a/code/game/gamemodes/gang/gang_datum.dm
+++ b/code/game/gamemodes/gang/gang_datum.dm
@@ -81,6 +81,53 @@
 			/datum/gang_item/equipment/dominator
 		)
 
+	if(SSevent.holidays && SSevent.holidays[APRIL_FOOLS])
+		if(name == "Donk")
+			fighting_style = "honking"
+			buyable_items = list(
+			/datum/gang_item/function/gang_ping,
+			/datum/gang_item/function/recall,
+			/datum/gang_item/equipment/spraycan,
+			/datum/gang_item/equipment/c4,
+			/datum/gang_item/equipment/implant_breaker,
+			/datum/gang_item/equipment/pen,
+			/datum/gang_item/equipment/gangtool,
+			/datum/gang_item/equipment/dominator,
+			/datum/gang_item/weapon/pistol,
+			/datum/gang_item/weapon/ammo/pistol_ammo,
+			/datum/gang_item/equipment/banana,
+			/datum/gang_item/equipment/clown_mask,
+			/datum/gang_item/equipment/golden_airhorn,
+			/datum/gang_item/weapon/bananium_esword,
+			/datum/gang_item/weapon/bananium_eshield,
+			/datum/gang_item/weapon/tearstache,
+			/datum/gang_item/weapon/clownbug,
+			/datum/gang_item/weapon/dark_honk
+			)
+
+		if(name == "Zero-G")
+			fighting_style = "miming"
+			buyable_items = list(
+			/datum/gang_item/function/gang_ping,
+			/datum/gang_item/function/recall,
+			/datum/gang_item/equipment/spraycan,
+			/datum/gang_item/equipment/c4,
+			/datum/gang_item/equipment/implant_breaker,
+			/datum/gang_item/equipment/pen,
+			/datum/gang_item/equipment/gangtool,
+			/datum/gang_item/equipment/dominator,
+			/datum/gang_item/weapon/pistol,
+			/datum/gang_item/weapon/ammo/pistol_ammo,
+			/datum/gang_item/equipment/bottleofnothing,
+			/datum/gang_item/equipment/mimemask,
+			/datum/gang_item/equipment/mimearts,
+			/datum/gang_item/equipment/mimewall,
+			/datum/gang_item/equipment/mutetoxin,
+			/datum/gang_item/equipment/invisibletouch,
+			/datum/gang_item/equipment/reactivestealth,
+			/datum/gang_item/weapon/reticence
+			)
+
 	ganghud = new()
 	log_game("The [name] Gang has been created. Their gang color is [color].")
 	build_item_list()

--- a/code/game/gamemodes/gang/gang_items.dm
+++ b/code/game/gamemodes/gang/gang_items.dm
@@ -205,6 +205,122 @@
 	item_path = /obj/item/weapon/implanter/gang
 	spawn_msg = "<span class='notice'>The <b>implant breaker</b> is a single-use device that destroys all implants within the target before trying to recruit them to your gang. Also works on enemy gangsters.</span>"
 
+// APRIL FOOLS START
+/datum/gang_item/equipment/banana
+	name = "Banana"
+	id = "banana"
+	cost = 15
+	item_path = /obj/item/weapon/reagent_containers/food/snacks/grown/banana
+	spawn_msg = "<span class='notice'>Honk!</span>"
+
+/datum/gang_item/equipment/clown_mask
+	name = "Clown Mask"
+	id = "clownmask"
+	cost = 5
+	item_path = /obj/item/clothing/mask/gas/clown_hat
+	spawn_msg = "<span class='notice'>You're in the family now, son!</span>"
+
+/datum/gang_item/equipment/golden_airhorn
+	name = "Golden Airhorn"
+	id = "goldenairhorn"
+	cost = 10
+	item_path = /obj/item/device/assembly/bikehorn/golden
+	spawn_msg = "<span class='notice'>Let's get this party STARTED!</span>"
+
+/datum/gang_item/weapon/bananium_esword
+	name = "Bananum Esword"
+	id = "b_esowrd"
+	cost = 30
+	item_path = /obj/item/weapon/melee/energy/sword/bananium
+	spawn_msg = "<span class='notice'>Ooooh! You are now one with the HONK!</span>"
+
+/datum/gang_item/weapon/bananium_eshield
+	name = "Bananum Eshield"
+	id = "b_eshield"
+	cost = 60
+	item_path = /obj/item/weapon/shield/energy/bananium
+	spawn_msg = "<span class='notice'>Throw it and it comes back!</span>"
+
+/datum/gang_item/weapon/tearstache
+	name = "Tearstache Grenade"
+	id = "tearstache"
+	cost = 10
+	item_path = /obj/item/weapon/grenade/chem_grenade/teargas/moustache
+
+/datum/gang_item/weapon/clownbug
+	name = "Clownbug Delivery"
+	id = "clownbugs"
+	cost = 30
+	item_path = /obj/item/weapon/grenade/spawnergrenade/clownbugs/weak
+
+/datum/gang_item/weapon/dark_honk
+	name = "Dark H.O.N.K.E.R."
+	id = "dark_honk"
+	cost = 200
+	item_path = /obj/mecha/combat/honker/dark/loaded/aprilfools
+	spawn_msg = "<span class='notice'>The rest is up to you! Honk.</span>"
+
+
+// mimery
+
+/datum/gang_item/equipment/bottleofnothing
+	name = "Bottle of Nothing"
+	id = "bottleofnothing"
+	cost = 10
+	item_path = /obj/item/weapon/reagent_containers/food/drinks/bottle/bottleofnothing
+	spawn_msg = "<span class='notice'>...</span>"
+
+/datum/gang_item/equipment/mimemask
+	name = "Mime Mask"
+	id = "mime_mask"
+	cost = 5
+	item_path = /obj/item/clothing/mask/gas/mime
+	spawn_msg = "<span class='notice'>...</span>"
+
+/datum/gang_item/equipment/mimearts
+	name = "Mimery"
+	id = "mimerybook"
+	cost = 10
+	item_path = /obj/item/weapon/spellbook/oneuse/mime
+	spawn_msg = "<span class='notice'>...</span>"
+
+/datum/gang_item/equipment/mimewall
+	name = "Mime Wall"
+	id = "mimerywall"
+	cost = 10
+	item_path = /obj/item/weapon/spellbook/oneuse/mime_wall
+	spawn_msg = "<span class='notice'>...Make sure you've read the book of mimery before approaching this.</span>"
+
+/datum/gang_item/equipment/mutetoxin
+	name = "Bottle of Mutetoxin"
+	id = "mutetoxin"
+	cost = 20
+	item_path = /obj/item/weapon/reagent_containers/glass/bottle/mutetoxin
+	spawn_msg = "<span class='notice'>...!</span>"
+
+/datum/gang_item/equipment/invisibletouch
+	name = "Legendary Invisible Touch"
+	id = "invisibletouch"
+	cost = 50
+	item_path = /obj/item/weapon/spellbook/oneuse/invisible_touch
+	spawn_msg = "<span class='notice'>This ability has no limits.</span>"
+
+/datum/gang_item/equipment/reactivestealth
+	name = "Reactive Stealth Armor"
+	id = "reactivestealth"
+	cost = 30
+	item_path = /obj/item/clothing/suit/armor/reactive/stealth
+	spawn_msg = "<span class='notice'>...</span>"
+
+/datum/gang_item/weapon/reticence
+	name = "Reticence"
+	id = "reticence_mech"
+	cost = 200
+	item_path = /obj/mecha/combat/reticence/loaded
+	spawn_msg = "<span class='notice'>... The rest is up to you ...</span>"
+
+// APROIL FOOLS END
+
 /datum/gang_item/equipment/implant_breaker/spawn_item(mob/living/carbon/user, datum/gang/gang, obj/item/device/gangtool/gangtool)
 	if(item_path)
 		var/obj/item/O = new item_path(user.loc, gang) //we need to override this whole proc for this one argument

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -849,3 +849,33 @@
 	var/real_type = pick(subtypesof(/obj/item/weapon/spellbook/oneuse))
 	new real_type(loc)
 	qdel(src)
+
+/obj/item/weapon/spellbook/oneuse/mime
+	spell = /obj/effect/proc_holder/spell/targeted/mime/speak
+	spellname = "how to mime"
+	icon_state ="bookcharge"
+	desc = "Silence!"
+	color = "#000000"
+
+/obj/item/weapon/spellbook/oneuse/mime/attack_self(mob/user)
+	if(!used)
+		user.job = "Mime" // welcome to the family, son.
+		user << "<span class='notice'>You feel.. different.</span>"
+	..()
+
+/obj/item/weapon/spellbook/oneuse/mime_wall
+	spell = /obj/effect/proc_holder/spell/aoe_turf/conjure/mime_wall
+	spellname = "how to hide in plain sight"
+	icon_state ="bookcharge"
+	desc = "Now you see me... now there's a wall inbetween us!"
+	color = "#000000"
+
+/obj/item/weapon/spellbook/oneuse/invisible_touch
+	spell = /obj/effect/proc_holder/spell/targeted/touch/mime/strong
+	spellname = "the legendary art of the invisible touch"
+	icon_state ="bookcharge"
+	desc = "This version has no limits unlike the roundstart mimes!"
+	color = "#000000"
+
+
+

--- a/code/game/objects/items/weapons/clown_weapons.dm
+++ b/code/game/objects/items/weapons/clown_weapons.dm
@@ -273,3 +273,6 @@
 /obj/structure/mecha_wreckage/honker/dark
 	name = "\improper Dark H.O.N.K wreckage"
 	icon_state = "darkhonker-broken"
+
+/obj/mecha/combat/honker/dark/loaded/aprilfools
+	operation_req_access = list(access_theatre)

--- a/code/game/objects/items/weapons/grenades/spawnergrenade.dm
+++ b/code/game/objects/items/weapons/grenades/spawnergrenade.dm
@@ -48,3 +48,6 @@
 	name = "clown bug special"
 	spawner_type = /mob/living/simple_animal/cockroach/clownbug
 	deliveryamt = 20
+
+/obj/item/weapon/grenade/spawnergrenade/clownbugs/weak
+	deliveryamt = 3

--- a/code/modules/events/holiday/aprilfools.dm
+++ b/code/modules/events/holiday/aprilfools.dm
@@ -7,7 +7,7 @@
 	min_players = 15
 
 /datum/round_event/clown_bugs
-	var/spawncount
+	var/spawncount = 1
 
 /datum/round_event/clown_bugs/setup()
 	spawncount = rand(5, 8)
@@ -22,8 +22,6 @@
 
 	while((spawncount >= 1) && vents.len)
 		var/obj/vent = pick(vents)
-		var/obj/effect/spider/spiderling/S = new(vent.loc)
-		if(prob(66))
-			S.grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/nurse
+		new /mob/living/simple_animal/cockroach/clownbug(vent.loc)
 		vents -= vent
 		spawncount--

--- a/code/modules/events/holiday/aprilfools.dm
+++ b/code/modules/events/holiday/aprilfools.dm
@@ -1,0 +1,29 @@
+/datum/round_event_control/clownbugs
+	name = "Clown Bugs"
+	holidayID = APRIL_FOOLS
+	typepath = /datum/round_event/clown_bugs
+	weight = 40
+	max_occurrences = 2
+	min_players = 15
+
+/datum/round_event/clown_bugs
+	var/spawncount
+
+/datum/round_event/clown_bugs/setup()
+	spawncount = rand(5, 8)
+
+/datum/round_event/clown_bugs/start()
+	var/list/vents = list()
+	for(var/obj/machinery/atmospherics/components/unary/vent_pump/temp_vent in world)
+		if(temp_vent.loc.z == ZLEVEL_STATION && !temp_vent.welded)
+			var/datum/pipeline/temp_vent_parent = temp_vent.PARENT1
+			if(temp_vent_parent.other_atmosmch.len > 20)
+				vents += temp_vent
+
+	while((spawncount >= 1) && vents.len)
+		var/obj/vent = pick(vents)
+		var/obj/effect/spider/spiderling/S = new(vent.loc)
+		if(prob(66))
+			S.grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/nurse
+		vents -= vent
+		spawncount--

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -367,3 +367,9 @@
 		reagents.add_reagent(randomchem, fillrate)
 		update_icon()
 	return 1
+
+/obj/item/weapon/reagent_containers/glass/bottle/mutetoxin
+	name = "Bottle of Mutetoxin"
+	desc = "Perfect tool for a stealthy assassin."
+	icon_state = "bottle3"
+	list_reagents = list("mutetoxin" = 30)

--- a/code/modules/spells/spell_types/mime.dm
+++ b/code/modules/spells/spell_types/mime.dm
@@ -46,10 +46,11 @@
 		return
 	if(!ishuman(usr))
 		return
-	if(world.time < 15000 && !(usr.mind.special_role)) // 25 minutes
-		usr << "<span class='warning'>It's too early into the shift to do this! Play your part!"
-		return
 	var/mob/living/carbon/human/H = usr
+	if(H.mind.miming) // so if you're here to make a vow, you won't be bothered
+		if(world.time < 15000 && !(usr.mind.special_role)) // 25 minutes
+			usr << "<span class='warning'>It's too early into the shift to do this! Play your part!"
+			return
 	if(H.mind.miming)
 		still_recharging_msg = "<span class='warning'>You can't break your vow of silence that fast!</span>"
 	else
@@ -86,3 +87,8 @@
 			usr << "<span class='notice'>You don't remember how to perform this... It probably takes dedication.</span>"
 			return
 	..()
+
+/obj/effect/proc_holder/spell/targeted/touch/mime/strong
+	hand_path = "/obj/item/weapon/melee/touch_attack/nothing"
+	charge_max = 1500
+	cooldown_min = 1000

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1156,6 +1156,7 @@
 #include "code\modules\events\spontaneous_appendicitis.dm"
 #include "code\modules\events\vent_clog.dm"
 #include "code\modules\events\wormholes.dm"
+#include "code\modules\events\holiday\aprilfools.dm"
 #include "code\modules\events\holiday\halloween.dm"
 #include "code\modules\events\holiday\vday.dm"
 #include "code\modules\events\holiday\xmas.dm"


### PR DESCRIPTION
Happy april fools!
and no this pr only makes it worse.

# NOW EVERY APRIL FOOLS DAY THE GANGS DONK AND ZERO-G REVEAL THEIR TRUE IDENTITIES

Donk becomes the CLOWN GANG!

Clown Gang
- Banana's. - 15 cost
- Clown Masks. - 5 cost
- Golden Airhorn - 10 cost
- Bananaium Esword - 30 cost
- Bananaium Eshield - 60 cost
- Tearstache - 10 cost
- Clownbug Delivery (only spawns 3 this time) - 30 cost
- Dark HONK! - 200 cost

Zero-G becomes the MIME GANG!

Mime Gang
- Bottle of Nothing - 10 cost
- Mime masks - 5 cost
- Spellbook that teaches you mimery - 10 cost
- Spellbook that teaches you invisible wall - 10 cost
- Bottle of Mutetoxin - 20 cost
- Spellbook that teaches you the invisible touch (does not come with limits) - 50 cost
- Reactive Stealth Armor  - 30 cost.
- RETICENCE! - 200 cost

Unlike sleeping carp, these gangs can still buy pistols.

like i mentioned before this only happens on april fools so pls merge into master branch

#### Changelog

:cl:
rscadd: On April Fools the Donk gang turns into the clown gang and the Zero-G gang turns into the mime gang!
rscadd: On April Fools the station gets a rare case of clown bugs...
/:cl:
