### PR TITLE
Adds a way to deal with looping immovable rods

### DIFF
--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -51,6 +51,29 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 /obj/effect/immovablerod/ex_act(test)
 	return 0
 
+/obj/effect/immovablerod/proc/check_suplex(mob/living/carbon/human/H)
+	if(!istype(H) || !H.mind || H.mind.assigned_role != "Research Director" || !H.in_throw_mode)
+		return FALSE
+	var/obj/structure/flora/kirbyplants/K = locate() in range(1, H)
+	if(!K)
+		return FALSE
+
+	var/turf/open/floor/T = get_turf(K)
+	H.forceMove(T)
+
+	H.visible_message("<span class='userdanger'>[H] suplexes \the [src] into [K]!</span>","<span class='userdanger'>You suplex \the [src] into [K]!</span>")
+	var/obj/structure/festivus/P = new(T)
+	P.desc = "During this year's Feats of Strength the Research Director was able to suplex this passing immovable rod into a planter."
+	if(istype(T))
+		T.break_tile()
+	playsound(T, "explosion", 100)
+	for(var/mob/bystander in urange(10, src))
+		shake_camera(bystander, 7, 2)
+
+	qdel(src)
+	qdel(K)
+	return TRUE
+
 /obj/effect/immovablerod/Bump(atom/clong)
 	if(prob(10))
 		playsound(src, 'sound/effects/bang.ogg', 50, 1)
@@ -67,34 +90,10 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	else if (istype(clong, /mob))
 		if(istype(clong, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = clong
-			do
-				if(!H.mind || H.mind.assigned_role != "Research Director" || !H.in_throw_mode)
-					break
-				var/obj/structure/flora/kirbyplants/K = locate() in range(1, H)
-				if(!K)
-					break
-
-				var/turf/open/floor/T = get_turf(K)
-				H.forceMove(T)
-
-				H.visible_message("<span class='danger'>[H] suplexes \the [src] into [K]!</span>","<span class='userdanger'>You suplex \the [src] into [K]!</span>")
-				var/obj/structure/festivus/P = new(T)
-				P.desc = "During this year's Feats of Strength the Research Director was able to suplex this passing immovable rod into a planter."
-				if(istype(T))
-					T.break_tile()
-				playsound(T, "explosion", 100)
-				for(var/mob/bystander in urange(10, src))
-					if(!bystander.stat)
-						shake_camera(bystander, 7, 2)
-
-				qdel(src)
-				qdel(K)
-				return
-			while(FALSE) //advanced spaghetti cooking techniques
-
-			H.visible_message("<span class='danger'>[H.name] is penetrated by an immovable rod!</span>" , "<span class='userdanger'>The rod penetrates you!</span>" , "<span class ='danger'>You hear a CLANG!</span>")
-			H.adjustBruteLoss(160)
-		if(clong.density || prob(10))
+			if(!check_suplex(H))
+				H.visible_message("<span class='danger'>[H.name] is penetrated by an immovable rod!</span>" , "<span class='userdanger'>The rod penetrates you!</span>" , "<span class ='danger'>You hear a CLANG!</span>")
+				H.adjustBruteLoss(160)
+		else if(clong.density || prob(10))
 			clong.ex_act(2)
 	return
 

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -26,7 +26,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	new /obj/effect/immovablerod(startT, endT)
 
 /obj/effect/immovablerod
-	name = "Immovable Rod"
+	name = "immovable rod"
 	desc = "What the fuck is that?"
 	icon = 'icons/obj/objects.dmi'
 	icon_state = "immrod"
@@ -75,6 +75,9 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	return TRUE
 
 /obj/effect/immovablerod/Bump(atom/clong)
+	if(qdeleted(src))
+		return
+
 	if(prob(10))
 		playsound(src, 'sound/effects/bang.ogg', 50, 1)
 		audible_message("CLANG")

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -91,6 +91,7 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	P.desc = "During this year's Feats of Strength the Research Director was able to suplex this passing immovable rod into a planter."
 	if(istype(T))
 		T.broken = 1
+		T.update_icon()
 	playsound(T, "explosion", 100)
 	for(var/mob/bystander in urange(10, src))
 		if(!bystander.stat)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -86,9 +86,6 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	var/turf/open/floor/T = get_turf(K)
 	M.forceMove(T)
 
-	qdel(src)
-	qdel(K)
-
 	M.visible_message("<span class='danger'>[M] suplexes \the [src] into [K]!</span>","<span class='userdanger'>You suplex \the [src] into [K]!</span>")
 	var/obj/structure/festivus/P = new(T)
 	P.desc = "During this year's Feats of Strength the Research Director was able to suplex this passing immovable rod into a planter."
@@ -98,3 +95,6 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	for(var/mob/bystander in urange(10, src))
 		if(!bystander.stat)
 			shake_camera(bystander, 3, 2)
+
+	qdel(src)
+	qdel(K)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -67,35 +67,34 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 	else if (istype(clong, /mob))
 		if(istype(clong, /mob/living/carbon/human))
 			var/mob/living/carbon/human/H = clong
+			do
+				if(!H.mind || H.mind.assigned_role != "Research Director" || !H.in_throw_mode)
+					break
+				var/obj/structure/flora/kirbyplants/K = locate() in range(1, H)
+				if(!K)
+					break
+
+				var/turf/open/floor/T = get_turf(K)
+				H.forceMove(T)
+
+				H.visible_message("<span class='danger'>[H] suplexes \the [src] into [K]!</span>","<span class='userdanger'>You suplex \the [src] into [K]!</span>")
+				var/obj/structure/festivus/P = new(T)
+				P.desc = "During this year's Feats of Strength the Research Director was able to suplex this passing immovable rod into a planter."
+				if(istype(T))
+					T.break_tile()
+				playsound(T, "explosion", 100)
+				for(var/mob/bystander in urange(10, src))
+					if(!bystander.stat)
+						shake_camera(bystander, 7, 2)
+
+				qdel(src)
+				qdel(K)
+				return
+			while(FALSE) //advanced spaghetti cooking techniques
+
 			H.visible_message("<span class='danger'>[H.name] is penetrated by an immovable rod!</span>" , "<span class='userdanger'>The rod penetrates you!</span>" , "<span class ='danger'>You hear a CLANG!</span>")
 			H.adjustBruteLoss(160)
 		if(clong.density || prob(10))
 			clong.ex_act(2)
 	return
 
-/obj/effect/immovablerod/attack_hand(mob/M)
-	if(!ishuman(M))
-		return
-	if(!M.mind || M.mind.assigned_role != "Research Director")
-		return
-
-	var/obj/structure/flora/kirbyplants/K = locate() in orange(2, M)
-	if(!K)
-		return
-
-	var/turf/open/floor/T = get_turf(K)
-	M.forceMove(T)
-
-	M.visible_message("<span class='danger'>[M] suplexes \the [src] into [K]!</span>","<span class='userdanger'>You suplex \the [src] into [K]!</span>")
-	var/obj/structure/festivus/P = new(T)
-	P.desc = "During this year's Feats of Strength the Research Director was able to suplex this passing immovable rod into a planter."
-	if(istype(T))
-		T.broken = 1
-		T.update_icon()
-	playsound(T, "explosion", 100)
-	for(var/mob/bystander in urange(10, src))
-		if(!bystander.stat)
-			shake_camera(bystander, 3, 2)
-
-	qdel(src)
-	qdel(K)

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -72,3 +72,29 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 		if(clong.density || prob(10))
 			clong.ex_act(2)
 	return
+
+/obj/effect/immovablerod/attack_hand(mob/M)
+	if(!ishuman(M))
+		return
+	if(!M.mind || M.mind.assigned_role != "Research Director")
+		return
+
+	var/obj/structure/flora/kirbyplants/K = locate() in orange(2, M)
+	if(!K)
+		return
+
+	var/turf/open/floor/T = get_turf(K)
+	M.forceMove(T)
+
+	qdel(src)
+	qdel(K)
+
+	M.visible_message("<span class='danger'>[M] suplexes \the [src] into [K]!</span>","<span class='userdanger'>You suplex \the [src] into [K]!</span>")
+	var/obj/structure/festivus/P = new(T)
+	P.desc = "During this year's Feats of Strength the Research Director was able to suplex this passing immovable rod into a planter."
+	if(istype(T))
+		T.broken = 1
+	playsound(T, "explosion", 100)
+	for(var/mob/bystander in urange(10, src))
+		if(!bystander.stat)
+			shake_camera(bystander, 3, 2)


### PR DESCRIPTION
"Oh no, the immovable rod has started looping! Call the shuttle!"
How many times has this happened to you? Pissed off because random chance screwed up your traitor round? Fear no more! Just ask your nearest RD to grab a plant box then grab the rod and suplex it into the poor bush.
*Slipping and penetration insurance sold separately.
:cl:  
rscadd: Research Directors can now attempt to slam looping immovable rods into plant pots. Grab the nearest pot and try to catch the rod!
/:cl:
