### PR TITLE
Mining Medics can now freely leave the mining station.

### DIFF
--- a/code/modules/jobs/job_types/medical.dm
+++ b/code/modules/jobs/job_types/medical.dm
@@ -202,7 +202,7 @@ Mining Medic
 	outfit = /datum/outfit/job/miningmedic
 
 	access = list(access_medical, access_morgue, access_surgery, access_cargo, access_mint, access_mining, access_mining_station, access_mailsorting, access_mineral_storeroom)
-	minimal_access = list(access_medical, access_morgue, access_mining, access_mint, access_mailsorting, access_mineral_storeroom)
+	minimal_access = list(access_medical, access_morgue, access_mining, access_mint, access_mailsorting, access_mineral_storeroom, access_mining_station)
 
 /datum/outfit/job/miningmedic
 	name = "Mining Medic"

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -89,6 +89,7 @@ var/list/medical_positions = list(
 	"Chemist",
 	"Paramedic",
 	"Psychiatrist"
+	"Mining Medic"
 )
 
 

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -88,7 +88,7 @@ var/list/medical_positions = list(
 	"Virologist",
 	"Chemist",
 	"Paramedic",
-	"Psychiatrist"
+	"Psychiatrist",
 	"Mining Medic"
 )
 


### PR DESCRIPTION
### Intent of your Pull Request

In the future I will be making the mother jaunter PUBLIC, giving every miner a wrench, give mining medics a bluespace futon to launch corpses back to the mining station, and eventually add in a camera console that will allow you to monitor the activity of those jaunter beacons.

#### Changelog

:cl:
tweak: Mining Medics can now freely leave the mining station.
/:cl:
