### PR TITLE
Slightly improved the NTscript IDE

### DIFF
--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -571,7 +571,6 @@ RCD AMMO
 	icon_state = "rcd"
 	item_state = "rcdammo"
 	origin_tech = "materials=3"
-	w_class = 2
 	materials = list(MAT_METAL=3000, MAT_GLASS=2000)
 	var/ammoamt = 40
 

--- a/code/game/objects/items/weapons/RCD.dm
+++ b/code/game/objects/items/weapons/RCD.dm
@@ -3,6 +3,7 @@
 /*
 CONTAINS:
 RCD
+RCD AMMO
 */
 
 /obj/item/weapon/rcd
@@ -570,6 +571,7 @@ RCD
 	icon_state = "rcd"
 	item_state = "rcdammo"
 	origin_tech = "materials=3"
+	w_class = 2
 	materials = list(MAT_METAL=3000, MAT_GLASS=2000)
 	var/ammoamt = 40
 

--- a/code/modules/scripting/IDE.dm
+++ b/code/modules/scripting/IDE.dm
@@ -45,8 +45,13 @@
 
 					if(compileerrors.len)
 						src << output("<b>Compile Errors</b>", "tcserror")
+						var/i = 1
 						for(var/scriptError/e in compileerrors)
-							src << output("<font color = red>\t>[e.message]</font color>", "tcserror")
+							if(i) //. Bold the first one, since it's probably important
+								src << output("<font color = red>\t><b>[e.message]</b></font color>", "tcserror")
+								i = 0
+							else
+								src << output("<font color = red>\t>[e.message]</font color>", "tcserror")
 						src << output("([compileerrors.len] errors)", "tcserror")
 
 						// Output compile errors to all other people viewing the code too
@@ -54,18 +59,26 @@
 							if(M.client)
 								M << output(null, "tcserror")
 								M << output("<b>Compile Errors</b>", "tcserror")
+								i = 1 //. Still using var/i from above
 								for(var/scriptError/e in compileerrors)
-									M << output("<font color = red>\t>[e.message]</font color>", "tcserror")
+									if(i)
+										M << output("<font color = red>\t><b>[e.message]</b></font color>", "tcserror")
+										i = 0
+									else
+										M << output("<font color = red>\t>[e.message]</font color>", "tcserror")
 								M << output("([compileerrors.len] errors)", "tcserror")
 
 
-					else
+					else // If no errors
 						src << output("<font color = blue>TCS compilation successful!</font color>", "tcserror")
+						src << output("Time of compile: [gameTimestamp("hh:mm:ss")]","tcserror")
+						//. ^ To make it obvious that it's done a new compile
 						src << output("(0 errors)", "tcserror")
 
 						for(var/mob/M in Machine.viewingcode)
 							if(M.client)
 								M << output("<font color = blue>TCS compilation successful!</font color>", "tcserror")
+								M << output("Time of compile: [gameTimestamp("hh:mm:ss")]","tcserror")
 								M << output("(0 errors)", "tcserror")
 
 			else


### PR DESCRIPTION

Babby's first PR! Does two, pretty minor things:
-Adds bold for the first error of the ones that are listed, because it's usually the first one that's the problem
-Adds a timestamp for the compilation, so it's obvious that compiling went OK and that the script is live.

#### Changelog

:cl:
rscadd: Minor changes to the NTscript IDE, adding a timestamp-on-compile and some bolding.
/:cl:
