### PR TITLE
Stops transfomation sting from transfering SE

### DIFF
--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -104,7 +104,7 @@
 		target.visible_message("<span class='danger'>[target] begins to violenty convulse!</span>","<span class='userdanger'>You feel a tiny prick and a begin to uncontrollably convulse!</span>")
 		spawn(10)
 			C.real_name = NewDNA.real_name
-			NewDNA.transfer_identity(C, transfer_SE=1)
+			NewDNA.transfer_identity(C, transfer_SE=0)
 			C.updateappearance(mutcolor_update=1)
 			C.domutcheck()
 	feedback_add_details("changeling_powers","TS")


### PR DESCRIPTION
### Intent of your Pull Request

The intent of the transformation sting was never to allow for you to load yourself up on a shitton of disablities, then transform-sting someone and instantly render them unable to fight back.

The intention of the sting was to cause confusion and chaos.

#### Changelog

:cl:  
tweak: Transformation stings will now no longer transfer SE DNA.  
/:cl:
