### PR TITLE
The syndicate shuttle ignores itself when determining its landing spot

### DIFF
--- a/code/modules/shuttle/assault_pod.dm
+++ b/code/modules/shuttle/assault_pod.dm
@@ -43,6 +43,7 @@
 	x_offset = 0
 	y_offset = 3
 	rotate_action = null
+	space_turfs_only = FALSE
 	var/target_set = FALSE
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/syndicate_pod/check_eye(mob/user)

--- a/code/modules/shuttle/navigation_computer.dm
+++ b/code/modules/shuttle/navigation_computer.dm
@@ -11,9 +11,12 @@
 	var/list/jumpto_ports = list()
 	var/list/blacklisted_turfs = list()
 	var/obj/docking_port/stationary/my_port
+	var/obj/docking_port/mobile/shuttle_port
+	var/area/shuttle_port_area
 	var/view_range = 7
 	var/x_offset = 0
 	var/y_offset = 0
+	var/space_turfs_only = TRUE
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/GrantActions(mob/living/user)
 	if(jumpto_ports.len)
@@ -31,18 +34,21 @@
 		actions += place_action
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/CreateEye()
-	var/obj/docking_port/mobile/M = SSshuttle.getShuttle(shuttleId)
-	if(!M)
+	shuttle_port = SSshuttle.getShuttle(shuttleId)
+	if(!shuttle_port)
+		shuttle_port = null
+		return
+	shuttle_port_area = shuttle_port.areaInstance
+	if(!shuttle_port_area)
+		shuttle_port = null
+		shuttle_port_area = null
 		return
 	eyeobj = new /mob/camera/aiEye/remote/shuttle_docker()
 	var/mob/camera/aiEye/remote/shuttle_docker/the_eye = eyeobj
 	the_eye.origin = src
-	the_eye.dir = M.dir
-	var/area/A = M.areaInstance
-	if(!A)
-		return
-	var/turf/origin = locate(M.x + x_offset, M.y + y_offset, M.z)
-	for(var/turf/T in A)
+	the_eye.dir = shuttle_port.dir
+	var/turf/origin = locate(shuttle_port.x + x_offset, shuttle_port.y + y_offset, shuttle_port.z)
+	for(var/turf/T in shuttle_port_area)
 		if(T.z != origin.z)
 			continue
 		var/image/I = image('icons/effects/alphacolors.dmi', origin, "red")
@@ -124,7 +130,7 @@
 	checkLandingSpot()
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/proc/checkLandingTurf(turf/T)
-	return T && !blacklisted_turfs[T]
+	return T && ((T.loc == shuttle_port_area) || (!blacklisted_turfs || !blacklisted_turfs[T]) && (!space_turfs_only || isspaceturf(T)) )
 
 /obj/machinery/computer/camera_advanced/shuttle_docker/proc/generateBlacklistedTurfs()
 	for(var/V in SSshuttle.stationary)

--- a/code/modules/shuttle/syndicate.dm
+++ b/code/modules/shuttle/syndicate.dm
@@ -51,8 +51,4 @@
 	x_offset = -4
 	y_offset = -2
 
-
-/obj/machinery/computer/camera_advanced/shuttle_docker/syndicate/checkLandingTurf(turf/T)
-	return ..() && isspaceturf(T)
-
 #undef SYNDICATE_CHALLENGE_TIMER


### PR DESCRIPTION
Made the shuttle navigation computer ignore its own area when determining valid turfs. This makes it easier to make small location changes.
:cl:  
tweak: tweaked a few things
/:cl:
