### PR TITLE
Fixed the recycler breaking the laws of physics by pulling qdeleted items from the event horizon of nullspace

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -109,9 +109,12 @@ var/const/SAFETY_COOLDOWN = 100
 		eat(AM)
 
 /obj/machinery/recycler/proc/eat(atom/AM0, sound=TRUE)
-	var/list/to_eat = list(AM0)
+	var/list/to_eat
 	if(istype(AM0, /obj/item))
-		to_eat += AM0.GetAllContents()
+		to_eat = AM0.GetAllContents()
+	else
+		to_eat = list(AM0)
+
 	var/items_recycled = 0
 
 	for(var/i in to_eat)


### PR DESCRIPTION
Fixes #2117

The list returned by GetAllContents() contains the item it was called on, so the item would be in the recycle list twice. The first time the item was eaten, it would be qdeleted, and the second time it would be moved to the crusher's loc but not qdeleted because it had already been qdeleted. No one usually noticed because qdeleting an item makes it invisible, but you can still slip on invisible banana peels.