### PR TITLE
Stops hulks from being permanently paralysed after crit.

### DIFF
--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -126,6 +126,7 @@
 /datum/mutation/human/hulk/on_acquiring(mob/living/carbon/human/owner)
 	if(..())
 		return
+	owner.SetParalysis(0)
 	owner.status_flags -= list(CANSTUN, CANWEAKEN, CANPARALYSE, CANPUSH)
 	owner.update_body_parts()
 


### PR DESCRIPTION

Fun fact! If you get hulk from Genetics but collapse from genetic exhaustion you will get permanently paralyzed if your health rises above 25 before you wake up.

This happens because AdjustParalysis only decreases paralysis when the player mob has the CANPARALYSE status flag(Yes, you'd think that CANPARALYSE would only stop paralysis from increasing not decreasing) hulks don't have CANPARALYSE which means they can't be paralyzed unless they drop below 25hp

#### Changelog

:cl:
fix: Hulks can no longer become permanently paralyzed by genetics.
/:cl:
