### PR TITLE
blobbernauts have less max health and lose health faster when off blob

### DIFF
--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -196,8 +196,8 @@
 	icon_state = "blobbernaut"
 	icon_living = "blobbernaut"
 	icon_dead = "blobbernaut_dead"
-	health = 140
-	maxHealth = 140
+	health = 160
+	maxHealth = 160
 	damage_coeff = list(BRUTE = 0.5, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 	next_move_modifier = 1.5 //slow-ass attack speed, 3 times higher than how fast the blob can attack
 	melee_damage_lower = 20

--- a/code/game/gamemodes/blob/blobs/blob_mobs.dm
+++ b/code/game/gamemodes/blob/blobs/blob_mobs.dm
@@ -196,8 +196,8 @@
 	icon_state = "blobbernaut"
 	icon_living = "blobbernaut"
 	icon_dead = "blobbernaut_dead"
-	health = 200
-	maxHealth = 200
+	health = 140
+	maxHealth = 140
 	damage_coeff = list(BRUTE = 0.5, BURN = 1, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 	next_move_modifier = 1.5 //slow-ass attack speed, 3 times higher than how fast the blob can attack
 	melee_damage_lower = 20
@@ -231,7 +231,7 @@
 			damagesources++
 		if(damagesources)
 			for(var/i in 1 to damagesources)
-				adjustHealth(maxHealth*0.025) //take 2.5% maxhealth as damage when not near the blob or if the naut has no factory, 5% if both
+				adjustHealth(maxHealth*0.05) //take 5% maxhealth as damage when not near the blob or if the naut has no factory, 10% if both
 			var/list/viewing = list()
 			for(var/mob/M in viewers(src))
 				if(M.client)

--- a/code/modules/reagents/chemistry/reagents/blob_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/blob_reagents.dm
@@ -656,9 +656,9 @@
 					if(setting_type)
 						var/atom/throw_target = get_edge_target_turf(X, get_dir(X, get_step_away(X, pull)))
 						var/throw_range = 5 - distance
-						X.throw_at_fast(throw_target, throw_range, 1)
+						X.throw_at(throw_target, throw_range, 1)
 					else
-						X.throw_at_fast(pull, distance, 1)
+						X.throw_at(pull, distance, 1)
 				else
 					spawn(0)
 						if(setting_type)


### PR DESCRIPTION
makes blobbernauts slightly more defensive
also this fixes an "oversight" I forgot to fix when I made blobbernauts heal twice as fast since they can actually outheal the damage from losing their factory which is really dumb
also makes sorium not stun you by slamming you into walls fuck you

:cl: ShadowDeath6
tweak: Blobbernauts now die more quickly upon losing their factory.
tweak: Blobbernauts die more quickly off of the blow.
tweak: Sorium blob doesn't stun you anymore.
tweak: Lowers blobbernaut max health from 200 to 160.
/:cl:
