### PR TITLE
Chameleon HUD's are no longer exposed by helptext

### DIFF
--- a/code/modules/clothing/glasses/hud.dm
+++ b/code/modules/clothing/glasses/hud.dm
@@ -76,16 +76,19 @@
 	icon_state = "securityhud"
 	origin_tech = "magnets=3;combat=2"
 	hud_type = DATA_HUD_SECURITY_ADVANCED
+	var/syndicate = FALSE
 
 /obj/item/clothing/glasses/hud/security/examine(mob/user)
 	. = ..()
-	user << "<span class='notice'>To operate the criminal status of someone in range,  ALT + SHIFT and click on the target.</span>"
-	user << "<span class='notice'>To add crimes and comments to a person, hold CTRL + SHIFT and click on the target</span>"
+	if(!syndicate)
+		user << "<span class='notice'>To operate the criminal status of someone in range,  ALT + SHIFT and click on the target.</span>"
+		user << "<span class='notice'>To add crimes and comments to a person, hold CTRL + SHIFT and click on the target</span>"
 
 /obj/item/clothing/glasses/hud/security/chameleon
 	name = "Chameleon Security HUD"
 	desc = "A stolen security HUD integrated with Syndicate chameleon technology. Toggle to disguise the HUD. Provides flash protection."
 	flash_protect = 1
+	syndicate = TRUE
 
 /obj/item/clothing/glasses/hud/security/chameleon/attack_self(mob/user)
 	chameleon(user)


### PR DESCRIPTION
Fixes https://github.com/yogstation13/yogstation/issues/2254

#### Changelog

:cl:
fix: Removes the securityHUD helptext from chameleon glasses
/:cl:
