### PR TITLE
emagged arcade machines now drop minibombs

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -238,7 +238,8 @@
 
 			if(emagged)
 				feedback_inc("arcade_win_emagged")
-				new /obj/effect/spawner/newbomb/timer/syndicate(src.loc)
+				new /obj/item/weapon/grenade/syndieminibomb(src.loc)
+				new /obj/item/weapon/grenade/syndieminibomb(src.loc)
 				new /obj/item/clothing/head/collectable/petehat(src.loc)
 				message_admins("[key_name_admin(usr)] has outbombed Cuban Pete and been awarded a bomb.")
 				log_game("[key_name(usr)] has outbombed Cuban Pete and been awarded a bomb.")


### PR DESCRIPTION
Refer to issue #2761 

### Intent of your Pull Request

Atmos changes made pre-made spawned bombs duds, so now it gives you two minibombs for the risk of gibbing yourself on loss

#### Changelog

:cl:  
tweak: Emagged arcade machines drop minibombs rather thank tank bombs.
/:cl:
