### PR TITLE
Adds admin logging to signalers

### DIFF
--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -114,6 +114,7 @@ Code:
 	var/turf/T = get_turf(src)
 	if(usr)
 		lastsignalers.Add("[time] <B>:</B> [usr.key] used [src] @ location ([T.x],[T.y],[T.z]) <B>:</B> [format_frequency(frequency)]/[code]")
+		log_game("[time] <B>:</B> [usr.key] used [src] @ location ([T.x],[T.y],[T.z]) <B>:</B> [format_frequency(frequency)]/[code]")
 
 
 	return


### PR DESCRIPTION
Whenever a signaler is activated, it is logged in the game logs.

See https://forums.yogstation.net/index.php?threads/logicalhazard-adameltablawy-bombing.14334/ as to why this is necessary.