### PR TITLE
Replaces the slime consoles with glass tables

### DIFF
--- a/_maps/map_files/Yogstation/yogstation.2.1.3.dmm
+++ b/_maps/map_files/Yogstation/yogstation.2.1.3.dmm
@@ -50308,7 +50308,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/computer/camera_advanced/xenobio,
+/obj/structure/table/glass,
 /turf/open/floor/plasteel{
 	icon_state = "white"
 	},


### PR DESCRIPTION
### Intent of your Pull Request

requested by @OakBoscage
![image](https://user-images.githubusercontent.com/20558591/32130271-e963ea38-bb95-11e7-8dd6-fa1de17af120.png)


#### Changelog

:cl:  
tweak: Removed the slime consoles from xenobio, and replaced them with glass tables
/:cl:
