### PR TITLE
Fixes admin messages/logs for singularities

### DIFF
--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -31,12 +31,11 @@
 //Academy Items
 
 /obj/singularity/academy
+	name = "magical gravitational singularity"
 	dissipate = 0
 	move_self = 0
 	grav_pull = 1
-
-/obj/singularity/academy/admin_investigate_setup()
-	return
+	notify_admins = FALSE
 
 /obj/singularity/academy/process()
 	eat()

--- a/code/modules/power/singularity/narsie.dm
+++ b/code/modules/power/singularity/narsie.dm
@@ -5,6 +5,7 @@
 	pixel_x = -89
 	pixel_y = -85
 	density = 0
+	notify_admins = FALSE
 	current_size = 9 //It moves/eats like a max-size singulo, aside from range. --NEO
 	contained = 0 //Are we going to move around?
 	dissipate = 0 //Do we lose energy over time?
@@ -136,6 +137,7 @@
 //Wizard narsie
 /obj/singularity/narsie/wizard
 	grav_pull = 0
+	notify_admins = FALSE
 
 /obj/singularity/narsie/wizard/eat()
 	set background = BACKGROUND_ENABLED

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -10,6 +10,7 @@
 	layer = MASSIVE_OBJ_LAYER
 	luminosity = 6
 	unacidable = 1 //Don't comment this out.
+	var/notify_admins = TRUE
 	var/current_size = 1
 	var/allowed_size = 1
 	var/contained = 1 //Are we going to move around?
@@ -32,7 +33,8 @@
 
 /obj/singularity/New(loc, var/starting_energy = 50, var/temp = 0)
 	//CARN: admin-alert for chuckle-fuckery.
-	admin_investigate_setup()
+	if(notify_admins)
+		admin_investigate_setup()
 
 	src.energy = starting_energy
 	..()
@@ -72,7 +74,8 @@
 	switch(severity)
 		if(1)
 			if(current_size <= STAGE_TWO)
-				investigate_log("has been destroyed by a heavy explosion.","singulo")
+				if(notify_admins)
+					investigate_log("has been destroyed by a heavy explosion.","singulo")
 				qdel(src)
 				return
 			else
@@ -213,7 +216,7 @@
 	if(rotation_time != cur_rotation)
 		SpinAnimation(rotation_time, segments = 8)
 		cur_rotation = rotation_time
-	if(current_size == allowed_size)
+	if((current_size == allowed_size) && notify_admins)
 		investigate_log("<font color='red'>grew to size [current_size]</font>","singulo")
 		return 1
 	else if(current_size < (--temp_allowed_size))
@@ -224,7 +227,8 @@
 
 /obj/singularity/proc/check_energy()
 	if(energy <= 0)
-		investigate_log("collapsed.","singulo")
+		if(notify_admins)
+			investigate_log("collapsed.","singulo")
 		qdel(src)
 		return 0
 	switch(energy)//Some of these numbers might need to be changed up later -Mport


### PR DESCRIPTION
fixes #2266

Also renames academy singularities, so it's easier to jump to the actual engineering one.

:cl:
tweak: Wizard Academy singulos will no longer be logged or bother admins.
tweak: Wizard Academy singulos renamed to 'magical gravitational singularity' for ease of finding the relevant ones.
/:cl: