### PR TITLE
Refactors grown products with shells into a new proc, seed extractor can now deshell grown products.

### DIFF
--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -119,7 +119,7 @@
 
 /obj/item/weapon/storage/bag/plants/portaseeder
 	name = "portable seed extractor"
-	desc = "For the enterprising botanist on the go. Less efficient than the stationary model, it creates one seed per plant."
+	desc = "For the enterprising botanist on the go. Less efficient than the stationary model, it creates one seed per plant. Also has the function to deshell grown goods like eggplants easily."
 	icon_state = "portaseeder"
 	origin_tech = "biotech=3;engineering=2"
 
@@ -133,6 +133,15 @@
 		seedify(O, 1)
 	close_all()
 
+/obj/item/weapon/storage/bag/plants/portaseeder/verb/deshell()
+	set name = "Deshell grown products"
+	set category = "Object"
+	set desc = "Activate to deshell plants, dropping the items on the ground."
+	if(usr.stat || !usr.canmove || usr.restrained())
+		return
+	for(var/obj/item/O in contents)
+		deshell(O)
+	close_all()
 
 // -----------------------------
 //        Sheet Snatcher

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -140,7 +140,7 @@
 	if(usr.stat || !usr.canmove || usr.restrained())
 		return
 	for(var/obj/item/weapon/reagent_containers/food/snacks/grown/shell/O in contents)
-		O.deshell(O, usr, 1)
+		O.deshell(O, usr, 0)
 	close_all()
 
 // -----------------------------

--- a/code/game/objects/items/weapons/storage/bags.dm
+++ b/code/game/objects/items/weapons/storage/bags.dm
@@ -139,8 +139,8 @@
 	set desc = "Activate to deshell plants, dropping the items on the ground."
 	if(usr.stat || !usr.canmove || usr.restrained())
 		return
-	for(var/obj/item/O in contents)
-		deshell(O)
+	for(var/obj/item/weapon/reagent_containers/food/snacks/grown/shell/O in contents)
+		O.deshell(O, usr, 1)
 	close_all()
 
 // -----------------------------

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -169,7 +169,7 @@
 /obj/item/weapon/reagent_containers/food/snacks/grown/shell/proc/deshell(obj/item/O, mob/living/user, extraction)
 	user.unEquip(src)
 	if(O.trash)
-		var/obj/item/weapon/reagent/containers/food/snacks/grown/shell/trash = O
+		var/obj/item/weapon/T
 		if(ispath(trash, /obj/item/weapon/grown) || ispath(trash, /obj/item/weapon/reagent_containers/food/snacks/grown))
 			T = new (user.loc, seed)
 		else

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -168,7 +168,7 @@
 
 /obj/item/weapon/reagent_containers/food/snacks/grown/shell/proc/deshell(obj/item/O, mob/living/user, extraction)
 	user.unEquip(src)
-	if(O.trash)
+	if(trash)
 		var/obj/item/weapon/T
 		if(ispath(trash, /obj/item/weapon/grown) || ispath(trash, /obj/item/weapon/reagent_containers/food/snacks/grown))
 			T = new (user.loc, seed)

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -160,20 +160,15 @@
 			user.AddLuminosity(-G.get_lum(seed))
 			SetLuminosity(G.get_lum(seed))
 
-
-
 // For item-containing growns such as eggy or gatfruit
-/obj/item/weapon/reagent_containers/food/snacks/grown/shell/attack_self(mob/user as mob)
-	deshell(src, user)
+/obj/item/weapon/reagent_containers/food/snacks/grown/shell/attack_self(mob/user as mob, message)
+	deshell(src, user, 1)
 
-/obj/item/weapon/reagent_containers/food/snacks/grown/shell/proc/deshell(obj/item/O, mob/living/user, extraction)
-	user.unEquip(src)
+/obj/item/weapon/reagent_containers/food/snacks/grown/shell/proc/deshell(obj/item/O, mob/living/user, message)
 	if(trash)
 		var/obj/item/weapon/T
-		if(ispath(trash, /obj/item/weapon/grown) || ispath(trash, /obj/item/weapon/reagent_containers/food/snacks/grown))
-			T = new (user.loc, seed)
-		else
-			T = new trash(user.loc)
-		to_chat(user, "<span class='notice'>You open [O]\'s shell and a [T] drops on the ground.</span>")
+		T = new trash(user.loc)
+		if(message)
+			to_chat(user, "<span class='notice'>You open [O]\'s shell and a [T] drops on the ground.</span>")
 		qdel(O)
 		return 1

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -164,13 +164,15 @@
 
 // For item-containing growns such as eggy or gatfruit
 /obj/item/weapon/reagent_containers/food/snacks/grown/shell/attack_self(mob/user as mob)
+	deshell(src, user)
+
+/obj/item/weapon/reagent_containers/food/snacks/grown/shell/proc/deshell(obj/item/O, mob/living/user, extraction)
 	user.unEquip(src)
-	if(trash)
-		var/obj/item/weapon/T
+	if(O.trash)
 		if(ispath(trash, /obj/item/weapon/grown) || ispath(trash, /obj/item/weapon/reagent_containers/food/snacks/grown))
 			T = new trash(user.loc, seed)
 		else
 			T = new trash(user.loc)
-		user.put_in_hands(T)
-		to_chat(user, "<span class='notice'>You open [src]\'s shell, revealing \a [T].</span>")
-	qdel(src)
+		to_chat(user, "<span class='notice'>You open [O]\'s shell and a [T] drops on the ground.</span>")
+		qdel(O)
+		return 1

--- a/code/modules/hydroponics/grown.dm
+++ b/code/modules/hydroponics/grown.dm
@@ -169,8 +169,9 @@
 /obj/item/weapon/reagent_containers/food/snacks/grown/shell/proc/deshell(obj/item/O, mob/living/user, extraction)
 	user.unEquip(src)
 	if(O.trash)
+		var/obj/item/weapon/reagent/containers/food/snacks/grown/shell/trash = O
 		if(ispath(trash, /obj/item/weapon/grown) || ispath(trash, /obj/item/weapon/reagent_containers/food/snacks/grown))
-			T = new trash(user.loc, seed)
+			T = new (user.loc, seed)
 		else
 			T = new trash(user.loc)
 		to_chat(user, "<span class='notice'>You open [O]\'s shell and a [T] drops on the ground.</span>")


### PR DESCRIPTION
Allows the seed extractor to deshell grown products with a shell like egg plants or gatfruit. This also makes the attack_self of those plants call a proc instead to easily deshell products, instead of just calling attack_self on grown products you can just use a neater proc. 

#### Changelog

:cl:  ma44  
tweak: The seed extractor can now deshell grown products.
/:cl:
