### PR TITLE
Adds pouch of holding for wizards

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -391,6 +391,13 @@
 	item_path = /obj/item/weapon/twohanded/singularityhammer
 	log_name = "SI"
 
+/datum/spellbook_entry/item/pouch_of_holding
+	name = "Pouch of Holding"
+	desc = "An unassuming pouch worn around the waist that holds in it a pocket dimmension for storing items"
+	item_path = /obj/item/weapon/storage/belt/fannypack/holding/pouch
+	log_name = "PH"
+	category = "Assistance"
+
 // /datum/spellbook_entry/item/cursed_heart
 //	name = "Cursed Heart"
 //	desc = "A heart that has been revived by dark magicks, the user must \

--- a/code/game/objects/items/weapons/storage/belt.dm
+++ b/code/game/objects/items/weapons/storage/belt.dm
@@ -414,6 +414,14 @@
 		return 0
 	return ..()
 
+/obj/item/weapon/storage/belt/fannypack/holding/pouch
+	name = "pouch of holding"
+	desc = "This small belt pouch appears completely mundane, save for the oversized compartment inside it. This compartment is an extradimensional space, about two cubic feet in volume and holding up to twenty pounds. Retrieving an item from the pouch is a move action."
+	icon = 'icons/obj/dice.dmi'
+	icon_state = "magicdicebag"
+	item_state = "magicdicebag"
+	storage_slots = 12
+
 /obj/item/weapon/storage/belt/fannypack/black
 	name = "black fannypack"
 	icon_state = "fannypack_black"


### PR DESCRIPTION
### Intent of your Pull Request
Adds a pouch of holding item for wizard. Costs 2 points. Holds 12 items, or a maximum of 34 weight.(Holds the entirety of armory, except the shotguns so you can rush armory and pocket them all c;  )

Dicebag sprite
![Dicebag](https://i.gyazo.com/f592172bd776109576b2b0670197e4ac.png)
Pouch of Holding sprite (Already in-game, but not used anywhere at all)
![MagicDiceBag](https://i.gyazo.com/6861a2065aae3d878e1138551ed9caa0.png)

Entire armory in your belt, and still able to carry a staff on your back
![HowMuchItHolds](https://i.gyazo.com/2eb2e5e16e5646b185d3ebc52e3d1e61.png)

#### Changelog

:cl:  
rscadd: The Wizards Federation have cast a new spell to create pocket dimensions contained in Pouches of holding for storing items.
/:cl:
