### PR TITLE
Zipgun

### DIFF
--- a/code/modules/projectiles/ammunition/magazines.dm
+++ b/code/modules/projectiles/ammunition/magazines.dm
@@ -76,6 +76,12 @@
 	caliber = "n762"
 	max_ammo = 7
 
+/obj/item/ammo_box/magazine/internal/shot/zipgun
+	name = "zipgun internal magazine"
+	ammo_type = /obj/item/ammo_casing/a357
+	caliber = "357"
+	max_ammo = 1
+
 // Shotgun internal mags
 /obj/item/ammo_box/magazine/internal/shot
 	name = "shotgun internal magazine"
@@ -121,8 +127,6 @@
 	name = "riot shotgun internal magazine"
 	ammo_type = /obj/item/ammo_casing/shotgun/rubbershot
 	max_ammo = 6
-
-
 
 
 /obj/item/ammo_box/magazine/internal/grenadelauncher

--- a/code/modules/projectiles/guns/projectile/revolver.dm
+++ b/code/modules/projectiles/guns/projectile/revolver.dm
@@ -373,3 +373,17 @@
 		new /obj/item/stack/cable_coil(get_turf(src), 10)
 		slung = 0
 		update_icon()
+
+
+// ZIP GUN //
+
+/obj/item/weapon/gun/projectile/revolver/doublebarrel/zipgun
+	name = "pen"
+	desc = "whatever the pen says. maybe visibly different this time"
+	icon = 'icons/obj/bureaucracy.dmi'
+	icon_state = "pen"
+	item_state = "pen"
+	slot_flags = SLOT_BELT | SLOT_EARS
+	w_class = 1
+	mag_type = /obj/item/ammo_box/magazine/internal/shot/zipgun
+	suppressed = 1

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -629,6 +629,11 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	surplus = 10
 	exclude_modes = list(/datum/game_mode/nuclear)
 
+/datum/uplink_item/stealthy_weapons/zipgun
+	name = "Zipgun"
+	desc = "A small, single shot pistol disguised as a regular pen. While everyone around can hear the  gunshot, it won't alert others who shot it."
+	cost = 4
+
 // Stealth Items
 /datum/uplink_item/stealthy_tools
 	category = "Stealth and Camouflage Items"


### PR DESCRIPTION

### Intent of your Pull Request

A small, one-shot .357 derringer disguised as a pen. Costs 4TC. Can be unloaded and reloaded the same was as an improvised shotgun. Gunshot still can be heard, but it will not alert in chat who shot it (Meaning if you're close enough that no one sees the bullet fly, no one will know who did it.).  Run up, pop your target to deal a decent amount of damage, then finish them off with less-then obviously evil weapons.

Debate me

Price?

Should I make it use Detective .38 rubber for the stun effect instead?
Should I make it so you can screwdriver it to use lethal .357 with a chance of backfiring and damaging you?

Delay on reloading (unscrewing the cap) to combat the fact that a hotkey wizard can easily rapid-fire the thing?

Should I make them noticeably "different" on examination?

Also the sprites are broken so don't merge this yet ha just kidding you won't see this for a few days anyway :^)

#### Changelog

:cl:  
rscadd: The syndicate have developed a new highly concealable firearm. Capable of a single shot, the zipgun is the perfect tool for highly covert operatives.
/:cl:
