### PR TITLE
[s] Fixes 2 bugs/exploits

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -221,14 +221,11 @@
 	if(!clockwork_component_cache["replicant_alloy"])
 		user << "<span class='warning'>There is no Replicant Alloy in the global component cache!</span>"
 		return 0
-	if(clockwork_component_cache["replicant_alloy"])
-		clockwork_component_cache["replicant_alloy"]--
-		var/obj/item/clockwork/component/replicant_alloy/A = new(get_turf(src))
-		user.visible_message("<span class='notice'>[user] withdraws [A] from [src].</span>", "<span class='notice'>You withdraw [A] from [src].</span>")
-		user.put_in_hands(A)
-		return 1
-	else
-		..()
+	clockwork_component_cache["replicant_alloy"]--
+	var/obj/item/clockwork/component/replicant_alloy/A = new(get_turf(src))
+	user.visible_message("<span class='notice'>[user] withdraws [A] from [src].</span>", "<span class='notice'>You withdraw [A] from [src].</span>")
+	user.put_in_hands(A)
+	return 1
 
 /obj/structure/clockwork/cache/examine(mob/user)
 	..()

--- a/code/game/gamemodes/clock_cult/clock_structures.dm
+++ b/code/game/gamemodes/clock_cult/clock_structures.dm
@@ -221,10 +221,14 @@
 	if(!clockwork_component_cache["replicant_alloy"])
 		user << "<span class='warning'>There is no Replicant Alloy in the global component cache!</span>"
 		return 0
-	var/obj/item/clockwork/component/replicant_alloy/A = new(get_turf(src))
-	user.visible_message("<span class='notice'>[user] withdraws [A] from [src].</span>", "<span class='notice'>You withdraw [A] from [src].</span>")
-	user.put_in_hands(A)
-	return 1
+	if(clockwork_component_cache["replicant_alloy"])
+		clockwork_component_cache["replicant_alloy"]--
+		var/obj/item/clockwork/component/replicant_alloy/A = new(get_turf(src))
+		user.visible_message("<span class='notice'>[user] withdraws [A] from [src].</span>", "<span class='notice'>You withdraw [A] from [src].</span>")
+		user.put_in_hands(A)
+		return 1
+	else
+		..()
 
 /obj/structure/clockwork/cache/examine(mob/user)
 	..()

--- a/code/game/machinery/computer/computer.dm
+++ b/code/game/machinery/computer/computer.dm
@@ -117,7 +117,7 @@
 			erase_data()
 			for (var/obj/C in src)
 				C.loc = src.loc
-			if (stat & BROKEN)
+			if ((stat & BROKEN) || computer_health != initial(src.computer_health))
 				user << "<span class='notice'>The broken glass falls out.</span>"
 				new /obj/item/weapon/shard(src.loc)
 				new /obj/item/weapon/shard(src.loc)


### PR DESCRIPTION
Fixes being able to pull an infinite amount of replicant alloy out of a cache

Fixes being able to repair partially broken screens by screwdrivering it. Screwdrivering a partially broken screen will now break it, cuz fuck you for exploiting my feature.

:cl:
fix: Fixes infinite replicant alloy bug
fix: Fixes instant repairing screens with screwdriver
/:cl:
