### PR TITLE
Fixes yogbot and stealthmins

### DIFF
--- a/code/world.dm
+++ b/code/world.dm
@@ -162,10 +162,9 @@ var/last_irc_status = 0
 	else if("adminwho" in input)
 		var/msg = "Current Admins:\n"
 		for(var/client/C in admins)
-			msg += "\t[C] is a [C.holder.rank]"
-			if(C.is_afk())
-				msg += " (AFK)"
-			msg += "\n"
+			if(!C.holder.fakekey)
+				msg += "\t[C] is a [C.holder.rank]"
+				msg += "\n"
 		return msg
 
 	else if(copytext(T,1,9) == "announce")


### PR DESCRIPTION
### Intent of your Pull Request

If someone's stealthminned, they won't show up in the yogbot adminwho anymore. It also won't show anyone who's AFK as being AFK.

#### Changelog

:cl:  
fix: Stealthmins are no longer shown on discord
/:cl:
