### PR TITLE
Printing a library book no longer reloads screen

### DIFF
--- a/code/modules/library/lib_machines.dm
+++ b/code/modules/library/lib_machines.dm
@@ -460,6 +460,8 @@ var/global/list/datum/cachedbook/cachedbooks // List of our cached book datums
 			say("Book has been sent to the printing queue!")
 			if(!print_busy && print_queue.len)
 				print_book(print_queue[1])
+				src.add_fingerprint(usr)
+				return
 		else
 			say("The printing queue is full!")
 	src.add_fingerprint(usr)


### PR DESCRIPTION
In a similar situation, the exosuit fabricator does not reload the screen when not changing it. In the case of the library, this proc made it so your screen jumped upwards, making you have to scroll for each book. WELL I SAY 

Refer to issue #1838 

### Intent of your Pull Request

Making printing books not be a massive pain in the ass

#### Changelog

:cl:
fix: The library computer has received a hardware update. Printing books no longer restarts the computer.
/:cl:
