### PR TITLE
replaces dexalin with salbutamol in medbots

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -39,7 +39,7 @@
 	var/stationary_mode = 0 //If enabled, the Medibot will not move automatically.
 	//Setting which reagents to use to treat what by default. By id.
 	var/treatment_brute = "bicaridine"
-	var/treatment_oxy = "dexalin"
+	var/treatment_oxy = "salbutamol"
 	var/treatment_fire = "kelotane"
 	var/treatment_tox = "antitoxin"
 	var/treatment_virus = "spaceacillin"


### PR DESCRIPTION
this makes them more in line with roundstart sleepers since you can't OD people in sleepers with tricord (until it's fully upgraded)

fixes #2543 
