### PR TITLE
Fixes emergency shelters accepting doms

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -197,6 +197,7 @@
 	icon_state = "away"
 	requires_power = 0
 	has_gravity = 1
+	valid_territory = 0
 
 /obj/item/weapon/survivalcapsule
 	name = "bluespace shelter capsule"


### PR DESCRIPTION
You could make an emergency shelter in space and place a dom there, now you can't
:cl:
fix: fixes being able to place doms in emergency shelters
/:cl: