### PR TITLE
Fixes AI cams

### DIFF
--- a/code/modules/mob/living/silicon/ai/freelook/chunk.dm
+++ b/code/modules/mob/living/silicon/ai/freelook/chunk.dm
@@ -115,6 +115,8 @@
 		if(obscuredTurfs[t])
 			if(!t.obscured)
 				t.obscured = image('icons/effects/cameravis.dmi', t, null, 16)
+				t.obscured.pixel_x = -t.pixel_x
+				t.obscured.pixel_y = -t.pixel_y
 				t.obscured.plane = PLANE_AI_STATIC
 
 			obscured += t.obscured
@@ -171,6 +173,8 @@
 		var/turf/t = turf
 		if(!t.obscured)
 			t.obscured = image('icons/effects/cameravis.dmi', t, null, 16)
+			t.obscured.pixel_x = -t.pixel_x
+			t.obscured.pixel_y = -t.pixel_y
 			t.obscured.plane = PLANE_AI_STATIC
 		obscured += t.obscured
 


### PR DESCRIPTION
### Intent of your Pull Request

Ports https://github.com/tgstation/tgstation/pull/31554

This fixes the lavaland looking like this to the AI:
![image](https://user-images.githubusercontent.com/20558591/31451723-1ee1817a-aead-11e7-919d-994e194338f4.png)

#### Changelog

:cl:  SpaceManiac
fix: AI eye camera static is now correctly positioned on Lavaland.
/:cl:
