### PR TITLE
Increased water turf-wetting time

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -108,8 +108,10 @@
 					C.spin(1,1)
 		return 1
 
-/turf/open/proc/MakeSlippery(wet_setting = TURF_WET_WATER, min_wet_time = 0, wet_time_to_add = 0) // 1 = Water, 2 = Lube, 3 = Ice, 4 = Permafrost, 5 = Slide
-	wet_time = max(wet_time+wet_time_to_add, min_wet_time)
+/turf/open/proc/MakeSlippery(wet_setting = TURF_WET_WATER, min_wet_time = 0, wet_time_to_add = 0, max_wet_time = INFINITY) // 1 = Water, 2 = Lube, 3 = Ice, 4 = Permafrost, 5 = Slide
+	if(wet_time >= max_wet_time)
+		return
+	wet_time = min(max_wet_time, max(wet_time+wet_time_to_add, min_wet_time))
 	if(wet >= wet_setting)
 		return
 	wet = wet_setting

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -114,7 +114,7 @@
 	var/CT = cooling_temperature
 
 	if(reac_volume >= 5)
-		T.MakeSlippery(min_wet_time = 5, wet_time_to_add = reac_volume*0.2)
+		T.MakeSlippery(min_wet_time = 5, wet_time_to_add = reac_volume * 2, max_wet_time = 50)
 
 	for(var/mob/living/simple_animal/slime/M in T)
 		M.apply_water()


### PR DESCRIPTION
Fixes #2109 
Closes #2454 

Water turf-wetting time is now increased by a factor of ten, but it is capped at 50 (approximately 90 seconds). This is how long a full mop will wet a floor for.

:cl: Oakboscage  
rscadd: Wet floors take longer to dry
/:cl:
