### PR TITLE
Removes spider vomit from changelings

### DIFF
--- a/code/game/gamemodes/changeling/powers/spiders.dm
+++ b/code/game/gamemodes/changeling/powers/spiders.dm
@@ -1,16 +1,18 @@
-/obj/effect/proc_holder/changeling/spiders
-	name = "Spread Infestation"
-	desc = "Our form divides, creating arachnids which will grow into deadly beasts."
-	helptext = "The spiders are thoughtless creatures, and may attack their creators when fully grown. Requires at least 5 DNA absorptions."
-	chemical_cost = 45
-	dna_cost = 1
-	req_dna = 5
-
+///obj/effect/proc_holder/changeling/spiders
+//	name = "Spread Infestation"
+//	desc = "Our form divides, creating arachnids which will grow into deadly beasts."
+//	helptext = "The spiders are thoughtless creatures, and may attack their creators when fully grown. Requires at least 5 DNA absorptions."
+//	chemical_cost = 45
+//	dna_cost = 1
+//	req_dna = 0
+//
 //Makes some spiderlings. Good for setting traps and causing general trouble.
-/obj/effect/proc_holder/changeling/spiders/sting_action(mob/user)
-	for(var/i=0, i<2, i++)
-		var/obj/effect/spider/spiderling/S = new(user.loc)
-		S.grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/hunter
+///obj/effect/proc_holder/changeling/spiders/sting_action(mob/user)
+//	for(var/i=0, i<2, i++)
+//		var/obj/effect/spider/spiderling/S = new(user.loc)
+//		S.grow_as = /mob/living/simple_animal/hostile/poison/giant_spider/hunter
+//
+//	feedback_add_details("changeling_powers","SI")
+//	return 1
 
-	feedback_add_details("changeling_powers","SI")
-	return 1
+// commented out by matskuman5 on 8.6.2017. just enables murderbone


### PR DESCRIPTION
1. It's a pretty worthless ability that is useful for only murderbone and causing chaos

2. It allows absorb murderboning because "oh I'm absorbing to get 5 absorbs so I can get spiders"

:cl:
rscdel: Changeling spider vomit ability has been removed.
/:cl:
