### PR TITLE
reinforced walls can't be burnt by clf3 anymore

### DIFF
--- a/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/pyrotechnic_reagents.dm
@@ -69,6 +69,8 @@
 					PoolOrNew(/obj/effect/hotspot, F)
 	if(istype(T, /turf/closed/wall/))
 		var/turf/closed/wall/W = T
+		if(W.walltype = "rwall") //use thermite
+			return
 		if(prob(reac_volume))
 			W.ChangeTurf(/turf/open/floor/plating)
 
@@ -79,6 +81,7 @@
 			M.IgniteMob()
 			if(!locate(/obj/effect/hotspot) in M.loc)
 				PoolOrNew(/obj/effect/hotspot, M.loc)
+
 /datum/reagent/sorium
 	name = "Sorium"
 	id = "sorium"


### PR DESCRIPTION
if adam complains about me nerfing this I'm gonna be pretty mad

:cl: ShadowDeath6
rscdel: Reinforced walls can't be burnt by chlorine triflouride anymore.
/:cl:
