### PR TITLE
Reduce The Speed of Swarmers

### DIFF
--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer.dm
@@ -89,7 +89,7 @@
 	attacktext = "shocks"
 	attack_sound = 'sound/effects/EMPulse.ogg'
 	friendly = "pinches"
-	speed = 0
+	speed = 1
 	faction = list("swarmer")
 	AIStatus = AI_OFF
 	pass_flags = PASSTABLE


### PR DESCRIPTION

### Intent of your Pull Request

Swarmers are both small and fast, which makes even one of them able to stand up ridiculously well against the crew, even when the crew has a large numbers advantage. Making them a little slower makes it more realistic to hit them.

#### Changelog

:cl:
tweak: Swarmers now move slightly slower.
/:cl:
