### PR TITLE
Adds jaunter beacons to survival capsule fridge

### DIFF
--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -569,6 +569,9 @@
 		var/obj/item/device/instrument/guitar/G = new(src)
 		load(G)
 
+	new /obj/item/device/jauntbeacon(src)
+	new /obj/item/weapon/wrench(src)
+
 //Fans
 /obj/structure/fans
 	icon = 'icons/obj/lavaland/survival_pod.dmi'


### PR DESCRIPTION
#### Changelog

:cl:
rscadd: Undeployed jaunter beacons and wrenches spawn in the survival capsule vendor.
/:cl:
