### PR TITLE
Adds more wizard hats for donors

### DIFF
--- a/code/modules/clothing/head/collectable.dm
+++ b/code/modules/clothing/head/collectable.dm
@@ -110,8 +110,23 @@
 	name = "collectable wizard's hat"
 	desc = "NOTE: Any magical powers gained from wearing this hat are purely coincidental."
 	icon_state = "wizard"
-
 	dog_fashion = /datum/dog_fashion/head/blue_wizard
+
+/obj/item/clothing/head/collectible/wizard/red
+	icon_state = "redwizard"
+	dog_fashion = /datum/dog_fashion/head/red_wizard
+
+/obj/item/clothing/head/collectible/wizard/yellow
+	icon_state = "yellowwizard"
+	dog_fashion = null
+
+/obj/item/clothing/head/collectible/wizard/black
+	icon_state = "blackwizard"
+	dog_fashion = null
+
+/obj/item/clothing/head/collectible/wizard/marisa
+	icon_state = "marisa"
+	dog_fashion = null
 
 /obj/item/clothing/head/collectable/hardhat
 	name = "collectable hard hat"

--- a/code/modules/donors/donor_items.dm
+++ b/code/modules/donors/donor_items.dm
@@ -24,6 +24,10 @@ var/list/donor_start_items = list(\
 						/obj/item/clothing/head/collectable/kitty, \
 						/obj/item/clothing/head/collectable/rabbitears, \
 						/obj/item/clothing/head/collectable/wizard, \
+						/obj/item/clothing/head/collectible/wizard/red, \
+						/obj/item/clothing/head/collectible/wizard/yellow, \
+						/obj/item/clothing/head/collectible/wizard/black, \
+						/obj/item/clothing/head/collectible/wizard/marisa, \
 						/obj/item/clothing/head/collectable/hardhat, \
 						/obj/item/clothing/head/collectable/HoS, \
 						/obj/item/clothing/head/collectable/thunderdome, \


### PR DESCRIPTION
Fixes #2315 

Adds in red, yellow, black and marisa hats. These of course have no functionality and are purely cosmetic like the blue one

:cl:
rscadd: Donors now have more wizard hats to choose from.
/:cl:
