### PR TITLE
Quick ore pick up + quick sandbag deployment

### DIFF
--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -59,6 +59,7 @@ var/global/list/datum/stack_recipe/sandstone_recipes = list ( \
 
 /obj/item/stack/sheet/mineral/sandbags
 	name = "sandbags"
+	desc = "Use this on the ground to quickly deploy barricades."
 	icon = 'icons/obj/items.dmi'
 	icon_state = "sandbags"
 	singular_name = "sandbag"

--- a/code/game/objects/items/stacks/sheets/mineral.dm
+++ b/code/game/objects/items/stacks/sheets/mineral.dm
@@ -76,6 +76,27 @@ var/global/list/datum/stack_recipe/sandbag_recipes = list ( \
 	pixel_y = rand(0,4)-4
 	..()
 
+/obj/item/stack/sheet/mineral/sandbags/afterattack(atom/target, mob/user)
+	if(istype(target, /turf/open/floor))
+		var/turf/open/floor/F = target
+		var/occupied
+		for(var/obj/structure/barricade/sandbags/S in F)
+			if(occupied)
+				occupied = TRUE
+				break
+		if(occupied)
+			user << "<span class='notice'>A sandbag is already deployed in that spot.</span>"
+			return
+
+		user << "<span class='notice'>You start building a barricade...</span>"
+		if(do_after(user, 25, target = F))
+			new /obj/structure/barricade/sandbags(get_turf(F))
+			use(1)
+			user << "<span class='notice'>You construct a sand barricade.</span>"
+		else
+			user << "<span class='notice'>You have been interrupted!</span>"
+		return 1
+
 /*
  * Diamond
  */

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -52,17 +52,6 @@
 				return
 		coil.place_turf(src, user)
 		return 1
-	if(istype(C, /obj/item/stack/sheet/mineral/sandbags))
-		var/obj/item/stack/sheet/mineral/sandbags/S = C
-		user << "<span class='notice'>You start building a barricade...</span>"
-		if(do_after(user, 30, target = src))
-			new /obj/structure/barricade/sandbags(get_turf(src))
-			S.use(1)
-			user << "<span class='notice'>You construct a sand barricade.</span>"
-		else
-			user << "<span class='notice'>You have been interrupted!</span>"
-		return 1
-
 	return 0
 
 /turf/Enter(atom/movable/mover as mob|obj, atom/forget as mob|obj|turf|area)

--- a/code/game/turfs/turf.dm
+++ b/code/game/turfs/turf.dm
@@ -52,6 +52,16 @@
 				return
 		coil.place_turf(src, user)
 		return 1
+	if(istype(C, /obj/item/stack/sheet/mineral/sandbags))
+		var/obj/item/stack/sheet/mineral/sandbags/S = C
+		user << "<span class='notice'>You start building a barricade...</span>"
+		if(do_after(user, 30, target = src))
+			new /obj/structure/barricade/sandbags(get_turf(src))
+			S.use(1)
+			user << "<span class='notice'>You construct a sand barricade.</span>"
+		else
+			user << "<span class='notice'>You have been interrupted!</span>"
+		return 1
 
 	return 0
 

--- a/code/modules/mining/orecapsule.dm
+++ b/code/modules/mining/orecapsule.dm
@@ -3,6 +3,7 @@
 	desc = "A small one-use capsule that summons an orebox."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "capsule2"
+	w_class = 1
 	var/obj/structure/ore_box/box
 
 /obj/item/orecapsule/attack_self(mob/user)

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -28,7 +28,8 @@
 		var/turf/T = get_turf(src)
 		for(var/obj/item/weapon/ore/O in T)
 			if(orestorage.can_be_inserted(O))
-				orestorage.handle_item_insertion(O, 1, user = H)
+				if(O.loc == T)
+					orestorage.handle_item_insertion(O, 1, user = H)
 
 /obj/item/weapon/ore/uranium
 	name = "uranium ore"

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -17,6 +17,19 @@
 			user << "<span class='info'>Not enough fuel to smelt [src].</span>"
 	..()
 
+/obj/item/weapon/ore/Crossed(atom/movable/AM as mob|obj)
+	if(ishuman(AM))
+		var/mob/living/carbon/human/H = AM
+		var/obj/item/weapon/storage/bag/ore/orestorage
+		if(istype(H.r_hand, /obj/item/weapon/storage/bag/ore))
+			orestorage = H.r_hand
+		else if(istype(H.l_hand, /obj/item/weapon/storage/bag/ore))
+			orestorage = H.l_hand
+		var/turf/T = get_turf(src)
+		for(var/obj/item/weapon/ore/O in T)
+			if(orestorage.can_be_inserted(O))
+				orestorage.handle_item_insertion(O, 1, user = H)
+
 /obj/item/weapon/ore/uranium
 	name = "uranium ore"
 	icon_state = "Uranium ore"


### PR DESCRIPTION
### Intent of your Pull Request

- You can now deploy sandbag barricades by clicking on floors instead of having to open the construction menu
- Walking over ore with a mining satchel will automatically pick it up. No, I did not port this from /tg/. Though I did hear about the system, so I thought I was already making a PR to clear up tedious shit miners have to go through so why not code it from scratch.

#### Changelog

:cl:
rscadd: You can now deploy sandbags easier! Try clicking on a floortile with a bag in your hand.
rscadd: You can now walk over ore with a mining satchel in hand to pick it up.
/:cl: