### PR TITLE
RD can no longer teleport

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -27,7 +27,7 @@
 	name = "a hand teleporter"
 	targetitem = /obj/item/weapon/hand_tele
 	difficulty = 5
-	excludefromjob = list("Captain")
+	excludefromjob = list("Captain", "Research Director")
 
 /datum/objective_item/steal/jetpack
 	name = "the Captain's jetpack"


### PR DESCRIPTION
### Intent of your Pull Request
RD can literally just walk into the teleporter and take the hand teleporter. Literally an objective about going to an area you have access to and taking something you're allowed to have.

#### Changelog

:cl:  
fix: RD now has to put more effort into his traitor objectives than walking
/:cl:
