### PR TITLE
Fixes collectable wizard hats

### DIFF
--- a/code/modules/clothing/head/collectable.dm
+++ b/code/modules/clothing/head/collectable.dm
@@ -112,19 +112,19 @@
 	icon_state = "wizard"
 	dog_fashion = /datum/dog_fashion/head/blue_wizard
 
-/obj/item/clothing/head/collectible/wizard/red
+/obj/item/clothing/head/collectable/wizard/red
 	icon_state = "redwizard"
 	dog_fashion = /datum/dog_fashion/head/red_wizard
 
-/obj/item/clothing/head/collectible/wizard/yellow
+/obj/item/clothing/head/collectable/wizard/yellow
 	icon_state = "yellowwizard"
 	dog_fashion = null
 
-/obj/item/clothing/head/collectible/wizard/black
+/obj/item/clothing/head/collectable/wizard/black
 	icon_state = "blackwizard"
 	dog_fashion = null
 
-/obj/item/clothing/head/collectible/wizard/marisa
+/obj/item/clothing/head/collectable/wizard/marisa
 	icon_state = "marisa"
 	dog_fashion = null
 

--- a/code/modules/donors/donor_items.dm
+++ b/code/modules/donors/donor_items.dm
@@ -24,10 +24,10 @@ var/list/donor_start_items = list(\
 						/obj/item/clothing/head/collectable/kitty, \
 						/obj/item/clothing/head/collectable/rabbitears, \
 						/obj/item/clothing/head/collectable/wizard, \
-						/obj/item/clothing/head/collectible/wizard/red, \
-						/obj/item/clothing/head/collectible/wizard/yellow, \
-						/obj/item/clothing/head/collectible/wizard/black, \
-						/obj/item/clothing/head/collectible/wizard/marisa, \
+						/obj/item/clothing/head/collectable/wizard/red, \
+						/obj/item/clothing/head/collectable/wizard/yellow, \
+						/obj/item/clothing/head/collectable/wizard/black, \
+						/obj/item/clothing/head/collectable/wizard/marisa, \
 						/obj/item/clothing/head/collectable/hardhat, \
 						/obj/item/clothing/head/collectable/HoS, \
 						/obj/item/clothing/head/collectable/thunderdome, \


### PR DESCRIPTION
fixes #2451 

This happened because of the PR:
![image](https://user-images.githubusercontent.com/20558591/29842195-68044b92-8d08-11e7-821a-88f9e5b09a31.png)

Now:
![image](https://user-images.githubusercontent.com/20558591/29842205-71e23cbe-8d08-11e7-8221-478f350def6d.png)


#### Changelog

:cl:
fix: Collectable Wizard's hats don't say you're wearing a head, but that you're wearing a hat
/:cl:
