### PR TITLE
Disarming a live nuclear Bomb

### DIFF
--- a/code/game/gamemodes/nuclear/nuclearbomb.dm
+++ b/code/game/gamemodes/nuclear/nuclearbomb.dm
@@ -84,7 +84,7 @@ var/bomb_set
 
 	switch(deconstruction_state)
 		if(NUKESTATE_INTACT)
-			if(istype(I, /obj/item/weapon/screwdriver/nuke))
+			if(istype(I, /obj/item/weapon/screwdriver))
 				playsound(loc, 'sound/items/Screwdriver.ogg', 100, 1)
 				user << "<span class='notice'>You start removing [src]'s front panel's screws...</span>"
 				if(do_after(user, 60/I.toolspeed,target=src))


### PR DESCRIPTION
This was blocked previously by the snowflake coded "nuke screwdriver" that was identical in every way to the regular screwdriver except for this tiny change. Now the crew has an incentive to try to stop the live nuke before it kills everyone. They'll struggle with the massive bursts of radiation, though.


PLEASE NOTE: This is a LOT! harder than you think it would be to pull off, and this mechanic isn't uncommon, except on many servers its even easier to do!
### Intent of your Pull Request

The crew can take apart a live nuclear bomb now, but they'll have to deal with massive bursts of radiation to do so. This makes the end not seem quite so futile for the crew.

#### Changelog

:cl:
tweak: Nuclear bombs are now equipped with larger screws for easier plutonium extraction and insertion. All standard screwdrivers can open the panel .
/:cl:
