### PR TITLE
Fixes intellicards

### DIFF
--- a/code/game/objects/items/devices/aicard.dm
+++ b/code/game/objects/items/devices/aicard.dm
@@ -65,7 +65,7 @@
 		data["wireless"] = !AI.control_disabled //todo disabled->enabled
 		data["radio"] = AI.radio_enabled
 		data["isDead"] = AI.stat == DEAD
-		data["isBraindead"] = AI.client ? TRUE : FALSE
+		data["isBraindead"] = AI.client ? FALSE : TRUE
 	data["wiping"] = flush
 	return data
 
@@ -88,7 +88,7 @@
 			. = TRUE
 		if("wireless")
 			AI.control_disabled = !AI.control_disabled
-			AI << "[src]'s wireless port has been [AI.control_disabled ? "disabled" : "enabled"]!"
+			AI << "Your wireless port has been [AI.control_disabled ? "disabled" : "enabled"]!"
 			. = TRUE
 		if("radio")
 			AI.radio_enabled = !AI.radio_enabled


### PR DESCRIPTION
Fixes a bug where it says AI's are inactive, whether they are braindead, dead, alive, or active

Refer to issue #2372.

### Intent of your Pull Request

Fixes #2372 

Also changes the message the AI gets when their wireless port is disabled/enabled

#### Changelog

:cl:
fix: Intellicards now display whether an AI is operative or not.
/:cl:
