### PR TITLE
Removes drone lights and gives them nightvision

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -46,6 +46,7 @@
 	staticOverlays = list()
 	hud_possible = list(DIAG_STAT_HUD, DIAG_HUD, ANTAG_HUD)
 	unique_name = TRUE
+	see_invisible = SEE_INVISIBLE_MINIMUM
 	var/staticChoice = "static"
 	var/list/staticChoices = list("static", "blank", "letter", "animal")
 	var/picked = FALSE //Have we picked our visual appearence (+ colour if applicable)

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -111,7 +111,6 @@
 	access_card = null
 	verbs -= /mob/living/verb/pulled //don't pull them onto the stun rune pls
 	verbs -= /mob/living/simple_animal/drone/verb/check_laws
-	verbs -= /mob/living/simple_animal/drone/verb/toggle_light
 	verbs -= /mob/living/simple_animal/drone/verb/drone_ping
 
 /mob/living/simple_animal/drone/cogscarab/Login()

--- a/code/modules/mob/living/simple_animal/friendly/drone/verbs.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/verbs.dm
@@ -12,20 +12,6 @@
 	to_chat(src, "<b>Drone Laws</b>")
 	to_chat(src, laws)
 
-/mob/living/simple_animal/drone/verb/toggle_light()
-	set category = "Drone"
-	set name = "Toggle drone light"
-	if(light_on == 2)
-		return
-	if(light_on)
-		AddLuminosity(-8)
-	else
-		AddLuminosity(8)
-
-	light_on = !light_on
-
-	to_chat(src, "<span class='notice'>Your light is now [light_on ? "on" : "off"].</span>")
-
 /mob/living/simple_animal/drone/verb/drone_ping()
 	set category = "Drone"
 	set name = "Drone ping"
@@ -53,4 +39,3 @@
 		staticChoice = selectedStatic
 
 	updateSeeStaticMobs()
-


### PR DESCRIPTION
### Intent of your Pull Request

Lights can fuck over slings and help phytosians. This also allows them to see through walls which just improves their ability to help the station 👍 

#### Changelog

:cl:  
tweak: The new series of NanoTrasen drones have had their optical sensors upgraded, meaning they no longer need a light to see.
/:cl:
