### PR TITLE
Red now obeys headlight policy.

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_skins.dm
+++ b/code/modules/mob/living/silicon/robot/robot_skins.dm
@@ -118,7 +118,7 @@
  	name = "Red"
  	icon_state = "secborg-red"		//Probably a donor sprite.
  	eye_icon_state = "eyes-standard"
- 	headlight_icon_state = "eyes-standard-light"
+ 	headlight_icon_state = "eyes-standard-lights"
  	modules = list(/obj/item/weapon/robot_module/security)
 
 //Peacekeeper


### PR DESCRIPTION

There was a problem with Red-Standard's headlights not showing up, making the sprite seem as though the cell were removed. This should patch that up. I also fucked up with #2799 which had a conflict...

### Intent of your Pull Request

Makes "Red" (standard sprite with a red skin) have actual headlights, and not look like he was killed by ashwalkers 2 hours before retirement but then reset, but without proper flashes.


#### Changelog
lights not showing up, making the sprite seem as though the cell were removed. This should patch that up.

### Intent of your Pull Request

Makes "Red" (standard sprite with a red skin) have actual headlights, and not look like he was killed by ashwalkers 2 hours before retirement but then reset, but without proper flashes.


#### Changelog

:cl:  
imageadd: "Red The Borg" now obeys headlight laws and has actual headlights to show for it. Does not mean he will obey the rest of Space Law.
/:cl:
