### PR TITLE
Changes removed HyperKA borg upgrade to advance plasma cutter

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -177,7 +177,7 @@
 
 	return 1
 
-/obj/item/borg/upgrade/hyperka
+/*/obj/item/borg/upgrade/hyperka
 	name = "mining cyborg hyper-kinetic accelerator"
 	desc = "A satchel of holding replacement for mining cyborg's ore satchel module."
 	icon_state = "cyborg_upgrade3"
@@ -193,6 +193,22 @@
 		qdel(H)
 
 	R.module.modules += new /obj/item/weapon/gun/energy/kinetic_accelerator/hyper/cyborg(R.module)
+	R.module.rebuild()
+
+	return 1*/
+
+/obj/item/borg/upgrade/plasmacutter_adv
+	name = "mining cyborg advanced plasma cutter"
+	desc = "An advanced plasma cutter module"
+	icon_state = "cyborg_upgrade3"
+	require_module = 1
+	module_type = /obj/item/weapon/robot_module/miner
+
+/obj/item/borg/upgrade/plasmacutter_adv/action(mob/living/silicon/robot/R)
+	if(..())
+		return
+
+	R.module.modules += new /obj/item/weapon/gun/energy/plasmacutter/adv/cyborg(R.module)
 	R.module.rebuild()
 
 	return 1

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -124,6 +124,9 @@
 	delay = 10
 	e_cost = 10
 
+/obj/item/ammo_casing/energy/plasma/adv/cyborg
+	e_cost = 50
+
 /obj/item/ammo_casing/energy/wormhole
 	projectile_type = /obj/item/projectile/beam/wormhole
 	e_cost = 0

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -175,6 +175,14 @@
 	force = 18
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma/adv)
 
+/obj/item/weapon/gun/energy/plasmacutter/adv/cyborg
+	name = "cyborg advanced plasma cutter"
+	ammo_type = list(/obj/item/ammo_casing/energy/plasma/adv/cyborg)
+
+/obj/item/weapon/gun/energy/plasmacutter/adv/cyborg/newshot()
+	..()
+	robocharge()
+
 /obj/item/weapon/gun/energy/wormhole_projector
 	name = "bluespace wormhole projector"
 	desc = "A projector that emits high density quantum-coupled bluespace beams."

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -648,7 +648,7 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
-/datum/design/borg_upgrade_hyperka
+/*/datum/design/borg_upgrade_hyperka
 	name = "Cyborg Upgrade(Hyper-Kinetic Accelerator)"
 	id = "borg_upgrade_hyperka"
 	req_tech = list("materials" = 7, "powerstorage" = 5, "engineering" = 5, "magnets" = 5, "combat" = 4)
@@ -656,7 +656,7 @@
 	materials = list(MAT_METAL = 8000, MAT_GLASS = 1500, MAT_SILVER = 2000, MAT_GOLD = 2000, MAT_DIAMOND = 2000)
 	build_path = /obj/item/borg/upgrade/hyperka
 	construction_time = 120
-	category = list("Cyborg Upgrade Modules")
+	category = list("Cyborg Upgrade Modules")*/
 
 /*/datum/design/borg_upgrade_ashplating
 	name = "Cyborg Upgrade (Ash Storm Plating)"
@@ -667,6 +667,16 @@
 	materials = list(MAT_METAL = 8000, MAT_PLASMA = 10000)
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")*/
+
+/datum/design/borg_upgrade_plasmacutter_adv
+	name = "Cyborg Upgrade(Advanced Plasma Cutter)"
+	id = "borg_upgrade_plasmacutter_adv"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/plasmacutter_adv
+	req_tech = list("materials" = 4, "plasmatech" = 4, "engineering" = 2, "combat" = 3, "magnets" = 3) //Same as the human version
+	materials = list(MAT_METAL = 3000, MAT_GLASS = 1000, MAT_PLASMA = 2000, MAT_GOLD = 500) //Same price as human version. Could raise it, since its autocharge
+	construction_time = 120
+	category = list("Cyborg Upgrade Modules")
 
 /datum/design/borg_syndicate_module
 	name = "Cyborg Upgrade (Illegal Modules)"


### PR DESCRIPTION

### Intent of your Pull Request

Changes hyperKA upgrade to advance plasma cutter because hyperKA's got removed

Self-charges off borg power cell, but has e_cost = 50 to make up for it

can probably add a double-charger KA upgrade too if its worth it

#### Changelog

:cl:  
rscadd: Scientists have developed a plasma cutter module for the mining cyborgs.
/:cl:
