### PR TITLE
Moves Cosmic Ashwalkers to the DLC pack

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -203,15 +203,16 @@ datum/species/lizard/before_equip_job(datum/job/J, mob/living/carbon/human/H)
 		rebirth = TRUE
 		rebirthcount++
 		H << "<span class='notice'>Your body is entering cryogenic rebirth. You will soon be restored to your physical form. Once this happens your soul will be dragged back into your body."
+		if(rebirthcount >= 3)
+			H << "<span class='notice'>You notice that your body isn't regenerating as fast as it use to. It seems like the abductor's effects are wearing off of you. This is your last rebirth cycle..</span>"
 		H.death()
+		H.ghostize()
+		for(var/obj/item/I in H)
+			H.unEquip(I)
 		var/obj/effect/cyrogenicbubble/CB = new(get_turf(H))
 		CB.name = H.real_name
 		H.forceMove(CB)
 		CB.ashwalker = H
-		if(rebirthcount >= 3)
-			H << "<span class='notice'>You notice that your body isn't regenerating as fast as it use to. It seems like the abductor's effects are wearing off of you. This is your last rebirth cycle..</span>"
-			//H << "<span class='notice'>If only there was a mutant out there with the same powers as you... female too.</span>"
-
 
 /datum/species/lizard/fly
 	// lizards turned into fly-like abominations in teleporter accidents.

--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -165,6 +165,8 @@
 	if(isobj(the_target))
 		if(is_type_in_list(the_target, wanted_objects))
 			return 1
+		else if (istype(the_target, /obj/effect/cyrogenicbubble))
+			return 1
 	return 0
 
 /mob/living/simple_animal/hostile/proc/GiveTarget(new_target)//Step 4, give us our selected target


### PR DESCRIPTION
Fixes https://github.com/yogstation13/yogstation/issues/2324 I guess

### Intent of your Pull Request

These are the changes I made after testing and this issue: https://github.com/yogstation13/yogstation/issues/2324;
- Fixes the attack bugs. Yes, you can now attack their bubbles. Friendly reminder to never . = ..() unless you know exactly what happens before it.
- Cosmic Ashwalkers are no longer conscious in their bubble. Instead they will be full out ghosted until the regeneration is up.
- Cosmic Ashwalkers no longer need 300 ticks to completely regenerate. I might as well be handing you a book to read if I'm going to make you wait that long. Instead it will be 50 ticks.
- In the event that the cosmic ashwalker is attacked (either by angry mob or person), and the bubble pops, depending on how much they've waited in the bubble they'll be healed by (multiplied by a factor of 2).
- Made the ashwalker drop everything they have upon entering the bubble.

#### Changelog

:cl:
rscadd: Cosmic Ashwalkers are currently GOD TIER in tribal ranks, so they are being transferred to the DLC installment which you can get by venting us sixty more dollars.
/:cl: