### PR TITLE
Fix echo effect settings toggle notification typo

### DIFF
--- a/code/modules/client/verbs/echo.dm
+++ b/code/modules/client/verbs/echo.dm
@@ -3,4 +3,4 @@
 	set category = "Preferences"
 	set desc = "Environments in this game and your characters condition can affect the sound you hear. Toggle whether you want that off or on."
 	prefs.soundenv = !prefs.soundenv
-	src << "Environments will [prefs.soundenv ? "now affect the sound you hear" : "no longer affecc the sound you hear"]."
+	src << "Environments will [prefs.soundenv ? "now affect the sound you hear" : "no longer affect the sound you hear"]."


### PR DESCRIPTION
Fix echo effect settings toggle notification typo

#### Changelog

:cl:
spellcheck: Fix echo effect settings toggle notification typo.
/:cl:
