### PR TITLE
Fixes admin tags in OOC

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -220,9 +220,6 @@ var/global/normal_ooc_colour = OOC_COLOR
 		if("CouncilMember")
 			return "\[Council\]"
 
-		if("ModeratorV2")
-			return "\[Moderator\]"
-
 		if("Moderator")
 			return "\[Moderator\]"
 
@@ -232,31 +229,14 @@ var/global/normal_ooc_colour = OOC_COLOR
 		if("PrimaryAdmin")
 			return "\[PrimaryAdmin\]"
 
-		if("SeniorAdmin")
-			return "\[SeniorAdmin\]"
+		if("Tribunal")
+			return "\[Tribunal\]"
 
 		if("HeadCoder")
 			return "\[HeadCoder\]"
 
 		if("ModeratorOnProbation")
 			return "\[ModOnProbation\]"
-
-		if("ProbationAdmin")
-			return "\[AdminOnProbation\]"
-		if("NonPlayingAdmin")
-			return "\[Admin\]"
-
-		if("NonPlayingMod")
-			return "\[Moderator\]"
-
-		if("AdminOnVacation")
-			return "\[AdminOnVacation\]"
-
-		if("ModeratorOnVacation")
-			return "\[ModOnVacation\]"
-
-		if("SeniorCoder")
-			return "\[SeniorCoder\]"
 
 		if("Coder")
 			return "\[Coder\]"

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -217,6 +217,10 @@ var/global/normal_ooc_colour = OOC_COLOR
 	var/client/C = client
 
 	switch(C.holder.rank.name)
+
+		if("Host")
+			return "\[Host\]"
+
 		if("CouncilMember")
 			return "\[Council\]"
 


### PR DESCRIPTION
After renaming the admin ranks a bit, forgot that the code had specific ranks and it didn't just pull from the database.

Also deleted the removed ranks.

:cl:
fix: Admin tags in OOC now work properly.
/:cl:
