### PR TITLE
Fixes photocopiers

### DIFF
--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -17,7 +17,7 @@
 	use_power = 1
 	idle_power_usage = 30
 	active_power_usage = 200
-	power_channel = EQUIP
+	power_channel = 1
 	var/obj/item/weapon/paper/copy = null	//what's in the copier!
 	var/obj/item/weapon/photo/photocopy = null
 	var/obj/item/documents/doccopy = null


### PR DESCRIPTION
Photocopiers on the station should work properly now, they used to be stuck unpowered because of their power_channel being EQUIP instead of 1

:cl:
bugfix: Photocopiers should now work properly.
/:cl:
