### PR TITLE
Adds 20 to the minimum amount of players for a revenant to spawn.

### DIFF
--- a/code/game/gamemodes/miniantags/revenant/revenant_spawn_event.dm
+++ b/code/game/gamemodes/miniantags/revenant/revenant_spawn_event.dm
@@ -6,7 +6,7 @@
 	weight = 7
 	max_occurrences = 1
 	earliest_start = 12000 //Meant to mix things up early-game.
-	min_players = 5
+	min_players = 25
 
 
 /datum/round_event/ghost_role/revenant


### PR DESCRIPTION
Few things. Revenant doesn't check for dead humans, it checks all dead mobs.  Meaning mining contributes basically every number of that.
It also doesn't stop fucking trying to fire until it actually gets 20 dead mobs, so having it able to trigger with 5 players is stupid.

I was going to make it only count mobs that have/had a ckey in them at some point but the odds of having 20 players die on most rounds unless a person has hijack/is a wizard/maybe nuke is incredibly slim so I might aswell just remove revenant if I did that.
