### PR TITLE
Replaced datacore manifest mob reference with a mind reference

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -258,7 +258,7 @@ var/record_id_num = 1001
 		L.fields["species"]		= H.dna.species.type
 		L.fields["features"]	= H.dna.features
 		L.fields["image"]		= image
-		L.fields["reference"]	= H
+		L.fields["mindref"]		= H.mind
 		locked += L
 	return
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -576,7 +576,8 @@
 	var/list/crewmembers = list()
 	for(var/V in data_core.locked)
 		var/datum/data/record/R = V
-		var/mob/living/carbon/human/H = R.fields["reference"]
+		var/datum/mind/M = R.fields["mindref"]
+		var/mob/living/carbon/human/H = M.current
 		if(istype(H) && H.client)
 			crewmembers += H
 	for(var/V in crewmembers)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -27,9 +27,9 @@
 	. = list()
 	for(var/V in data_core.locked)
 		var/datum/data/record/R = V
-		var/mob/M = R.fields["reference"]
-		if(M && M.mind)
-			. += M.mind
+		var/datum/mind/M = R.fields["mindref"]
+		if(M)
+			. += M
 
 /datum/objective/proc/find_target()
 	var/list/possible_targets = list()

--- a/code/modules/paperwork/filingcabinet.dm
+++ b/code/modules/paperwork/filingcabinet.dm
@@ -194,8 +194,9 @@ var/list/employmentCabinets = list()
 		var/datum/data/record/G = record
 		if(!G)
 			continue
-		if(G.fields["reference"])
-			addFile(G.fields["reference"])
+		var/datum/mind/M = G.fields["mindref"]
+		if(M && ishuman(M.current))
+			addFile(M.current)
 
 
 /obj/structure/filingcabinet/employment/proc/addFile(mob/living/carbon/human/employee)


### PR DESCRIPTION
This could cause weird edge cases like late-round traitors never targeting someone who has been cloned. Minds are a more reliable indicator of identity than mobs, because minds carry over through operations like cloning and mindswap.