### PR TITLE
Added shuttle navigation computers for the syndicate shuttle and assault pod

### DIFF
--- a/_maps/map_files/Yogstation/yogstation.2.1.3.dmm
+++ b/_maps/map_files/Yogstation/yogstation.2.1.3.dmm
@@ -68488,6 +68488,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"DYZ" = (
+/obj/machinery/computer/camera_advanced/shuttle_docker/syndicate,
+/turf/open/floor/plasteel/shuttle{
+	icon_state = "shuttlefloor4"
+	},
+/area/shuttle/syndicate)
 "FCq" = (
 /obj/structure/table,
 /obj/item/weapon/stock_parts/subspace/ansible,
@@ -79777,7 +79783,7 @@ aaa
 aaa
 aaa
 aah
-aak
+aal
 aak
 aak
 aag
@@ -80034,8 +80040,8 @@ aaa
 aaa
 aaa
 aah
-aal
-aak
+DYZ
+aaq
 aak
 aag
 aay

--- a/code/game/gamemodes/miniantags/abduction/machinery/camera.dm
+++ b/code/game/gamemodes/miniantags/abduction/machinery/camera.dm
@@ -2,7 +2,6 @@
 	name = "Human Observation Console"
 	var/team = 0
 	networks = list("SS13","Abductor")
-	off_action = new/datum/action/innate/camera_off/abductor //specific datum
 	var/datum/action/innate/teleport_in/tele_in_action = new
 	var/datum/action/innate/teleport_out/tele_out_action = new
 	var/datum/action/innate/teleport_self/tele_self_action = new
@@ -21,29 +20,37 @@
 	eyeobj.icon_state = "camera_target"
 
 /obj/machinery/computer/camera_advanced/abductor/GrantActions(mob/living/carbon/user)
-	off_action.target = user
-	off_action.Grant(user)
+	..()
 
-	jump_action.target = user
-	jump_action.Grant(user)
-	//TODO : add null checks
-	tele_in_action.target = console.pad
-	tele_in_action.Grant(user)
+	if(tele_in_action)
+		tele_in_action.target = console.pad
+		tele_in_action.Grant(user)
+		actions += tele_in_action
 
-	tele_out_action.target = console
-	tele_out_action.Grant(user)
+	if(tele_out_action)
+		tele_out_action.target = console
+		tele_out_action.Grant(user)
+		actions += tele_out_action
 
-	tele_self_action.target = console.pad
-	tele_self_action.Grant(user)
+	if(tele_self_action)
+		tele_self_action.target = console.pad
+		tele_self_action.Grant(user)
+		actions += tele_self_action
 
-	vest_mode_action.target = console
-	vest_mode_action.Grant(user)
+	if(vest_mode_action)
+		vest_mode_action.target = console
+		vest_mode_action.Grant(user)
+		actions += vest_mode_action
 
-	vest_disguise_action.target = console
-	vest_disguise_action.Grant(user)
+	if(vest_disguise_action)
+		vest_disguise_action.target = console
+		vest_disguise_action.Grant(user)
+		actions += vest_disguise_action
 
-	set_droppoint_action.target = console
-	set_droppoint_action.Grant(user)
+	if(set_droppoint_action)
+		set_droppoint_action.target = console
+		set_droppoint_action.Grant(user)
+		actions += set_droppoint_action
 
 /obj/machinery/computer/camera_advanced/abductor/proc/IsScientist(mob/living/carbon/human/H)
 	var/datum/species/abductor/S = H.dna.species
@@ -53,30 +60,6 @@
 	if(!isabductor(user))
 		return
 	return ..()
-
-/datum/action/innate/camera_off/abductor/Activate()
-	if(!target || !iscarbon(target))
-		return
-	var/mob/living/carbon/C = target
-	var/mob/camera/aiEye/remote/remote_eye = C.remote_control
-	var/obj/machinery/computer/camera_advanced/abductor/origin = remote_eye.origin
-	origin.current_user = null
-	origin.jump_action.Remove(C)
-	origin.tele_in_action.Remove(C)
-	origin.tele_out_action.Remove(C)
-	origin.tele_self_action.Remove(C)
-	origin.vest_mode_action.Remove(C)
-	origin.vest_disguise_action.Remove(C)
-	origin.set_droppoint_action.Remove(C)
-	remote_eye.eye_user = null
-	C.reset_perspective(null)
-	if(C.client)
-		C.client.images -= remote_eye.user_image
-		for(var/datum/camerachunk/chunk in remote_eye.visibleCameraChunks)
-			C.client.images -= chunk.obscured
-	C.remote_control = null
-	C.unset_machine()
-	src.Remove(C)
 
 
 /datum/action/innate/teleport_in

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -3,24 +3,46 @@
 	desc = "Used to access the various cameras on the station."
 	icon_screen = "cameras"
 	icon_keyboard = "security_key"
+	var/z_lock = null // Lock use to this zlevel
 	var/mob/camera/aiEye/remote/eyeobj
-	var/mob/living/carbon/human/current_user = null
+	var/mob/living/current_user = null
 	var/list/networks = list("SS13")
 	var/datum/action/innate/camera_off/off_action = new
 	var/datum/action/innate/camera_jump/jump_action = new
+	var/list/actions = list()
 
 /obj/machinery/computer/camera_advanced/proc/CreateEye()
 	eyeobj = new()
 	eyeobj.origin = src
 
-/obj/machinery/computer/camera_advanced/proc/GrantActions(mob/living/carbon/user)
-	off_action.target = user
-	off_action.Grant(user)
-	jump_action.target = user
-	jump_action.Grant(user)
+/obj/machinery/computer/camera_advanced/proc/GrantActions(mob/living/user)
+	if(off_action)
+		off_action.target = user
+		off_action.Grant(user)
+		actions += off_action
+
+	if(jump_action)
+		jump_action.target = user
+		jump_action.Grant(user)
+		actions += jump_action
+
+/obj/machinery/computer/camera_advanced/proc/remove_eye_control(mob/living/user)
+	if(!user)
+		return
+	for(var/V in actions)
+		var/datum/action/A = V
+		A.Remove(user)
+	if(user.client)
+		user.reset_perspective(null)
+		eyeobj.RemoveImages()
+	eyeobj.eye_user = null
+	user.remote_control = null
+
+	current_user = null
+	user.unset_machine()
 
 /obj/machinery/computer/camera_advanced/check_eye(mob/user)
-	if( (stat & (NOPOWER|BROKEN)) || !Adjacent(user) || user.eye_blind || user.incapacitated() )
+	if( (stat & (NOPOWER|BROKEN)) || (!Adjacent(user) && !user.has_unlimited_silicon_privilege) || user.eye_blind || user.incapacitated() )
 		user.unset_machine()
 
 /obj/machinery/computer/camera_advanced/Destroy()
@@ -28,35 +50,37 @@
 		current_user.unset_machine()
 	if(eyeobj)
 		qdel(eyeobj)
+		eyeobj = null
 	return ..()
 
 /obj/machinery/computer/camera_advanced/on_unset_machine(mob/M)
 	if(M == current_user)
-		off_action.Activate()
+		remove_eye_control(M)
 
 /obj/machinery/computer/camera_advanced/attack_hand(mob/user)
 	if(current_user)
-		user << "The console is already in use!"
-		return
-	if(!iscarbon(user))
+		user << "<span class='notice'>The console is already in use!</span>"
 		return
 	if(..())
 		return
-	var/mob/living/carbon/L = user
+	var/mob/living/L = user
 
 	if(!eyeobj)
 		CreateEye()
+		if(!eyeobj)
+			user << "<span class='warning'>Error - no available camera</span>"
+			return
 
-	if(!eyeobj.initialized)
+	if(!eyeobj.eye_initialized)
 		var/camera_location
 		for(var/obj/machinery/camera/C in cameranet.cameras)
-			if(!C.can_use())
+			if(!C.can_use() || z_lock && C.z != z_lock)
 				continue
-			if(C.network&networks)
+			if(C.network & networks)
 				camera_location = get_turf(C)
 				break
 		if(camera_location)
-			eyeobj.initialized = 1
+			eyeobj.eye_initialized = TRUE
 			give_eye_control(L)
 			eyeobj.setLoc(camera_location)
 		else
@@ -65,6 +89,11 @@
 		give_eye_control(L)
 		eyeobj.setLoc(eyeobj.loc)
 
+/obj/machinery/computer/camera_advanced/attack_robot(mob/user)
+	return attack_hand(user)
+
+/obj/machinery/computer/camera_advanced/attack_ai(mob/user)
+	return //AIs would need to disable their own camera procs to use the console safely. Bugs happen otherwise.
 
 
 /obj/machinery/computer/camera_advanced/proc/give_eye_control(mob/user)
@@ -74,21 +103,40 @@
 	eyeobj.name = "Camera Eye ([user.name])"
 	user.remote_control = eyeobj
 	user.reset_perspective(eyeobj)
+	eyeobj.setLoc(eyeobj.loc)
 
 /mob/camera/aiEye/remote
 	name = "Inactive Camera Eye"
 	var/sprint = 10
 	var/cooldown = 0
 	var/acceleration = 1
-	var/mob/living/carbon/human/eye_user = null
+	var/mob/living/eye_user = null
 	var/obj/machinery/computer/camera_advanced/origin
-	var/initialized = 0
+	var/eye_initialized = 0
 	var/visible_icon = 0
 	var/image/user_image = null
 
+/mob/camera/aiEye/remote/update_remote_sight(mob/living/user)
+	user.see_invisible = SEE_INVISIBLE_LIVING //can't see ghosts through cameras
+	user.sight = 0
+	user.see_in_dark = 2
+	return 1
+
+/mob/camera/aiEye/remote/RemoveImages()
+	..()
+	if(visible_icon)
+		var/client/C = GetViewerClient()
+		if(C)
+			C.images -= user_image
+
 /mob/camera/aiEye/remote/Destroy()
+	if(origin)
+		var/obj/machinery/computer/camera_advanced/console = origin
+		origin = null
+		console.eyeobj = null
+		if(eye_user)
+			console.remove_eye_control(eye_user)
 	eye_user = null
-	origin = null
 	return ..()
 
 /mob/camera/aiEye/remote/GetViewerClient()
@@ -102,7 +150,8 @@
 			return
 		T = get_turf(T)
 		loc = T
-		cameranet.visibility(src)
+		if(use_static)
+			cameranet.visibility(src)
 		if(visible_icon)
 			if(eye_user.client)
 				eye_user.client.images -= user_image
@@ -119,7 +168,7 @@
 	for(var/i = 0; i < max(sprint, initial); i += 20)
 		var/turf/step = get_turf(get_step(src, direct))
 		if(step)
-			src.setLoc(step)
+			setLoc(step)
 
 	cooldown = world.timeofday + 5
 	if(acceleration)
@@ -132,37 +181,29 @@
 	button_icon_state = "camera_off"
 
 /datum/action/innate/camera_off/Activate()
-	if(!target || !iscarbon(target))
+	if(!target || !isliving(target))
 		return
-	var/mob/living/carbon/C = target
+	var/mob/living/C = target
 	var/mob/camera/aiEye/remote/remote_eye = C.remote_control
-	remote_eye.origin.current_user = null
-	remote_eye.origin.jump_action.Remove(C)
-	remote_eye.eye_user = null
-	if(C.client)
-		C.reset_perspective(null)
-		if(remote_eye.visible_icon)
-			C.client.images -= remote_eye.user_image
-		for(var/datum/camerachunk/chunk in remote_eye.visibleCameraChunks)
-			C.client.images -= chunk.obscured
-	C.remote_control = null
-	C.unset_machine()
-	src.Remove(C)
+	var/obj/machinery/computer/camera_advanced/console = remote_eye.origin
+	console.remove_eye_control(target)
 
 /datum/action/innate/camera_jump
 	name = "Jump To Camera"
 	button_icon_state = "camera_jump"
 
 /datum/action/innate/camera_jump/Activate()
-	if(!target || !iscarbon(target))
+	if(!target || !isliving(target))
 		return
-	var/mob/living/carbon/C = target
+	var/mob/living/C = target
 	var/mob/camera/aiEye/remote/remote_eye = C.remote_control
 	var/obj/machinery/computer/camera_advanced/origin = remote_eye.origin
 
 	var/list/L = list()
 
 	for (var/obj/machinery/camera/cam in cameranet.cameras)
+		if(origin.z_lock && cam.z != origin.z_lock)
+			continue
 		L.Add(cam)
 
 	camera_sort(L)
@@ -170,12 +211,12 @@
 	var/list/T = list()
 
 	for (var/obj/machinery/camera/netcam in L)
-		var/list/tempnetwork = netcam.network&origin.networks
+		var/list/tempnetwork = netcam.network & origin.networks
 		if (tempnetwork.len)
-			T[text("[][]", netcam.c_tag, (netcam.can_use() ? null : " (Deactivated)"))] = netcam
-
+			T["[netcam.c_tag][netcam.can_use() ? null : " (Deactivated)"]"] = netcam
 
 	var/camera = input("Choose which camera you want to view", "Cameras") as null|anything in T
 	var/obj/machinery/camera/final = T[camera]
+	playsound(src, "terminal_type", 25, 0)
 	if(final)
 		remote_eye.setLoc(get_turf(final))

--- a/code/modules/mob/living/silicon/ai/freelook/eye.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/eye.dm
@@ -10,6 +10,7 @@
 	var/list/visibleCameraChunks = list()
 	var/mob/living/silicon/ai/ai = null
 	var/relay_speech = FALSE
+	var/use_static = TRUE
 
 // Use this when setting the aiEye's location.
 // It will also stream the chunk that the new loc is in.
@@ -21,7 +22,8 @@
 			return
 		T = get_turf(T)
 		loc = T
-		cameranet.visibility(src)
+		if(use_static)
+			cameranet.visibility(src)
 		if(ai.client)
 			ai.client.eye = src
 		update_parallax_contents()
@@ -37,6 +39,11 @@
 	if(ai)
 		return ai.client
 	return null
+
+/mob/camera/aiEye/proc/RemoveImages()
+	if(use_static)
+		for(var/datum/camerachunk/chunk in visibleCameraChunks)
+			chunk.remove(src)
 
 /mob/camera/aiEye/Destroy()
 	if(ai)

--- a/code/modules/research/xenobiology/xenobio_camera.dm
+++ b/code/modules/research/xenobiology/xenobio_camera.dm
@@ -16,7 +16,6 @@
 	name = "Slime management console"
 	desc = "A computer used for remotely handling slimes."
 	networks = list("SS13")
-	off_action = new/datum/action/innate/camera_off/xenobio
 	var/datum/action/innate/slime_place/slime_place_action = new
 	var/datum/action/innate/slime_pick_up/slime_up_action = new
 	var/datum/action/innate/feed_slime/feed_slime_action = new
@@ -38,23 +37,27 @@
 	eyeobj.icon_state = "camera_target"
 
 /obj/machinery/computer/camera_advanced/xenobio/GrantActions(mob/living/carbon/user)
-	off_action.target = user
-	off_action.Grant(user)
+	..()
 
-	jump_action.target = user
-	jump_action.Grant(user)
+	if(slime_up_action)
+		slime_up_action.target = src
+		slime_up_action.Grant(user)
+		actions += slime_up_action
 
-	slime_up_action.target = src
-	slime_up_action.Grant(user)
+	if(slime_place_action)
+		slime_place_action.target = src
+		slime_place_action.Grant(user)
+		actions += slime_place_action
 
-	slime_place_action.target = src
-	slime_place_action.Grant(user)
+	if(feed_slime_action)
+		feed_slime_action.target = src
+		feed_slime_action.Grant(user)
+		actions += feed_slime_action
 
-	feed_slime_action.target = src
-	feed_slime_action.Grant(user)
-
-	monkey_recycle_action.target = src
-	monkey_recycle_action.Grant(user)
+	if(monkey_recycle_action)
+		monkey_recycle_action.target = src
+		monkey_recycle_action.Grant(user)
+		actions += monkey_recycle_action
 
 
 /obj/machinery/computer/camera_advanced/xenobio/attack_hand(mob/user)
@@ -81,29 +84,6 @@
 			user << "<span class='notice'>You fill [src] with the monkey cubes stored in [O]. [src] now has [monkeys] monkey cubes stored.</span>"
 		return
 	..()
-
-/datum/action/innate/camera_off/xenobio/Activate()
-	if(!target || !ishuman(target))
-		return
-	var/mob/living/carbon/C = target
-	var/mob/camera/aiEye/remote/xenobio/remote_eye = C.remote_control
-	var/obj/machinery/computer/camera_advanced/xenobio/origin = remote_eye.origin
-	origin.current_user = null
-	origin.jump_action.Remove(C)
-	origin.slime_place_action.Remove(C)
-	origin.slime_up_action.Remove(C)
-	origin.feed_slime_action.Remove(C)
-	origin.monkey_recycle_action.Remove(C)
-	//All of this stuff below could probably be a proc for all advanced cameras, only the action removal needs to be camera specific
-	remote_eye.eye_user = null
-	C.reset_perspective(null)
-	if(C.client)
-		C.client.images -= remote_eye.user_image
-		for(var/datum/camerachunk/chunk in remote_eye.visibleCameraChunks)
-			C.client.images -= chunk.obscured
-	C.remote_control = null
-	C.unset_machine()
-	src.Remove(C)
 
 
 /datum/action/innate/slime_place

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -1,0 +1,227 @@
+/obj/machinery/computer/camera_advanced/shuttle_docker
+	name = "navigation computer"
+	desc = "Used to designate a precise transit location for a spacecraft."
+	z_lock = ZLEVEL_STATION
+	jump_action = null
+	var/datum/action/innate/shuttledocker_rotate/rotate_action = new
+	var/datum/action/innate/shuttledocker_place/place_action = new
+	var/shuttleId = ""
+	var/shuttlePortId = ""
+	var/shuttlePortName = ""
+	var/list/jumpto_ports = list()
+	var/list/blacklisted_turfs = list()
+	var/obj/docking_port/stationary/my_port
+	var/view_range = 7
+	var/x_offset = 0
+	var/y_offset = 0
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/GrantActions(mob/living/user)
+	if(jumpto_ports.len)
+		jump_action = new /datum/action/innate/camera_jump/shuttle_docker
+	..()
+
+	if(rotate_action)
+		rotate_action.target = user
+		rotate_action.Grant(user)
+		actions += rotate_action
+
+	if(place_action)
+		place_action.target = user
+		place_action.Grant(user)
+		actions += place_action
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/CreateEye()
+	var/obj/docking_port/mobile/M = SSshuttle.getShuttle(shuttleId)
+	if(!M)
+		return
+	eyeobj = new /mob/camera/aiEye/remote/shuttle_docker()
+	var/mob/camera/aiEye/remote/shuttle_docker/the_eye = eyeobj
+	the_eye.origin = src
+	the_eye.dir = M.dir
+	var/area/A = M.areaInstance
+	if(!A)
+		return
+	var/turf/origin = locate(M.x + x_offset, M.y + y_offset, M.z)
+	for(var/turf/T in A)
+		if(T.z != origin.z)
+			continue
+		var/image/I = image('icons/effects/alphacolors.dmi', origin, "red")
+		I.layer = ABOVE_NORMAL_TURF_LAYER
+		I.plane = 0
+		I.mouse_opacity = 0
+		var/x_off = T.x - origin.x
+		var/y_off = T.y - origin.y
+		I.pixel_x = x_off * 32
+		I.pixel_y = y_off * 32
+		the_eye.placement_images[I] = list(x_off, y_off)
+	generateBlacklistedTurfs()
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/give_eye_control(mob/user)
+	..()
+	if(user && user.client)
+		var/mob/camera/aiEye/remote/shuttle_docker/the_eye = eyeobj
+		user.client.images += the_eye.placement_images
+		user.client.images += the_eye.placed_images
+		user.client.view = view_range
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/remove_eye_control(mob/living/user)
+	..()
+	if(user && user.client)
+		var/mob/camera/aiEye/remote/shuttle_docker/the_eye = eyeobj
+		user.client.images -= the_eye.placement_images
+		user.client.images -= the_eye.placed_images
+		user.client.view = world.view
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/proc/placeLandingSpot()
+	if(!checkLandingSpot())
+		return FALSE
+	var/mob/camera/aiEye/remote/shuttle_docker/the_eye = eyeobj
+	if(!my_port)
+		my_port = new /obj/docking_port/stationary
+		my_port.name = shuttlePortName
+		my_port.id = shuttlePortId
+		var/obj/docking_port/mobile/M = SSshuttle.getShuttle(shuttleId)
+		my_port.height = M.height
+		my_port.width = M.width
+		my_port.dheight = M.dheight
+		my_port.dwidth = M.dwidth
+	my_port.dir = the_eye.dir
+	my_port.loc = locate(eyeobj.x - x_offset, eyeobj.y - y_offset, eyeobj.z)
+	if(current_user && current_user.client)
+		current_user.client.images -= the_eye.placed_images
+
+	for(var/V in the_eye.placed_images)
+		qdel(V)
+	the_eye.placed_images = list()
+
+	for(var/V in the_eye.placement_images)
+		var/turf/T = locate(eyeobj.x + the_eye.placement_images[V][1], eyeobj.y + the_eye.placement_images[V][2], eyeobj.z)
+		var/image/I = image('icons/effects/alphacolors.dmi', T, "blue")
+		I.layer = ABOVE_OPEN_TURF_LAYER
+		I.plane = 0
+		I.mouse_opacity = 0
+		the_eye.placed_images += I
+
+	if(current_user && current_user.client)
+		current_user.client.images += the_eye.placed_images
+	return TRUE
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/proc/rotateLandingSpot()
+	var/mob/camera/aiEye/remote/shuttle_docker/the_eye = eyeobj
+	the_eye.dir = turn(the_eye.dir, -90)
+	for(var/V in the_eye.placement_images)
+		var/image/I = V
+		var/list/coords = the_eye.placement_images[V]
+		var/Tmp = coords[1]
+		coords[1] = coords[2]
+		coords[2] = -Tmp
+
+		I.pixel_x = coords[1] * 32
+		I.pixel_y = coords[2] * 32
+	var/Tmp = x_offset
+	x_offset = y_offset
+	y_offset = -Tmp
+	checkLandingSpot()
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/proc/checkLandingTurf(turf/T)
+	return T && !blacklisted_turfs[T]
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/proc/generateBlacklistedTurfs()
+	for(var/V in SSshuttle.stationary)
+		if(!V)
+			continue
+		var/obj/docking_port/stationary/S = V
+		if(z_lock && (S.z != z_lock))
+			continue
+		if((S.id == shuttlePortId) || (S.id in jumpto_ports))
+			continue
+		for(var/T in S.return_turfs())
+			blacklisted_turfs[T] = TRUE
+
+/obj/machinery/computer/camera_advanced/shuttle_docker/proc/checkLandingSpot()
+	var/mob/camera/aiEye/remote/shuttle_docker/the_eye = eyeobj
+	var/turf/eyeturf = get_turf(the_eye)
+	if(!eyeturf)
+		return
+	var/landing_spot_clear = TRUE
+	for(var/V in the_eye.placement_images)
+		var/image/I = V
+		I.loc = eyeturf
+		var/list/coords = the_eye.placement_images[V]
+		var/turf/T = locate(eyeturf.x + coords[1], eyeturf.y + coords[2], eyeturf.z)
+		if(checkLandingTurf(T))
+			I.icon_state = "green"
+		else
+			I.icon_state = "red"
+			landing_spot_clear = FALSE
+	return landing_spot_clear
+
+/mob/camera/aiEye/remote/shuttle_docker
+	visible_icon = FALSE
+	use_static = FALSE
+	var/list/placement_images = list()
+	var/list/placed_images = list()
+
+/mob/camera/aiEye/remote/shuttle_docker/setLoc(T)
+	..()
+	var/obj/machinery/computer/camera_advanced/shuttle_docker/console = origin
+	console.checkLandingSpot()
+
+/mob/camera/aiEye/remote/shuttle_docker/update_remote_sight(mob/living/user)
+	user.sight = BLIND|SEE_TURFS
+	return 1
+
+/datum/action/innate/shuttledocker_rotate
+	name = "Rotate"
+	button_icon_state = "mech_cycle_equip_off"
+
+/datum/action/innate/shuttledocker_rotate/Activate()
+	if(!target || !isliving(target))
+		return
+	var/mob/living/C = target
+	var/mob/camera/aiEye/remote/remote_eye = C.remote_control
+	var/obj/machinery/computer/camera_advanced/shuttle_docker/origin = remote_eye.origin
+	origin.rotateLandingSpot()
+
+/datum/action/innate/shuttledocker_place
+	name = "Place"
+	button_icon_state = "mech_zoom_off"
+
+/datum/action/innate/shuttledocker_place/Activate()
+	if(!target || !isliving(target))
+		return
+	var/mob/living/C = target
+	var/mob/camera/aiEye/remote/remote_eye = C.remote_control
+	var/obj/machinery/computer/camera_advanced/shuttle_docker/origin = remote_eye.origin
+	if(origin.placeLandingSpot())
+		target << "<span class='notice'>Transit location designated</span>"
+	else
+		target << "<span class='warning'>Invalid transit location</span>"
+
+/datum/action/innate/camera_jump/shuttle_docker
+	name = "Jump to Location"
+	button_icon_state = "camera_jump"
+
+/datum/action/innate/camera_jump/shuttle_docker/Activate()
+	if(!target || !isliving(target))
+		return
+	var/mob/living/C = target
+	var/mob/camera/aiEye/remote/remote_eye = C.remote_control
+	var/obj/machinery/computer/camera_advanced/shuttle_docker/console = remote_eye.origin
+
+	var/list/L = list()
+	for(var/V in SSshuttle.stationary)
+		if(!V)
+			continue
+		var/obj/docking_port/stationary/S = V
+		if(console.z_lock && (S.z != console.z_lock))
+			continue
+		if(S.id in console.jumpto_ports)
+			L[S.name] = S
+
+	var/selected = input("Choose location to jump to", "Locations", null) as null|anything in L
+	if(selected)
+		var/turf/T = get_turf(L[selected])
+		if(T)
+			remote_eye.setLoc(T)
+			target << "<span class='notice'>Jumped to location [selected]</span>"

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -7,7 +7,7 @@
 	icon_keyboard = "syndie_key"
 	req_access = list(access_syndicate)
 	shuttleId = "syndicate"
-	possible_destinations = "syndicate_away;syndicate_z5;syndicate_ne;syndicate_nw;syndicate_n;syndicate_se;syndicate_sw;syndicate_s"
+	possible_destinations = "syndicate_away;syndicate_z5;syndicate_ne;syndicate_nw;syndicate_n;syndicate_se;syndicate_sw;syndicate_s;syndicate_custom"
 
 /obj/machinery/computer/shuttle/syndicate/recall
 	name = "syndicate shuttle recall terminal"
@@ -37,21 +37,22 @@
 	syndicate_shuttle_boards -= src
 	return ..()
 
-/obj/machinery/computer/shuttle/syndicate/drop_pod
-	name = "syndicate assault pod control"
-	icon = 'icons/obj/terminals.dmi'
-	icon_state = "dorm_available"
-	req_access = list(access_syndicate)
-	shuttleId = "steel_rain"
-	possible_destinations = null
-	clockwork = TRUE //it'd look weird
+/obj/machinery/computer/camera_advanced/shuttle_docker/syndicate
+	name = "syndicate shuttle navigation computer"
+	desc = "Used to designate a precise transit location for the syndicate shuttle."
+	icon_screen = "syndishuttle"
+	icon_keyboard = "syndie_key"
+	z_lock = ZLEVEL_STATION
+	shuttleId = "syndicate"
+	shuttlePortId = "syndicate_custom"
+	shuttlePortName = "custom location"
+	jumpto_ports = list("syndicate_away", "syndicate_z5", "syndicate_ne", "syndicate_nw", "syndicate_n", "syndicate_se", "syndicate_sw", "syndicate_s")
+	view_range = 13
+	x_offset = -4
+	y_offset = -2
 
-/obj/machinery/computer/shuttle/syndicate/drop_pod/Topic(href, href_list)
-	if(href_list["move"])
-		if(z != ZLEVEL_CENTCOM)
-			usr << "<span class='warning'>Pods are one way!</span>"
-			return 0
-	..()
 
+/obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/checkLandingTurf(turf/T)
+	return ..() && isspaceturf(T)
 
 #undef SYNDICATE_CHALLENGE_TIMER

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1848,6 +1848,7 @@
 #include "code\modules\shuttle\emergency.dm"
 #include "code\modules\shuttle\ferry.dm"
 #include "code\modules\shuttle\manipulator.dm"
+#include "code\modules\shuttle\navigation_computer.dm"
 #include "code\modules\shuttle\shuttle.dm"
 #include "code\modules\shuttle\special.dm"
 #include "code\modules\shuttle\supply.dm"


### PR DESCRIPTION
The syndicate shuttle now has a navigation computer right next to the shuttle computer that lets you target any area on the station z-level that does not have any part of the shuttle intersect with a non-space turf or a shuttle docking turf. The person targeting the location gets a meson view of the station.

![shuttle](https://user-images.githubusercontent.com/16478175/27013698-548b1abe-4ea6-11e7-8409-a4b6adadea18.png)

The assault pod gets a similar interface, but it can target non-space turfs. It might need a slight nerf if people start using it in creative ways.

:cl:
rscadd: The syndicate shuttle and assault pod can now have their exact landing locations set by camera.
/:cl:
