### PR TITLE
Fixes constructed turrets

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -55,7 +55,7 @@
 	var/shot_sound 			//what sound should play when the turret fires
 	var/eshot_sound			//what sound should play when the emagged turret fires
 
-	var/faction = "neutral"
+	var/faction = "silicon"
 
 	var/datum/effect_system/spark_spread/spark_system	//the spark system, used for generating... sparks?
 


### PR DESCRIPTION
Changes the faction of constructed turrets to "silicon" rather than "neutral" to make them actually shoot at people

### Intent of your Pull Request

Turrets only target people who are either not carbon humans or who aren't in a faction. Because the constructed turrets' faction used to be set to "neutral" they wouldn't target people because they're all in the same faction. By changing the faction to "silicon" it actually targets people based on the settings of the turret. 

#### Changelog

:cl:
rscadd: Turret software has been updated so that any constructed turrets actually target people.
/:cl:
