### PR TITLE
Fixes empty necro chests

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -10,7 +10,7 @@
 
 /obj/structure/closet/crate/necropolis/tendril/New()
 	..()
-	var/loot = rand(1,24)
+	var/loot = rand(1,23)
 	switch(loot)
 		if(1)
 			new /obj/item/device/shared_storage/red(src)


### PR DESCRIPTION
Fixes https://github.com/yogstation13/yogstation/issues/2237

this happened when cruix changed 24 to another number.

#### Changelog

:cl:
rscadd: Fixes necropolis chests giving miners NOTHING
/:cl:
