### PR TITLE
Fixes meaty ores spawning bugged snacks

### DIFF
--- a/code/game/gamemodes/meteor/meteors.dm
+++ b/code/game/gamemodes/meteor/meteors.dm
@@ -254,7 +254,7 @@
 	hits = 2
 	heavy = 1
 	meteorsound = 'sound/effects/blobattack.ogg'
-	meteordrop = list(/obj/item/weapon/reagent_containers/food/snacks/meat, /obj/item/organ/heart, /obj/item/organ/lungs, /obj/item/organ/tongue, /obj/item/organ/appendix/)
+	meteordrop = list(/obj/item/weapon/reagent_containers/food/snacks/meatball, /obj/item/organ/heart, /obj/item/organ/lungs, /obj/item/organ/tongue, /obj/item/organ/appendix/)
 	var/meteorgibs = /obj/effect/gibspawner/generic
 
 /obj/effect/meteor/meaty/New()


### PR DESCRIPTION
Fixes #2289 

Record number of changed lines, I only added 4 characters in this PR

:cl:
bugfix: Fixes meaty ores spawning bugged snacks.
/:cl:
