### PR TITLE
Fixes death whispering during cloning

### DIFF
--- a/code/modules/mob/living/carbon/human/life.dm
+++ b/code/modules/mob/living/carbon/human/life.dm
@@ -80,7 +80,7 @@
 		if(ear_damage < 100)
 			adjustEarDamage(-0.05,-1)
 
-	if (getBrainLoss() >= 60 && stat != DEAD)
+	if (getBrainLoss() >= 60 && stat == CONSCIOUS)
 		if (prob(3))
 			if(prob(25))
 				emote("drool")


### PR DESCRIPTION
I have no idea why, but this was happening in cloning.
This PR https://github.com/tgstation/tgstation/pull/28949 fixed it for /tg/ after they had the same problem.
:cl:
fix: fixes clones deathwhispering during cloning
/:cl: