### PR TITLE
Fixed the airlock popup window updating when it should not

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -501,7 +501,7 @@ var/list/airlock_overlays = list()
 	user.set_machine(src)
 	var/datum/browser/popup = new /datum/browser(user, "airlock", "Airlock Control")
 	popup.set_content(dat)
-	popup.open(FALSE)
+	popup.open(TRUE)
 
 
 /obj/machinery/door/airlock/proc/hack(mob/user)


### PR DESCRIPTION
Fixes #2028

I am sure there was a reason for this being FALSE, but I cannot figure out what it was.

:cl:
fix: The airlock control panel will not longer pop back up after being closed whenever and airlock's settings change or a timer counts down.
/:cl:
