### PR TITLE
Nerfs the changeling LSD sting

### DIFF
--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -220,7 +220,7 @@
 	feedback_add_details("changeling_powers","BS")
 	return 1
 
-/obj/effect/proc_holder/changeling/sting/LSD
+/*/obj/effect/proc_holder/changeling/sting/LSD
 	name = "Hallucinogenic Sting"
 	desc = "Causes terror in the target."
 	helptext = "We evolve the ability to sting a target with a powerful hallucinogenic chemical. The target does not notice they have been stung, and the effect occurs very quickly."
@@ -234,6 +234,7 @@
 		target.reagents.add_reagent("mindbreaker", 30)
 	feedback_add_details("changeling_powers","HS")
 	return 1
+*/
 
 /*
 /obj/effect/proc_holder/changeling/sting/cryo

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -220,7 +220,7 @@
 	feedback_add_details("changeling_powers","BS")
 	return 1
 
-/*/obj/effect/proc_holder/changeling/sting/LSD
+/obj/effect/proc_holder/changeling/sting/LSD
 	name = "Hallucinogenic Sting"
 	desc = "Causes terror in the target."
 	helptext = "We evolve the ability to sting a target with a powerful hallucinogenic chemical. The target does not notice they have been stung, and the effect occurs very quickly."
@@ -231,10 +231,9 @@
 /obj/effect/proc_holder/changeling/sting/LSD/sting_action(mob/user, mob/living/carbon/target)
 	add_logs(user, target, "stung", "LSD sting")
 	if(target.reagents)
-		target.reagents.add_reagent("mindbreaker", 30)
+		target.reagents.add_reagent("mindbreaker", 10)
 	feedback_add_details("changeling_powers","HS")
 	return 1
-*/
 
 /*
 /obj/effect/proc_holder/changeling/sting/cryo

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -231,7 +231,7 @@
 /obj/effect/proc_holder/changeling/sting/LSD/sting_action(mob/user, mob/living/carbon/target)
 	add_logs(user, target, "stung", "LSD sting")
 	if(target.reagents)
-		target.reagents.add_reagent("mindbreaker", 10)
+		target.reagents.add_reagent("mindbreaker", 15)
 	feedback_add_details("changeling_powers","HS")
 	return 1
 


### PR DESCRIPTION
WELCOME, LADIES AND GENTLEMEN, TO NICH'S SALT PR SHOW. IN THIS EPISODE, WE'LL BE LOOKING AT THE CHANGELING LSD STING.

### Intent of your Pull Request

Nerfs the changeling hallucination sting by reducing the amount of mindbreaker it injects. It now cuts the amount of mindbreaker in half, meaning I'll only crash every 30 seconds for 5 minutes, instead of 10!

#### Changelog

:cl:
tweak: the changeling LSD-sting has been nerfed
/:cl:
