### PR TITLE
Distinguishes special antag talk, and also logs clock cult talk

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -22,7 +22,7 @@
 /proc/log_adminsay(text)
 	if (config.log_adminchat)
 		log_admin("ASAY: [text]")
-		
+
 /proc/log_dsay(text)
 	if (config.log_adminchat)
 		log_admin("DSAY: [text]")
@@ -39,9 +39,9 @@
 	if (config.log_access)
 		diary << "\[[time_stamp()]]ACCESS: [text]"
 
-/proc/log_say(text)
+/proc/log_say(text, channel = "SAY")
 	if (config.log_say)
-		diary << "\[[time_stamp()]]SAY: [text]"
+		diary << "\[[time_stamp()]][channel]: [text]"
 
 /proc/log_prayer(text)
 	if (config.log_prayer)
@@ -75,4 +75,3 @@
 	if (config.log_pda)
 		//reusing the PDA option because I really don't think news comments are worth a config option
 		diary << "\[[time_stamp()]]COMMENT: [text]"
-

--- a/code/game/gamemodes/blob/overmind.dm
+++ b/code/game/gamemodes/blob/overmind.dm
@@ -121,7 +121,7 @@
 	blob_talk(message)
 
 /mob/camera/blob/proc/blob_talk(message)
-	log_say("[key_name(src)] : [message]")
+	log_say("[key_name(src)] : [message]", "BLOB")
 
 	message = trim(copytext(sanitize(message), 1, MAX_MESSAGE_LEN))
 

--- a/code/game/gamemodes/clock_cult/clock_unsorted.dm
+++ b/code/game/gamemodes/clock_cult/clock_unsorted.dm
@@ -2,6 +2,7 @@
 /proc/titled_hierophant_message(mob/user, message, name_span = "heavy_brass", message_span = "brass", user_title = "Servant")
 	if(!user || !message || !ticker || !ticker.mode)
 		return 0
+	log_say("[key_name(src)] : [message]", "RATVAR")
 	var/parsed_message = "<span class='[name_span]'>[user_title ? "[user_title] ":""][findtextEx(user.name, user.real_name) ? user.name : "[user.real_name] (as [user.name])"]: \
 	</span><span class='[message_span]'>\"[message]\"</span>"
 	hierophant_message(parsed_message, FALSE, user)

--- a/code/game/gamemodes/cult/cult_comms.dm
+++ b/code/game/gamemodes/cult/cult_comms.dm
@@ -40,7 +40,7 @@
 			var/link = FOLLOW_LINK(M, user)
 			M << "[link] [my_message]"
 
-	log_say("[user.real_name]/[user.key] : [message]")
+	log_say("[user.real_name]/[user.key] : [message]", "NAR-SIE")
 
 /mob/living/proc/cult_help()
 	set category = "Cultist"

--- a/code/game/gamemodes/cybermen/cybermen_abilities.dm
+++ b/code/game/gamemodes/cybermen/cybermen_abilities.dm
@@ -136,7 +136,7 @@
 	var/input = stripped_input(user, "Enter a message to share with all other Cybermen.", "Cybermen Broadcast", "")
 	if(input)
 		cyberman_network.log_broadcast("[user.real_name]([user.ckey ? user.ckey : "No ckey"]) Sent a Cyberman Broadcast: [input]")
-		log_say("[key_name(user)] : [input]")
+		log_say("[key_name(user)] : [input]", "CYBERMAN")
 		//user.say_log_silent += "Cyberman Broadcast: [input]"
 		for(var/datum/mind/cyberman in cyberman_network.cybermen)
 			var/distorted_message = input

--- a/code/game/gamemodes/handofgod/god.dm
+++ b/code/game/gamemodes/handofgod/god.dm
@@ -192,7 +192,7 @@
 
 
 /mob/camera/god/proc/god_speak(msg)
-	log_say("Hand of God: [capitalize(side)] God/[key_name(src)] : [msg]")
+	log_say("[capitalize(side)] God/[key_name(src)] : [msg]", "Hand of God")
 	msg = trim(copytext(sanitize(msg), 1, MAX_MESSAGE_LEN))
 	if(!msg)
 		return

--- a/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_abilities.dm
@@ -131,7 +131,7 @@
 			if(!msg)
 				charge_counter = charge_max
 				return
-			log_say("RevenantTransmit: [key_name(user)]->[key_name(M)] : [msg]")
+			log_say("[key_name(user)]->[key_name(M)] : [msg]", "RevenantTransmit")
 			user << "<span class='revenboldnotice'>You transmit to [M]:</span> <span class='revennotice'>[msg]</span>"
 			M << "<span class='revenboldnotice'>An alien voice resonates from all around...</span> <span class='revennotice'>[msg]</span>"
 			for(var/ded in dead_mob_list)

--- a/code/game/gamemodes/shadowling/shadowling_abilities.dm
+++ b/code/game/gamemodes/shadowling/shadowling_abilities.dm
@@ -460,7 +460,7 @@
 	if(!text)
 		return
 	var/my_message = "<span class='shadowling'><b>\[Shadowling\]</b><i> [user.real_name]</i>: [text]</span>"
-	log_say("[key_name(user)] : [text]")
+	log_say("[key_name(user)] : [text]", "SHADOWLING")
 	//user.say_log_silent += "Shadowling Hivemind: [text]"
 	for(var/mob/M in mob_list)
 		if(is_shadow_or_thrall(M))
@@ -943,7 +943,7 @@
 		if(isobserver(M))
 			var/link = FOLLOW_LINK(M, user)
 			M << "[link] [text]"
-	log_say("[user.real_name]/[user.key] : [text]")
+	log_say("[user.real_name]/[user.key] : [text]", "THRALL")
 
 /obj/effect/proc_holder/spell/self/lesser_shadowling_hivemind/proc/cooldownCheck(mob/living/carbon/human/user)
 	if(istype(user) && (user.dna.species.specflags & THRALLAPPTITUDE))
@@ -1091,7 +1091,7 @@
 		if(isobserver(M))
 			var/link = FOLLOW_LINK(M, user)
 			M << "[link] [text]"
-	log_say("[user.real_name]/[user.key] : [text]")
+	log_say("[user.real_name]/[user.key] : [text]", "ASCENDANT")
 
 
 /obj/effect/proc_holder/spell/self/ascendant_transmit //Sends a message to the entire world. If this gets abused too much it can be removed safely

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -69,11 +69,6 @@
 				if(admin_controlled)
 					admin << "A decision has already been made."
 					return
-				if(admin.ckey == bearer.ckey || admin.key == bearer.key)
-					admin << "You cannot approve your own station name."
-					log_admin("[admin] has attempted to approve their own station name: [pending_name]")
-					message_admins("[admin] has attempted to approve their own station name: [pending_name]")
-					return
 
 				message_admins("[admin] has approved the new station's name made by: [pending_name]")
 				log_admin("[admin] has approved [bearer]'s new station name: [pending_name]")

--- a/code/game/objects/items/charter.dm
+++ b/code/game/objects/items/charter.dm
@@ -69,6 +69,11 @@
 				if(admin_controlled)
 					admin << "A decision has already been made."
 					return
+				if(admin.ckey == bearer.ckey || admin.key == bearer.key)
+					admin << "You cannot approve your own station name."
+	 				log_admin("[admin] has attempted to approve their own station name: [pending_name]")
+					message_admins("[admin] has attempted to approve their own station name: [pending_name]")
+					return
 
 				message_admins("[admin] has approved the new station's name made by: [pending_name]")
 				log_admin("[admin] has approved [bearer]'s new station name: [pending_name]")

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -85,7 +85,7 @@ Doesn't work on other aliens/AI.*/
 		return 0
 	var/msg = sanitize(input("Message:", "Alien Whisper") as text|null)
 	if(msg)
-		log_say("AlienWhisper: [key_name(user)]->[M.key] : [msg]")
+		log_say("[key_name(user)]->[M.key] : [msg]", "ALIENWHISPER")
 		M << "<span class='noticealien'>You hear a strange, alien voice in your head...</span>[msg]"
 		user << "<span class='noticealien'>You said: \"[msg]\" to [M]</span>"
 		for(var/ded in dead_mob_list)
@@ -153,7 +153,7 @@ Doesn't work on other aliens/AI.*/
 		// TURF CHECK
 		else if(istype(target, /turf))
 			var/turf/T = target
-      
+
 			if(T.unacidable)
 				user << "<span class='noticealien'>You cannot dissolve this object.</span>"
 				return 0

--- a/code/modules/mob/living/carbon/alien/say.dm
+++ b/code/modules/mob/living/carbon/alien/say.dm
@@ -1,5 +1,5 @@
 /mob/living/proc/alien_talk(message, shown_name = name, obj/item/organ/alien/hivenode/speakerNode)
-	log_say("[key_name(src)] : [message]")
+	log_say("[key_name(src)] : [message]", "XENO HIVEMIND")
 	message = trim(message)
 	if(!message)
 		return

--- a/code/modules/mob/living/carbon/human/species_types.dm
+++ b/code/modules/mob/living/carbon/human/species_types.dm
@@ -802,7 +802,7 @@ datum/species/lizard/before_equip_job(datum/job/J, mob/living/carbon/human/H)
 					L.show_message("<span class='notice'>You hear quiet, garbled whispers.</span>", 2)
 				if(iscarbon(L) && L.stat)
 					L << "<span class='notice'>The room smells like leaves.</span>"
-		log_say("[H.name]/[H.key] : \[Pheromones\]: [message]")
+		log_say("[H.name]/[H.key] : [message]", "PHEROMONE")
 		H.say_log += "\[Pheromones\]: [message]"
 		return 1
 	return ..()

--- a/code/modules/mob/living/carbon/human/whisper.dm
+++ b/code/modules/mob/living/carbon/human/whisper.dm
@@ -17,7 +17,6 @@
 		return
 
 	message = "[message]"
-	log_whisper("[src.name]/[src.key] : [message]")
 
 	if (src.client)
 		if (src.client.prefs.muted & MUTE_IC)

--- a/code/modules/mob/living/silicon/ai/say.dm
+++ b/code/modules/mob/living/silicon/ai/say.dm
@@ -42,7 +42,7 @@
 
 //For holopads only. Usable by AI.
 /mob/living/silicon/ai/proc/holopad_talk(message)
-	log_say("[key_name(src)] : [message]")
+	log_say("[key_name(src)] : [message]", "HOLOPAD")
 
 	message = trim(message)
 

--- a/code/modules/mob/living/silicon/say.dm
+++ b/code/modules/mob/living/silicon/say.dm
@@ -3,7 +3,7 @@
 	return ..() | SPAN_ROBOT
 
 /mob/living/proc/robot_talk(message)
-	log_say("[key_name(src)] : [message]")
+	log_say("[key_name(src)] : [message]", "BINARY")
 	var/desig = "Default Cyborg" //ezmode for taters
 	if(istype(src, /mob/living/silicon))
 		var/mob/living/silicon/S = src

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -73,6 +73,7 @@
 		K = src.key
 
 	message = src.say_quote(message, get_spans())
+	log_say("[name]/[ckey]: [oldmsg]", "DEAD")
 	var/rendered = "<span class='game deadsay'><span class='prefix'>DEAD:</span> <span class='name'>[name]</span>[alt_name] <span class='message'>[message]</span></span>"
 
 	deadchat_broadcast(rendered, follow_target = src, speaker_key = K)


### PR DESCRIPTION
Instead of server logs saying "SAY: [message]" when someone talks over shadowling hivemind, it actually says "SHADOWLING: [message]" or "THRALL: [message]" or whatever.

It also adds logging for clockcult chat, as that wasn't logged before, unless you bothered patching together the whispers that came shortly before it
And now whispers aren't logged twice either

#### Changelog

:cl:
tweak: Say logs now distinguish whether it's said normally, or over cult talk, or blob hivemind or etc.
/:cl:
