### PR TITLE
Gold slimes can no longer spawn magicarp

### DIFF
--- a/code/modules/events/wizard/magicarp.dm
+++ b/code/modules/events/wizard/magicarp.dm
@@ -37,6 +37,7 @@
 	projectilesound = 'sound/weapons/emitter.ogg'
 	maxHealth = 50
 	health = 50
+	gold_core_spawnable = 0
 
 /mob/living/simple_animal/hostile/carp/ranged/New()
 	projectiletype = pick(typesof(initial(projectiletype)))


### PR DESCRIPTION
Magicarp and chaos magicarp do nothing but grief the station. Chaos magicarp just spam their staff everywhere and "accidentally" kill 5 people with a fireball bolt

:cl:
rscdel: Gold slimes can no longer spawn magicarp.
/:cl:
