### PR TITLE
Security Borg-Red

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_skins.dm
+++ b/code/modules/mob/living/silicon/robot/robot_skins.dm
@@ -115,8 +115,8 @@
 	
 //Red
 /datum/robot_skin/secred
- 	Name = "Red"
- 	Icon_State = "secborg-red"		//Probably a donor sprite.
+ 	name = "Red"
+ 	icon_State = "secborg-red"		//Probably a donor sprite.
  	eye_icon_state = "eyes-secborg-red"
  	headlight_icon_state = "eyes-standard-light"
  	modules = list(/obj/item/weapon/robot_module/security)

--- a/code/modules/mob/living/silicon/robot/robot_skins.dm
+++ b/code/modules/mob/living/silicon/robot/robot_skins.dm
@@ -119,7 +119,7 @@
  	Icon_State = "secborg-red"		//Probably a donor sprite.
  	eye_icon_state = "eyes-secborg-red"
  	headlight_icon_state = "eyes-standard-light"
- 	modules = list(/obj/item/weapon/robot_module/security
+ 	modules = list(/obj/item/weapon/robot_module/security)
 
 //Peacekeeper
 /datum/robot_skin/peaceborg

--- a/code/modules/mob/living/silicon/robot/robot_skins.dm
+++ b/code/modules/mob/living/silicon/robot/robot_skins.dm
@@ -117,7 +117,7 @@
 /datum/robot_skin/secred
  	name = "Red"
  	icon_State = "secborg-red"		//Probably a donor sprite.
- 	eye_icon_state = "eyes-secborg-red"
+ 	eye_icon_state = "eyes-standard"
  	headlight_icon_state = "eyes-standard-light"
  	modules = list(/obj/item/weapon/robot_module/security)
 

--- a/code/modules/mob/living/silicon/robot/robot_skins.dm
+++ b/code/modules/mob/living/silicon/robot/robot_skins.dm
@@ -116,7 +116,7 @@
 //Red
 /datum/robot_skin/secred
  	name = "Red"
- 	icon_State = "secborg-red"		//Probably a donor sprite.
+ 	icon_state = "secborg-red"		//Probably a donor sprite.
  	eye_icon_state = "eyes-standard"
  	headlight_icon_state = "eyes-standard-light"
  	modules = list(/obj/item/weapon/robot_module/security)

--- a/code/modules/mob/living/silicon/robot/robot_skins.dm
+++ b/code/modules/mob/living/silicon/robot/robot_skins.dm
@@ -112,7 +112,14 @@
 	eye_icon_state = "eyes-secborg"
 	headlight_icon_state = "eyes-secborg-lights"
 	modules = list(/obj/item/weapon/robot_module/security)
-
+	
+//Red
+/datum/robot_skin/secred
+ 	Name = "Red"
+ 	Icon_State = "secborg-red"		//Probably a donor sprite.
+ 	eye_icon_state = "eyes-secborg-red"
+ 	headlight_icon_state = "eyes-standard-light"
+ 	modules = list(/obj/item/weapon/robot_module/security
 
 //Peacekeeper
 /datum/robot_skin/peaceborg
@@ -123,7 +130,7 @@
 	eye_icon_state = "eyes-peaceborg"
 	headlight_icon_state = "eyes-peaceborg-lights"
 	modules = list(/obj/item/weapon/robot_module/peacekeeper)
-
+	
 //Janitor
 /datum/robot_skin/janiborg
 	name = "Janiborg"


### PR DESCRIPTION
### Intent of your Pull Request

Adds code for the red standard borg sprite for the security module. Sprite is already in the source files, but I'm classifying this as an image addition for sake of sanity. _Adding because there is a sizeable number of people that enjoy the standard borg model and when selecting non-standard module, will choose appearances that use the base of this model._
#### Changelog

:cl:  
imageadd: There is now a second sprite for the security module in the form of a standard borg with a red color scheme akin to the Yellow Engineering model, Purple Janitorial model, and Blue Medical model.
/:cl:
#