### PR TITLE
Adds timestamps to say logs

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -109,7 +109,8 @@ var/list/crit_allowed_modes = list(MODE_WHISPER,MODE_CHANGELING,MODE_ALIEN)
 	spans += get_spans()
 
 	//Log of what we've said, plain message, no spans or junk
-	say_log += message
+	var/message_log = "\[[gameTimestamp()]\] [message]"
+	say_log += message_log
 
 	var/message_range = 7
 	var/radio_return = radio(message, message_mode, spans)


### PR DESCRIPTION
### Intent of your Pull Request

Adds timestamps to the say logs. Note: changelings get this, but it's in-game station time, so it shouldn't matter much.

#### Changelog

:cl:
rscadd: Admins can now see when you've said something without downloading the logs for the current round!
/:cl:
