### PR TITLE
Removes joining as an AI

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -190,7 +190,7 @@ EVENTS_MIN_PLAYERS_MUL 1
 ### AI ###
 
 ## Allow the AI job to be picked.
-ALLOW_AI
+#ALLOW_AI
 
 ### Secborg ###
 ## Uncomment to prevent the security cyborg module from being chosen


### PR DESCRIPTION
Fixes gamebreaking glitch allowing people to join as AIs at roundstart

#### Changelog

:cl:  
fix: You can no longer join as an AI
/:cl:
