### PR TITLE
Adds holographic item projector

### DIFF
--- a/code/game/objects/items/devices/holoprojector.dm
+++ b/code/game/objects/items/devices/holoprojector.dm
@@ -23,7 +23,6 @@
 	var/replaced_parts = FALSE
 	var/range = 1
 
-
 /obj/item/device/holoprojector/New()
 	..()
 	laser = new(src)
@@ -60,7 +59,6 @@
 	else
 		user << "<span class='warning'>You cannot scan that!</span>"
 
-
 /obj/item/device/holoprojector/proc/create_holograph(mob/user, turf/open/floor/target)
 	if(!current_item)
 		user << "<span class='warning'>You have not scanned anything to replicate yet!</span>"
@@ -83,7 +81,6 @@
 			cap.loc = get_turf(src.loc)
 			cap = null
 			replaced_parts = TRUE
-
 		if(replaced_parts)
 			replaced_parts = FALSE
 			user << "<span class='notice'>You pop out the parts from [src].</span>"
@@ -120,7 +117,6 @@
 
 		max_holographs = 8*cap.rating
 
-
 /obj/item/device/holoprojector/attack_self(mob/user)
 	user << "<span class='notice'>You disable the projector.</span>"
 	for(var/obj/effect/dummy/holograph/H in holographs)
@@ -153,23 +149,23 @@
 	return ..()
 
 /obj/effect/dummy/holograph/attackby(obj/item/W, mob/user)
-	visible_message("<span class='danger'>[W] passes right through [src]!</span>")
+	user << "<span class='danger'>[W] passes right through [src]!</span>"
 	qdel(src)
 
-/obj/effect/dummy/holograph/attack_hand()
-	visible_message("<span class='danger'>Your hand passes right through [src]!</span>")
+/obj/effect/dummy/holograph/attack_hand(mob/user)
+	user << "<span class='danger'>Your hand passes right through [src]!</span>"
 	qdel(src)
 
-/obj/effect/dummy/holograph/attack_animal()
-	visible_message("<span class='danger'>Your appendage passes right through [src]!</span>")
+/obj/effect/dummy/holograph/attack_animal(mob/user)
+	user << "<span class='danger'>Your appendage passes right through [src]!</span>"
 	qdel(src)
 
-/obj/effect/dummy/holograph/attack_slime()
-	visible_message("<span class='danger'>Your blubber passes right through [src]!</span>")
+/obj/effect/dummy/holograph/attack_slime(mob/user)
+	user << "<span class='danger'>Your blubber passes right through [src]!</span>"
 	qdel(src)
 
-/obj/effect/dummy/holograph/attack_alien()
-	visible_message("<span class='danger'>Your claws pass right through [src]!</span>")
+/obj/effect/dummy/holograph/attack_alien(mob/user)
+	user << "<span class='danger'>Your claws pass right through [src]!</span>"
 	qdel(src)
 
 /obj/effect/dummy/holograph/ex_act(S, T)
@@ -181,15 +177,13 @@
 
 /obj/effect/dummy/holograph/CtrlClick(mob/user)
 	if(get_dist(src, user) > 1) return
-	visible_message("<span class='danger'>You pass through [src] as you try to grab it!</span>")
+	user << "<span class='danger'>You pass through [src] as you try to grab it!</span>"
 	qdel(src)
 
 /obj/item/device/holoprojector/debug
 	name = "debug holoprojector"
-
 	max_holographs = 24
-	allow_scanning_these = list(/obj, /mob) //upgrade microlaser to increase scanning abilities
-
+	allow_scanning_these = list(/obj, /mob)
 	range = 9
 
 /obj/item/device/holoprojector/debug/New()

--- a/code/game/objects/items/devices/holoprojector.dm
+++ b/code/game/objects/items/devices/holoprojector.dm
@@ -53,9 +53,13 @@
 			temp.layer = initial(target.layer) // scanning things in your inventory
 			current_item = temp.appearance
 			current_item_dir = target.dir
-			break
+			return
+
 	if(istype(target,/turf/open))
 		create_holograph(user, target)
+	else
+		user << "<span class='warning'>You cannot scan that!</span>"
+
 
 /obj/item/device/holoprojector/proc/create_holograph(mob/user, turf/open/floor/target)
 	if(!current_item)
@@ -143,6 +147,7 @@
 /obj/effect/dummy/holograph/Destroy()
 	var/msg = pick("[src] distorts for a moment, then disappears!","[src] flickers out of existence!","[src] suddenly disappears!","[src] warps wildly before disappearing!")
 	visible_message("<span class='danger'>[msg]</span>")
+	playsound(get_turf(src), "sparks", 100, 1)
 	if(parent_projector)
 		parent_projector.holographs -= src
 	return ..()

--- a/code/game/objects/items/devices/holoprojector.dm
+++ b/code/game/objects/items/devices/holoprojector.dm
@@ -1,6 +1,6 @@
 /obj/item/device/holoprojector
-	name = "holographic item projector"
-	desc = "A device which has the ability to scan items and create stationary holographs of them."
+	name = "holographic object projector"
+	desc = "A device which has the ability to scan objects and create stationary holographs of them."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "signmaker"
 	item_state = "electronic"
@@ -11,20 +11,50 @@
 	throw_range = 7
 	origin_tech = "magnets=4;programming=4;syndicate=3"
 
-	var/max_holographs = 5
+	var/max_holographs = 6 //upgrade capacitor to increase max holograms
 	var/list/holographs = list()
-	var/obj/item/current_item = null
+	var/atom/current_item = null
+	var/current_item_dir = null
+	var/list/allow_scanning_these = list(/obj/item) //upgrade microlaser to increase scanning abilities
+
+	var/obj/item/weapon/stock_parts/micro_laser/laser
+	var/obj/item/weapon/stock_parts/capacitor/cap
+
+	var/replaced_parts = FALSE
+	var/range = 1
+
+
+/obj/item/device/holoprojector/New()
+	..()
+	laser = new(src)
+	cap = new(src)
+
+/obj/item/device/holoprojector/attack(mob/living/M, mob/user)
+	return
 
 /obj/item/device/holoprojector/afterattack(atom/target, mob/user, proximity)
-	if(!proximity) return
-	if(istype(target,/obj/item))
-		playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, 1, -6)
-		user << "<span class='notice'>Scanned [target].</span>"
-		var/obj/temp = new/obj()
-		temp.appearance = target.appearance
-		temp.layer = initial(target.layer) // scanning things in your inventory
-		current_item = temp.appearance
-	else if(istype(target,/turf/open/floor))
+	if(!target) return
+	if(get_dist(user, target) > range) return
+	if(!laser || !cap)
+		user << "<span class='warning'>[src] is missing some parts!</span>"
+		return
+
+	if(istype(target, /obj/effect/dummy))
+		qdel(target)
+		user << "<span class='notice'>You remove the holograph.</span>"
+		return
+
+	for(var/T in allow_scanning_these)
+		if(istype(target, T))
+			playsound(get_turf(src), 'sound/weapons/flash.ogg', 50, 1, -6)
+			user << "<span class='notice'>Scanned [target].</span>"
+			var/obj/temp = new/obj()
+			temp.appearance = target.appearance
+			temp.layer = initial(target.layer) // scanning things in your inventory
+			current_item = temp.appearance
+			current_item_dir = target.dir
+			break
+	if(istype(target,/turf/open))
 		create_holograph(user, target)
 
 /obj/item/device/holoprojector/proc/create_holograph(mob/user, turf/open/floor/target)
@@ -39,23 +69,80 @@
 	playsound(get_turf(src), 'sound/effects/pop.ogg', 50, 1, -6)
 	new /obj/effect/dummy/holograph(target, src)
 
+/obj/item/device/holoprojector/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/weapon/screwdriver))
+		if(laser)
+			laser.loc = get_turf(src.loc)
+			laser = null
+			replaced_parts = TRUE
+		if(cap)
+			cap.loc = get_turf(src.loc)
+			cap = null
+			replaced_parts = TRUE
+
+		if(replaced_parts)
+			replaced_parts = FALSE
+			user << "<span class='notice'>You pop out the parts from [src].</span>"
+			for(var/obj/effect/dummy/holograph/H in holographs)
+				qdel(H)
+		else
+			user << "<span class='warning'>[src] does not have any parts installed!</span>"
+
+	else if(istype(I, /obj/item/weapon/stock_parts/micro_laser) && !laser)
+		if(!user.unEquip(I))
+			return
+		laser = I
+		I.loc = src
+		user << "<span class='notice'>You insert [laser.name] into [src].</span>"
+
+		switch(laser.rating)
+			if(1)
+				allow_scanning_these = list(/obj/item)
+			if(2)
+				allow_scanning_these = list(/obj)
+			if(3)
+				allow_scanning_these = list(/obj, /mob)
+			if(4)
+				allow_scanning_these = list(/obj, /mob)
+
+		range = 1+(laser.rating*2)
+
+	else if(istype(I, /obj/item/weapon/stock_parts/capacitor) && !cap)
+		if(!user.unEquip(I))
+			return
+		cap = I
+		I.loc = src
+		user << "<span class='notice'>You insert [cap.name] into [src].</span>"
+
+		max_holographs = 8*cap.rating
+
+
+/obj/item/device/holoprojector/attack_self(mob/user)
+	user << "<span class='notice'>You disable the projector.</span>"
+	for(var/obj/effect/dummy/holograph/H in holographs)
+		qdel(H)
+
 /obj/effect/dummy/holograph
 	name = ""
 	desc = ""
 	density = 0
 	var/obj/item/device/holoprojector/parent_projector = null
+	var/datum/effect_system/spark_spread/spark_system
 
 /obj/effect/dummy/holograph/New(loc, parent)
 	if(parent)
 		parent_projector = parent
 		if(parent_projector.current_item)
 			appearance = parent_projector.current_item.appearance
-			desc += " It seems to be shimmering a little..."
+			dir = parent_projector.current_item_dir
+			if(prob(100 - (parent_projector.cap.rating*11.25 + parent_projector.laser.rating*11.25))) //Better parts, higher chance of quality hologram, up to 90%
+				desc += " <span class='italics'>It seems to be shimmering a little...</span>"
 		parent_projector.holographs += src
 	..()
 
 /obj/effect/dummy/holograph/Destroy()
-	visible_message("<span class='danger'>[src] distorts for a moment, then disappears!</span>")
+	var/msg = pick("[src] distorts for a moment, then disappears!","[src] flickers out of existence!","[src] suddenly disappears!","[src] warps wildly before disappearing!")
+	visible_message("<span class='danger'>[msg]</span>")
 	if(parent_projector)
 		parent_projector.holographs -= src
 	return ..()
@@ -91,3 +178,16 @@
 	if(get_dist(src, user) > 1) return
 	visible_message("<span class='danger'>You pass through [src] as you try to grab it!</span>")
 	qdel(src)
+
+/obj/item/device/holoprojector/debug
+	name = "debug holoprojector"
+
+	max_holographs = 24
+	allow_scanning_these = list(/obj, /mob) //upgrade microlaser to increase scanning abilities
+
+	range = 9
+
+/obj/item/device/holoprojector/debug/New()
+	..()
+	laser = new /obj/item/weapon/stock_parts/micro_laser/quadultra(src)
+	cap = new /obj/item/weapon/stock_parts/capacitor/quadratic(src)

--- a/code/game/objects/items/devices/holoprojector.dm
+++ b/code/game/objects/items/devices/holoprojector.dm
@@ -39,18 +39,18 @@
 	if(!target) return
 	if(get_dist(user, target) > range) return
 	if(!laser || !cap)
-		user << "<span class='warning'>[src] is missing some parts!</span>"
+		to_chat(user, "<span class='warning'>[src] is missing some parts!</span>")
 		return
 
 	if(istype(target, /obj/effect/dummy/hologram))
 		qdel(target)
-		user << "<span class='notice'>You remove the hologram.</span>"
+		to_chat(user, "<span class='notice'>You remove the hologram.</span>")
 		return
 
 	for(var/T in allow_scanning_these)
 		if(istype(target, T))
 			playsound(get_turf(src), 'sound/weapons/flash.ogg', 50, 1, -6)
-			user << "<span class='notice'>Scanned [target].</span>"
+			to_chat(user, "<span class='notice'>Scanned [target].</span>")
 			var/obj/temp = new/obj()
 			temp.appearance = target.appearance
 			temp.layer = initial(target.layer) // scanning things in your inventory
@@ -62,17 +62,17 @@
 		if(target in view(range, user))
 			create_hologram(user, target)
 	else
-		user << "<span class='warning'>You cannot scan that!</span>"
+		to_chat(user, "<span class='warning'>You cannot scan that!</span>")
 
 /obj/item/device/holoprojector/proc/create_hologram(mob/user, turf/open/target)
 	if(!current_item)
-		user << "<span class='warning'>You have not scanned anything to replicate yet!</span>"
+		to_chat(user, "<span class='warning'>You have not scanned anything to replicate yet!</span>")
 		return
 
 	if(holograms.len >= max_holograms)
 		qdel(holograms[1])
 
-	user << "<span class='notice'>You create a fake [current_item.name].</span>"
+	to_chat(user, "<span class='notice'>You create a fake [current_item.name].</span>")
 	playsound(get_turf(src), 'sound/effects/pop.ogg', 50, 1, -6)
 	new /obj/effect/dummy/hologram(target, src)
 
@@ -88,18 +88,18 @@
 			replaced_parts = TRUE
 		if(replaced_parts)
 			replaced_parts = FALSE
-			user << "<span class='notice'>You pop out the parts from [src].</span>"
+			to_chat(user, "<span class='notice'>You pop out the parts from [src].</span>")
 			for(var/obj/effect/dummy/hologram/H in holograms)
 				qdel(H)
 		else
-			user << "<span class='warning'>[src] does not have any parts installed!</span>"
+			to_chat(user, "<span class='warning'>[src] does not have any parts installed!</span>")
 
 	else if(istype(I, /obj/item/weapon/stock_parts/micro_laser) && !laser)
 		if(!user.unEquip(I))
 			return
 		laser = I
 		I.loc = src
-		user << "<span class='notice'>You insert [laser.name] into [src].</span>"
+		to_chat(user, "<span class='notice'>You insert [laser.name] into [src].</span>")
 
 		switch(laser.rating)
 			if(1)
@@ -118,12 +118,12 @@
 			return
 		cap = I
 		I.loc = src
-		user << "<span class='notice'>You insert [cap.name] into [src].</span>"
+		to_chat(user, "<span class='notice'>You insert [cap.name] into [src].</span>")
 
 		max_holograms = 8*cap.rating
 
 /obj/item/device/holoprojector/attack_self(mob/user)
-	user << "<span class='notice'>You disable the projector.</span>"
+	to_chat(user, "<span class='notice'>You disable the projector.</span>")
 	for(var/obj/effect/dummy/hologram/H in holograms)
 		qdel(H)
 
@@ -153,23 +153,23 @@
 	return ..()
 
 /obj/effect/dummy/hologram/attackby(obj/item/W, mob/user)
-	user << "<span class='danger'>[W] passes right through [src]!</span>"
+	to_chat(user, "<span class='danger'>[W] passes right through [src]!</span>")
 	qdel(src)
 
 /obj/effect/dummy/hologram/attack_hand(mob/user)
-	user << "<span class='danger'>Your hand passes right through [src]!</span>"
+	to_chat(user, "<span class='danger'>Your hand passes right through [src]!</span>")
 	qdel(src)
 
 /obj/effect/dummy/hologram/attack_animal(mob/user)
-	user << "<span class='danger'>Your appendage passes right through [src]!</span>"
+	to_chat(user, "<span class='danger'>Your appendage passes right through [src]!</span>")
 	qdel(src)
 
 /obj/effect/dummy/hologram/attack_slime(mob/user)
-	user << "<span class='danger'>Your blubber passes right through [src]!</span>"
+	to_chat(user, "<span class='danger'>Your blubber passes right through [src]!</span>")
 	qdel(src)
 
 /obj/effect/dummy/hologram/attack_alien(mob/user)
-	user << "<span class='danger'>Your claws pass right through [src]!</span>"
+	to_chat(user, "<span class='danger'>Your claws pass right through [src]!</span>")
 	qdel(src)
 
 /obj/effect/dummy/hologram/ex_act(S, T)
@@ -181,7 +181,7 @@
 
 /obj/effect/dummy/hologram/CtrlClick(mob/user)
 	if(get_dist(src, user) > 1) return
-	user << "<span class='danger'>You pass through [src] as you try to grab it!</span>"
+	to_chat(user, "<span class='danger'>You pass through [src] as you try to grab it!</span>")
 	qdel(src)
 
 /obj/item/device/holoprojector/debug

--- a/code/game/objects/items/devices/holoprojector.dm
+++ b/code/game/objects/items/devices/holoprojector.dm
@@ -1,0 +1,93 @@
+/obj/item/device/holoprojector
+	name = "holographic item projector"
+	desc = "A device which has the ability to scan items and create stationary holographs of them."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "signmaker"
+	item_state = "electronic"
+	force = 0
+	w_class = 2
+	throwforce = 0
+	throw_speed = 3
+	throw_range = 7
+	origin_tech = "magnets=4;programming=4;syndicate=3"
+
+	var/max_holographs = 5
+	var/list/holographs = list()
+	var/obj/item/current_item = null
+
+/obj/item/device/holoprojector/afterattack(atom/target, mob/user, proximity)
+	if(!proximity) return
+	if(istype(target,/obj/item))
+		playsound(get_turf(src), 'sound/weapons/flash.ogg', 100, 1, -6)
+		user << "<span class='notice'>Scanned [target].</span>"
+		var/obj/temp = new/obj()
+		temp.appearance = target.appearance
+		temp.layer = initial(target.layer) // scanning things in your inventory
+		current_item = temp.appearance
+	else if(istype(target,/turf/open/floor))
+		create_holograph(user, target)
+
+/obj/item/device/holoprojector/proc/create_holograph(mob/user, turf/open/floor/target)
+	if(!current_item)
+		user << "<span class='warning'>You have not scanned anything to replicate yet!</span>"
+		return
+
+	if(holographs.len >= max_holographs)
+		qdel(holographs[1])
+
+	user << "<span class='notice'>You create a fake [current_item.name].</span>"
+	playsound(get_turf(src), 'sound/effects/pop.ogg', 50, 1, -6)
+	new /obj/effect/dummy/holograph(target, src)
+
+/obj/effect/dummy/holograph
+	name = ""
+	desc = ""
+	density = 0
+	var/obj/item/device/holoprojector/parent_projector = null
+
+/obj/effect/dummy/holograph/New(loc, parent)
+	if(parent)
+		parent_projector = parent
+		if(parent_projector.current_item)
+			appearance = parent_projector.current_item.appearance
+			desc += " It seems to be shimmering a little..."
+		parent_projector.holographs += src
+	..()
+
+/obj/effect/dummy/holograph/Destroy()
+	visible_message("<span class='danger'>[src] distorts for a moment, then disappears!</span>")
+	if(parent_projector)
+		parent_projector.holographs -= src
+	return ..()
+
+/obj/effect/dummy/holograph/attackby(obj/item/W, mob/user)
+	visible_message("<span class='danger'>[W] passes right through [src]!</span>")
+	qdel(src)
+
+/obj/effect/dummy/holograph/attack_hand()
+	visible_message("<span class='danger'>Your hand passes right through [src]!</span>")
+	qdel(src)
+
+/obj/effect/dummy/holograph/attack_animal()
+	visible_message("<span class='danger'>Your appendage passes right through [src]!</span>")
+	qdel(src)
+
+/obj/effect/dummy/holograph/attack_slime()
+	visible_message("<span class='danger'>Your blubber passes right through [src]!</span>")
+	qdel(src)
+
+/obj/effect/dummy/holograph/attack_alien()
+	visible_message("<span class='danger'>Your claws pass right through [src]!</span>")
+	qdel(src)
+
+/obj/effect/dummy/holograph/ex_act(S, T)
+	qdel(src)
+
+/obj/effect/dummy/holograph/bullet_act()
+	..()
+	qdel(src)
+
+/obj/effect/dummy/holograph/CtrlClick(mob/user)
+	if(get_dist(src, user) > 1) return
+	visible_message("<span class='danger'>You pass through [src] as you try to grab it!</span>")
+	qdel(src)

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -954,6 +954,14 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	cost = 4
 	include_modes = list(/datum/game_mode/nuclear)
 
+/datum/uplink_item/device_tools/projector
+	name = "Holographic Object Projector"
+	item = /obj/item/device/holoprojector
+	desc = "A device for masters of deception and trickery. This item allows you to scan objects and create \
+			holograms of them. The holograms will dissipate when interacted with. You can replace the stock \
+			parts it comes with to increase the maximum number of holograms and variety of scannable objects."
+	cost = 4
+
 // Implants
 /datum/uplink_item/implants
 	category = "Implants"

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -645,6 +645,7 @@
 #include "code\game\objects\items\devices\doorCharge.dm"
 #include "code\game\objects\items\devices\flashlight.dm"
 #include "code\game\objects\items\devices\geiger_counter.dm"
+#include "code\game\objects\items\devices\holoprojector.dm"
 #include "code\game\objects\items\devices\instruments.dm"
 #include "code\game\objects\items\devices\laserpointer.dm"
 #include "code\game\objects\items\devices\lightreplacer.dm"


### PR DESCRIPTION
Adds the holographic item projector: A traitor device which allows you to scan any item then create a holographic clone of it. The clone disappears when interacted with in any way. Here is an example:

![image](https://user-images.githubusercontent.com/16842348/30656281-d952e2e0-9e33-11e7-9439-8d096e0c8980.png)
I've stolen several important things from that table, yet at first glance it looks like nothing is missing. Feedback would be appreciated!

Bugs:
-items scanned from inventory take up the whole tile
-you can't scan containers

:cl: McDonald072
rscadd: New uplink item, the holographic object projector! Use it to scan items, structures and mobs and create fake copies (some assembly required). Idea courtesy of Nickvr628.
/:cl:
