### PR TITLE
Rebases Yogstation to /tg/ (Part 1/3)

### DIFF
--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -66,7 +66,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 	var/parallax_movedir = 0
 
-	var/sound_env
+	var/sound_env = ROOM
 
 /*Adding a wizard area teleport list because motherfucking lag -- Urist*/
 /*I am far too lazy to make it a proper list of areas so I'll just make it run the usual telepot routine at the start of the game*/
@@ -136,6 +136,7 @@ var/list/teleportlocs = list()
 
 /area/shuttle/arrival
 	name = "Arrival Shuttle"
+	sound_env = LARGE_ENCLOSED
 
 /area/shuttle/pod_1
 	name = "Escape Pod One"
@@ -157,21 +158,25 @@ var/list/teleportlocs = list()
 
 /area/shuttle/supply
 	name = "Supply Shuttle"
+	sound_env = LARGE_ENCLOSED
 
 /area/shuttle/escape
 	name = "Emergency Shuttle"
+	sound_env = LARGE_ENCLOSED
 
 /area/shuttle/transport
 	name = "Transport Shuttle"
 
 /area/shuttle/syndicate
 	name = "Syndicate Infiltrator"
+	sound_env = LARGE_ENCLOSED
 
 /area/shuttle/assault_pod
 	name = "Steel Rain"
 
 /area/shuttle/abandoned
 	name = "Abandoned Ship"
+	sound_env = LARGE_ENCLOSED
 
 /area/start
 	name = "start area"
@@ -180,6 +185,7 @@ var/list/teleportlocs = list()
 	luminosity = 1
 	lighting_use_dynamic = DYNAMIC_LIGHTING_DISABLED
 	has_gravity = 1
+	sound_env = PADDED_CELL
 
 // CENTCOM
 
@@ -190,6 +196,7 @@ var/list/teleportlocs = list()
 	has_gravity = 1
 	noteleport = 1
 	blob_allowed = 0 //Should go without saying, no blobs should take over centcom as a win condition.
+	sound_env = LARGE_ENCLOSED
 
 /area/centcom/control
 	name = "Centcom Docks"
@@ -227,6 +234,7 @@ var/list/teleportlocs = list()
 	has_gravity = 1
 	noteleport = 1
 	blob_allowed = 0 //Not... entirely sure this will ever come up... but if the bus makes blobs AND ops, it shouldn't aim for the ops to win.
+	sound_env = LARGE_ENCLOSED
 
 /area/syndicate_mothership/control
 	name = "Syndicate Control Room"
@@ -311,6 +319,7 @@ var/list/teleportlocs = list()
 	requires_power = 0
 	has_gravity = 1
 	noteleport = 1
+	sound_env = LARGE_ENCLOSED
 
 //Abductors
 /area/abductor_ship
@@ -319,6 +328,7 @@ var/list/teleportlocs = list()
 	requires_power = 0
 	noteleport = 1
 	has_gravity = 1
+	sound_env = SMALL_ENCLOSED
 
 
 //PRISON
@@ -346,6 +356,9 @@ var/list/teleportlocs = list()
 /area/prison/closet
 	name = "Prison Supply Closet"
 	icon_state = "dk_yellow"
+
+/area/prison/hallway/
+	sound_env = LARGE_ENCLOSED
 
 /area/prison/hallway/fore
 	name = "Prison Fore Hallway"
@@ -396,14 +409,17 @@ var/list/teleportlocs = list()
 /area/prison/cell_block/A
 	name = "Prison Cell Block A"
 	icon_state = "brig"
+	sound_env = PADDED_CELL
 
 /area/prison/cell_block/B
 	name = "Prison Cell Block B"
 	icon_state = "brig"
+	sound_env = PADDED_CELL
 
 /area/prison/cell_block/C
 	name = "Prison Cell Block C"
 	icon_state = "brig"
+	sound_env = PADDED_CELL
 
 //STATION13
 
@@ -551,6 +567,7 @@ var/list/teleportlocs = list()
 /area/crew_quarters/courtroom
 	name = "Courtroom"
 	icon_state = "courtroom"
+	sound_env = LARGE_ENCLOSED
 
 /area/crew_quarters/heads
 	name = "Head of Personnel's Office"
@@ -648,11 +665,12 @@ var/list/teleportlocs = list()
 	name = "Chapel"
 	icon_state = "chapel"
 	ambientsounds = list('sound/ambience/ambicha1.ogg','sound/ambience/ambicha2.ogg','sound/ambience/ambicha3.ogg','sound/ambience/ambicha4.ogg')
-	sound_env = LARGE_SOFTFLOOR
+	sound_env = LARGE_ENCLOSED
 
 /area/chapel/office
 	name = "Chapel Office"
 	icon_state = "chapeloffice"
+	sound_env = LARGE_SOFTFLOOR
 
 /area/lawoffice
 	name = "Law Office"
@@ -676,10 +694,12 @@ var/list/teleportlocs = list()
 /area/engine/break_room
 	name = "Engineering Foyer"
 	icon_state = "engine"
+	sound_env = LARGE_SOFTFLOOR
 
 /area/engine/chiefs_office
 	name = "Chief Engineer's office"
 	icon_state = "engine_control"
+	sound_env = SMALL_SOFTFLOOR
 
 /area/engine/secure_construction
 	name = "Secure Construction Area"
@@ -745,6 +765,7 @@ var/list/teleportlocs = list()
 /area/assembly/chargebay
 	name = "Mech Bay"
 	icon_state = "mechbay"
+	sound_env = LARGE_ENCLOSED
 
 /area/assembly/showroom
 	name = "Robotics Showroom"
@@ -753,6 +774,7 @@ var/list/teleportlocs = list()
 /area/assembly/robotics
 	name = "Robotics Lab"
 	icon_state = "ass_line"
+	sound_env = LARGE_ENCLOSED
 
 /area/assembly/assembly_line //Derelict Assembly Line
 	name = "Assembly Line"
@@ -767,6 +789,7 @@ var/list/teleportlocs = list()
 	name = "Teleporter"
 	icon_state = "teleporter"
 	music = "signal"
+	sound_env = SMALL_ENCLOSED
 
 /area/gateway
 	name = "Gateway"
@@ -785,25 +808,30 @@ var/list/teleportlocs = list()
 	name = "Medbay"
 	icon_state = "medbay"
 	music = 'sound/ambience/signal.ogg'
+	sound_env = LARGE_ENCLOSED
 
 //Medbay is a large area, these additional areas help level out APC load.
 /area/medical/medbay2
 	name = "Medbay"
 	icon_state = "medbay2"
 	music = 'sound/ambience/signal.ogg'
+	sound_env = LARGE_ENCLOSED
 
 /area/medical/medbay3
 	name = "Medbay"
 	icon_state = "medbay3"
 	music = 'sound/ambience/signal.ogg'
+	sound_env = LARGE_ENCLOSED
 
 /area/medical/patients_rooms
 	name = "Patients' Rooms"
 	icon_state = "patients"
+	sound_env = SMALL_ENCLOSED
 
 /area/medical/cmo
 	name = "Chief Medical Officer's office"
 	icon_state = "CMO"
+	sound_env = SMALL_ENCLOSED
 
 /area/medical/robotics
 	name = "Robotics"
@@ -825,14 +853,17 @@ var/list/teleportlocs = list()
 /area/medical/chemistry
 	name = "Chemistry"
 	icon_state = "chem"
+	sound_env = SMALL_ENCLOSED
 
 /area/medical/surgery
 	name = "Surgery"
 	icon_state = "surgery"
+	sound_env = LARGE_ENCLOSED
 
 /area/medical/cryo
 	name = "Cryogenics"
 	icon_state = "cryo"
+	sound_env = LARGE_ENCLOSED
 
 /area/medical/exam_room
 	name = "Exam Room"
@@ -841,14 +872,17 @@ var/list/teleportlocs = list()
 /area/medical/genetics
 	name = "Genetics Lab"
 	icon_state = "genetics"
+	sound_env = LARGE_ENCLOSED
 
 /area/medical/genetics_cloning
 	name = "Cloning Lab"
 	icon_state = "cloning"
+	sound_env = SMALL_ENCLOSED
 
 /area/medical/sleeper
 	name = "Medbay Treatment Center"
 	icon_state = "exam_room"
+	sound_env = LARGE_ENCLOSED
 
 //Security
 
@@ -859,10 +893,12 @@ var/list/teleportlocs = list()
 /area/security/brig
 	name = "Brig"
 	icon_state = "brig"
+	sound_env = LARGE_ENCLOSED
 
 /area/security/prison
 	name = "Prison Wing"
 	icon_state = "sec_prison"
+	sound_env = LARGE_ENCLOSED
 
 /area/security/processing
 	name = "Labor Shuttle Dock"
@@ -871,14 +907,17 @@ var/list/teleportlocs = list()
 /area/security/warden
 	name = "Brig Control"
 	icon_state = "Warden"
+	sound_env = LARGE_ENCLOSED
 
 /area/security/armory
 	name = "Armory"
 	icon_state = "armory"
+	sound_env = LARGE_ENCLOSED
 
 /area/security/hos
 	name = "Head of Security's Office"
 	icon_state = "sec_hos"
+	sound_env = SMALL_ENCLOSED
 
 /area/security/detectives_office
 	name = "Detective's Office"
@@ -897,6 +936,7 @@ var/list/teleportlocs = list()
 /area/security/interrogation
 	name = "\improper Interrogation"
 	icon_state = "firingrange"
+	sound_env = SMALL_ENCLOSED
 
 /*
 /area/security/transfer/New()
@@ -918,10 +958,12 @@ var/list/teleportlocs = list()
 /area/security/nuke_storage
 	name = "Vault"
 	icon_state = "nuke_storage"
+	sound_env = LARGE_ENCLOSED
 
 /area/ai_monitored/nuke_storage
 	name = "Vault"
 	icon_state = "nuke_storage"
+	sound_env = LARGE_ENCLOSED
 
 /area/security/checkpoint
 	name = "Security Checkpoint"
@@ -1005,10 +1047,12 @@ var/list/teleportlocs = list()
 /area/toxins/lab
 	name = "Research and Development"
 	icon_state = "toxlab"
+	sound_env = LARGE_ENCLOSED
 
 /area/toxins/xenobiology
 	name = "Xenobiology Lab"
 	icon_state = "toxlab"
+	sound_env = LARGE_ENCLOSED
 
 /area/toxins/storage
 	name = "Toxins Storage"
@@ -1026,6 +1070,7 @@ var/list/teleportlocs = list()
 /area/toxins/mixing
 	name = "Toxins Mixing Room"
 	icon_state = "toxmix"
+	sound_env = LARGE_ENCLOSED
 
 /area/toxins/misc_lab
 	name = "Testing Lab"
@@ -1042,6 +1087,7 @@ var/list/teleportlocs = list()
 /area/toxins/telesci
 	name = "\improper Telescience Lab"
 	icon_state = "toxtest"
+	sound_env = LARGE_ENCLOSED
 
 /area/toxins/toxlab
 	name = "\improper Toxins Lab"
@@ -1072,6 +1118,7 @@ var/list/teleportlocs = list()
 /area/storage/eva
 	name = "EVA Storage"
 	icon_state = "eva"
+	sound_env = LARGE_ENCLOSED
 
 /area/storage/secure
 	name = "Secure Storage"
@@ -1213,6 +1260,7 @@ var/list/teleportlocs = list()
 /area/construction
 	name = "Construction Area"
 	icon_state = "yellow"
+	sound_env = LARGE_ENCLOSED
 
 /area/construction/supplyshuttle
 	name = "Supply Shuttle"
@@ -1275,10 +1323,12 @@ var/list/teleportlocs = list()
 /area/turret_protected/ai_upload_foyer
 	name = "AI Upload Access"
 	icon_state = "ai_foyer"
+	sound_env = LARGE_ENCLOSED
 
 /area/turret_protected/ai
 	name = "AI Chamber"
 	icon_state = "ai_chamber"
+	sound_env = LARGE_ENCLOSED
 
 /area/turret_protected/aisat
 	name = "AI Satellite"
@@ -1351,6 +1401,7 @@ var/list/teleportlocs = list()
 // Telecommunications Satellite
 
 /area/tcommsat
+	sound_env = LARGE_ENCLOSED
 	ambientsounds = list('sound/ambience/ambisin2.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/signal.ogg', 'sound/ambience/ambigen10.ogg')
 
 /area/tcommsat/entrance
@@ -1401,6 +1452,7 @@ var/list/teleportlocs = list()
 	//icon_state = "NAME OF ICON"
 	requires_power = 0
 	music = "music/music.ogg"
+	sound_env = LARGE_ENCLOSED // AHAHAHHAHAHA I'm not even sorry.
 
 /area/hell/trial1
 	name = "Hell Trial1"
@@ -1441,6 +1493,7 @@ var/list/teleportlocs = list()
 	requires_power = 0
 	has_gravity = 1
 	ambientsounds = list('sound/ambience/shore.ogg', 'sound/ambience/seag1.ogg','sound/ambience/seag2.ogg','sound/ambience/seag2.ogg')
+	sound_env = PLAIN
 
 /area/spacecontent
 	name = "space"

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -102,7 +102,7 @@
 		var/mob/M = src
 		if(M.client)
 			if(!M.client.prefs.soundenv)
-				S.environment = GENERIC
+				S.environment = ROOM
 	src << S
 
 /mob/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, surround = 1)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -22,6 +22,7 @@
 
 /atom/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, surround = 1, var/is_global)
 	soundin = get_sfx(soundin)
+	world << "AAAAA!"
 
 	var/sound/S = sound(soundin)
 	S.wait = 0 //No queue
@@ -97,6 +98,11 @@
 		else
 			var/area/A = get_area(src)
 			S.environment = A.sound_env
+	if(istype(src, /mob))
+		var/mob/M = src
+		if(M.client)
+			if(!M.client.prefs.soundenv)
+				S.environment = GENERIC
 	src << S
 
 /mob/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, surround = 1)
@@ -105,13 +111,13 @@
 	..()
 
 /mob/proc/stopLobbySound()
-	src << sound(null, repeat = 0, wait = 0, volume = 85, channel = 1)
+	src << nullify_sound(null, repeat = 0, wait = 0, volume = 85, channel = 1)
 
 /client/proc/playtitlemusic()
 	if(!ticker || !ticker.login_music)
 		return
 	if(prefs && (prefs.toggles & SOUND_LOBBY))
-		src << sound(ticker.login_music, repeat = 0, wait = 0, volume = 85, channel = 1) // MAD JAMS
+		src << nullify_sound(ticker.login_music, repeat = 0, wait = 0, volume = 85, channel = 1) // MAD JAMS
 
 /proc/get_rand_frequency()
 	return rand(32000, 55000) //Frequency stuff only works with 45kbps oggs.
@@ -148,3 +154,9 @@
 /proc/playsound_global(file, repeat=0, wait, channel, volume)
 	for(var/V in clients)
 		V << sound(file, repeat, wait, channel, volume)
+
+/proc/nullify_sound(file, repeat, wait, volume, channel)
+	var/sound/S = sound(file, repeat, wait, volume, channel)
+	S.environment = ROOM
+	S.echo = 0
+	return S

--- a/code/modules/admin/tickets/admin_ticket.dm
+++ b/code/modules/admin/tickets/admin_ticket.dm
@@ -99,14 +99,14 @@ var/ticket_counter_visible_to_everyone = 0
 		handling_admin << "<span class='ticket-text-sent'>Ticket created by you for [is_admin(handling_admin) ? key_name_params(ntarget, 1, 1, null, src) : key_name_params(ntarget, 1, 0, null, src)]: \"[admin_title]\"</span>"
 		log += new /datum/ticket_log(src, usr, "Ticket created by <b>[handling_admin] for [ntarget]</b>", 0)
 		if(has_pref(owner, SOUND_ADMINHELP))
-			owner << 'sound/effects/adminhelp.ogg'
+			owner << nullify_sound('sound/effects/adminhelp.ogg')
 		if(has_pref(handling_admin, SOUND_ADMINHELP))
-			handling_admin << 'sound/effects/adminhelp.ogg'
+			handling_admin << nullify_sound('sound/effects/adminhelp.ogg')
 	else
 		log += new /datum/ticket_log(src, usr, "Ticket created by <b>[owner]</b>", 0)
 		owner << "<span class='ticket-status'>Ticket created for Admins: \"[title]\"</span>"
 		if(has_pref(owner, SOUND_ADMINHELP))
-			owner << 'sound/effects/adminhelp.ogg'
+			owner << nullify_sound('sound/effects/adminhelp.ogg')
 
 	if(usr.client.holder && owner && !owner.holder && compare_ckey(usr, handling_admin) && force_popup)
 		spawn()	//so we don't hold the caller proc up
@@ -136,7 +136,7 @@ var/ticket_counter_visible_to_everyone = 0
 			if(invalid)
 				admin_number_decrease++
 			if(has_pref(X, SOUND_ADMINHELP))
-				X << 'sound/effects/adminhelp.ogg'
+				X << nullify_sound('sound/effects/adminhelp.ogg')
 			X << msg
 
 	var/admin_number_present = admin_number_total - admin_number_decrease	//Number of admins who are neither afk nor invalid

--- a/code/modules/admin/tickets/admin_ticket_procs.dm
+++ b/code/modules/admin/tickets/admin_ticket_procs.dm
@@ -51,7 +51,7 @@
 			messageSentTo += get_ckey(handling_admin)
 			handling_admin << "<span class='ticket-text-received'>-- [get_view_link(user)] [key_name_params(user, 1, 1, null, src)] -> [log_item.isAdminComment() ? get_view_link(user) : key_name_params(handling_admin, 0, 1, null, src)]: [log_item.text]</span>"
 			if(has_pref(handling_admin, SOUND_ADMINHELP))
-				handling_admin << 'sound/effects/adminhelp.ogg'
+				handling_admin << nullify_sound('sound/effects/adminhelp.ogg')
 
 	if(!log_item.for_admins && compare_ckey(owner_ckey, user) || compare_ckey(handling_admin, user))
 		if(!(get_ckey(owner) in messageSentTo))
@@ -60,7 +60,7 @@
 			if(!compare_ckey(owner_ckey, user))
 				if(!is_admin(owner)) owner << "<span class='ticket-header-recieved'>-- Administrator private message --</span>"
 				if(has_pref(owner, SOUND_ADMINHELP))
-					owner << 'sound/effects/adminhelp.ogg'
+					owner << nullify_sound('sound/effects/adminhelp.ogg')
 
 			if(compare_ckey(owner_ckey, user))
 				var/toLink
@@ -93,7 +93,7 @@
 			M << "<span class='ticket-text-received'>-- [get_view_link(user)] [key_name_params(user, 1, 1, null, src)] -> [key_name_params(handling_admin, 0, 1, null, src)]: [log_item.text_admin]</span>"
 
 		if(has_pref(M, SOUND_ADMINHELP))
-			M << 'sound/effects/adminhelp.ogg'
+			M << nullify_sound('sound/effects/adminhelp.ogg')
 
 	for(var/client/X in admins)
 		if(has_pref(X, TICKET_ALL))
@@ -136,7 +136,7 @@
 			for(var/client/X in admins)
 				X << "<span class='ticket-status'>[get_view_link(X)] is still unclaimed.</span>"
 				if(has_pref(X, SOUND_ADMINHELP))
-					X << 'sound/effects/adminhelp.ogg'
+					X << nullify_sound('sound/effects/adminhelp.ogg')
 
 /datum/admin_ticket/proc/toggle_monitor()
 	var/foundMonitor = 0

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -100,6 +100,8 @@ var/list/preferences_datums = list()
 	var/quiet_round = 0
 	var/purrbation = null
 
+	var/soundenv = TRUE
+
 /datum/preferences/New(client/C)
 	custom_names["ai"] = pick(ai_names)
 	custom_names["cyborg"] = pick(ai_names)

--- a/code/modules/client/verbs/echo.dm
+++ b/code/modules/client/verbs/echo.dm
@@ -1,0 +1,6 @@
+/client/verb/toggle_sound_env()
+	set name = "Toggle Echo Effect"
+	set category = "Preferences"
+	set desc = "Environments in this game and your characters condition can affect the sound you hear. Toggle whether you want that off or on."
+	prefs.soundenv = !prefs.soundenv
+	src << "Environments will [prefs.soundenv ? "now affect the sound you hear" : "no longer affecc the sound you hear"]."

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -153,6 +153,7 @@ var/const/VOX_DELAY = 600
 
 		var/sound_file = vox_sounds[word]
 		var/sound/voice = sound(sound_file, wait = 2, channel = VOX_CHANNEL)
+		voice.environment = GENERIC
 		voice.status = SOUND_STREAM
 
  		// If there is no single listener, broadcast to everyone in the same z level

--- a/code/orphaned_procs/priority_announce.dm
+++ b/code/orphaned_procs/priority_announce.dm
@@ -28,7 +28,7 @@
 		if(!istype(M,/mob/new_player) && !M.ear_deaf)
 			M << announcement
 			if(M.client.prefs.toggles & SOUND_ANNOUNCEMENTS)
-				M << sound(sound)
+				M << nullify_sound(sound)
 
 /proc/print_command_report(text = "", title = "Central Command Update")
 	for (var/obj/machinery/computer/communications/C in machines)
@@ -49,6 +49,6 @@
 			M << "<b><font size = 3><font color = red>[title]</font color><BR>[message]</font size></b><BR>"
 			if(M.client.prefs.toggles & SOUND_ANNOUNCEMENTS)
 				if(alert)
-					M << sound('sound/misc/notice1.ogg')
+					M << nullify_sound('sound/misc/notice1.ogg')
 				else
-					M << sound('sound/misc/notice2.ogg')
+					M << nullify_sound('sound/misc/notice2.ogg')

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1050,6 +1050,7 @@
 #include "code\modules\client\preferences.dm"
 #include "code\modules\client\preferences_savefile.dm"
 #include "code\modules\client\preferences_toggles.dm"
+#include "code\modules\client\verbs\echo.dm"
 #include "code\modules\client\verbs\ooc.dm"
 #include "code\modules\client\verbs\sethotkeys.dm"
 #include "code\modules\client\verbs\suicide.dm"


### PR DESCRIPTION
rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase 

rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase 
rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase 

rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase rebase 

Happy April Fools Day (again)!

This PR installs a preference option to disable bay sounds.
This PR will also nullify global sounds (announcements, vox sounds, admin helps) from being affected by the area you're in.

#### Changelog

:cl:
rscadd: Global / OOC sounds will no longer be affected by your environment (admin helps, vox, communication announcements).
rscadd: There is now a preference option to disable bay sounds...for all you bay haters.
/:cl: