### PR TITLE
removes pulling from bots

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -111,6 +111,7 @@
 
 /mob/living/simple_animal/bot/New()
 	..()
+	verbs -= /mob/living/verb/pulled //no pulling people around as medbot and shit
 	access_card = new /obj/item/weapon/card/id(src)
 //This access is so bots can be immediately set to patrol and leave Robotics, instead of having to be let out first.
 	access_card.access += access_robotics


### PR DESCRIPTION

![aborting](https://cloud.githubusercontent.com/assets/17034893/25113466/4054da76-23bd-11e7-9a21-2320002d5304.PNG)
![cru](https://cloud.githubusercontent.com/assets/17034893/25113469/45ff90ce-23bd-11e7-963b-3b6f91cad434.PNG)

:cl: ShadowDeath6
rscdel: Removed pulling from simple animal bots. Yes, this means pAI medbots and the wizard ED-201.
/:cl:
