### PR TITLE
medical healing stuff balancing

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -106,7 +106,7 @@
 	icon_state = "brutepack"
 	heal_brute = 40
 	origin_tech = "biotech=2"
-	self_delay = 20
+	self_delay = 0
 
 /obj/item/stack/medical/gauze
 	name = "medical gauze"
@@ -136,4 +136,4 @@
 	icon_state = "ointment"
 	heal_burn = 40
 	origin_tech = "biotech=2"
-	self_delay = 20
+	self_delay = 0

--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -106,7 +106,7 @@
 	icon_state = "brutepack"
 	heal_brute = 40
 	origin_tech = "biotech=2"
-	self_delay = 0
+	self_delay = 10
 
 /obj/item/stack/medical/gauze
 	name = "medical gauze"
@@ -136,4 +136,4 @@
 	icon_state = "ointment"
 	heal_burn = 40
 	origin_tech = "biotech=2"
-	self_delay = 0
+	self_delay = 10

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -8,7 +8,7 @@
 	volume = 50
 	apply_type = PATCH
 	apply_method = "apply"
-	self_delay = 30		// three seconds
+	self_delay = 30  // three seconds
 
 /obj/item/weapon/reagent_containers/pill/patch/afterattack(obj/target, mob/user , proximity)
 	return // thanks inheritance again

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -9,7 +9,7 @@
 	var/apply_type = INGEST
 	var/apply_method = "swallow"
 	var/roundstart = 0
-	var/self_delay = 0 //pills are instant, this is because patches inheret their aplication from pills
+	var/self_delay = 0 //pills are instant, this is because patches inherit their aplication from pills
 
 /obj/item/weapon/reagent_containers/pill/New()
 	..()
@@ -29,9 +29,8 @@
 
 	if(M == user)
 		M.visible_message("<span class='notice'>[user] attempts to [apply_method] [src].</span>")
-		if(self_delay)
-			if(!do_mob(user, M, self_delay))
-				return 0
+		if(!do_mob(user, user, self_delay))
+			return 0
 		M << "<span class='notice'>You [apply_method] [src].</span>"
 
 	else


### PR DESCRIPTION
apparently patches were supposed to have a delay but there's some weird thing that I can't figure out where both pills AND patches will either always have the same delay or never have a delay and if someone could tell me how to fix that I would appreciate it because it'd make the separation of the two much more fine

also the stacking stuff like bruise packs and ointment don't have a self-app delay because nobody uses those unless they don't want to waste patches, but since it's isolated to one limb and it's very finite and burst-healing, I doubt that it could be effectively abused as much as patches are

:cl: ShadowDeath6
tweak: Bruise packs and ointment no longer have a delay.
tweak: Pills and patches now have a delay- 3 seconds to apply.
/:cl:
