### PR TITLE
Silent storage objects no longer make a rustling noise when items are inserted or removed

### DIFF
--- a/code/game/objects/items/weapons/storage/backpack.dm
+++ b/code/game/objects/items/weapons/storage/backpack.dm
@@ -23,7 +23,8 @@
 	burntime = 20
 
 /obj/item/weapon/storage/backpack/attackby(obj/item/weapon/W, mob/user, params)
-	playsound(src.loc, "rustle", 50, 1, -5)
+	if(!silent)
+		playsound(src.loc, "rustle", 50, 1, -5)
 	return ..()
 
 /*

--- a/code/game/objects/items/weapons/storage/book.dm
+++ b/code/game/objects/items/weapons/storage/book.dm
@@ -6,6 +6,7 @@
 	throw_speed = 2
 	throw_range = 5
 	w_class = 3
+	silent = TRUE
 	burn_state = FLAMMABLE
 	var/title = "book"
 /obj/item/weapon/storage/book/attack_self(mob/user)
@@ -205,7 +206,3 @@ var/global/list/bibleitemstates =	list("bible", "koran", "scrapbook", "bible", "
 			var/unholy2clean = A.reagents.get_reagent_amount("unholywater")
 			A.reagents.del_reagent("unholywater")
 			A.reagents.add_reagent("holywater",unholy2clean)
-
-/obj/item/weapon/storage/book/bible/attackby(obj/item/weapon/W, mob/user, params)
-	playsound(src.loc, "rustle", 50, 1, -5)
-	return ..()

--- a/code/game/objects/items/weapons/storage/secure.dm
+++ b/code/game/objects/items/weapons/storage/secure.dm
@@ -168,7 +168,8 @@
 	if ((src.loc == user) && (src.locked == 1))
 		usr << "<span class='warning'>[src] is locked and cannot be opened!</span>"
 	else if ((src.loc == user) && (!src.locked))
-		playsound(src.loc, "rustle", 50, 1, -5)
+		if(!silent)
+			playsound(src.loc, "rustle", 50, 1, -5)
 		if (user.s_active)
 			user.s_active.close(user) //Close and re-open
 		src.show_to(user)

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -9,7 +9,7 @@
 	name = "storage"
 	icon = 'icons/obj/storage.dmi'
 	w_class = 3
-	var/silent = 0 // No message on putting items in
+	var/silent = 0 // No message or sound on putting items in
 	var/list/can_hold = new/list() //List of objects which this item can store (if set, it can't store anything else)
 	var/list/cant_hold = new/list() //List of objects which this item can't store (in effect only if can_hold isn't set)
 	var/list/is_seeing = new/list() //List of mobs which are currently seeing the contents of this item's storage
@@ -51,7 +51,8 @@
 			if(loc != usr || (loc && loc.loc == usr))
 				return
 
-			playsound(loc, "rustle", 50, 1, -5)
+			if(!silent)
+				playsound(loc, "rustle", 50, 1, -5)
 
 
 			if(istype(over_object, /obj/screen/inventory/hand))
@@ -70,7 +71,8 @@
 /obj/item/weapon/storage/proc/content_can_dump(atom/dest_object, mob/user)
 	if(Adjacent(user) && dest_object.Adjacent(user))
 		if(dest_object.storage_contents_dump_act(src, user))
-			playsound(loc, "rustle", 50, 1, -5)
+			if(!silent)
+				playsound(loc, "rustle", 50, 1, -5)
 			return 1
 	return 0
 
@@ -315,7 +317,10 @@
 
 		add_fingerprint(usr)
 
-		if(!prevent_warning)
+
+		if(prevent_warning)
+			usr << "<span class='notice'>You silently put [W] [preposition]to [src].</span>"
+		else
 			for(var/mob/M in viewers(usr, null))
 				if(M == usr)
 					usr << "<span class='notice'>You put [W] [preposition]to [src].</span>"
@@ -392,7 +397,8 @@
 		close(user)
 		return
 
-	playsound(loc, "rustle", 50, 1, -5)
+	if(!silent)
+		playsound(loc, "rustle", 50, 1, -5)
 
 	if(ishuman(user))
 		var/mob/living/carbon/human/H = user

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -257,7 +257,8 @@
 	S = M.get_item_by_slot(slot_back)	//else we put in backpack
 	if(istype(S) && S.can_be_inserted(src,1))
 		S.handle_item_insertion(src)
-		playsound(src.loc, "rustle", 50, 1, -5)
+		if(!S.silent)
+			playsound(src.loc, "rustle", 50, 1, -5)
 		return 1
 
 	M << "<span class='warning'>You are unable to equip that!</span>"


### PR DESCRIPTION
Fixes #2342
Closes #2449 

There is already a var for this in storage items that should do the same thing.
:cl: matskuman5 
tweak: Hollowed out books no longer make noise like bags when you interact with them.
/:cl:
