### PR TITLE
makes malf preference matter

### DIFF
--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -186,7 +186,7 @@
 	var/mob/living/silicon/ai/AI
 	for(var/V in ai_list)
 		AI = V
-		if(jobban_isbanned(AI, ROLE_TRAITOR) || jobban_isbanned(AI, "Syndicate") || !age_check(AI.client))
+		if(jobban_isbanned(AI, ROLE_TRAITOR) || jobban_isbanned(AI, "Syndicate") || !age_check(AI.client) || !(ROLE_MALF in AI.client.prefs.be_special))
 			AI = null
 		else
 			break


### PR DESCRIPTION
fixes #1312
fixes #2374

If someone has "malf AI" set to off in antag preferences, they will no longer become a malf AI! Isn't that just fun.

#### Changelog

:cl:
fix: If you set malf AI preference to off, you won't be malf anymore
/:cl:
