### PR TITLE
Adds accepting objectives in exchange for TC

### DIFF
--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1088,7 +1088,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	desc = "An additional objective, chosen from either assassinate, steal or maroon"
 	item = /obj/item/weapon/wrench //we need an item or it won't be included in the uplink
 	cost = -5
-	var/max_objectives = 10
+	var/max_objectives = 5
 	exclude_modes = list(/datum/game_mode/nuclear)
 
 // Pointless

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1087,6 +1087,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	name = "Additional Objective"
 	desc = "An additional objective, chosen from either assassinate, steal or maroon"
 	item = /obj/item/weapon/wrench //we need an item or it won't be included in the uplink
+	surplus = 0
 	cost = -5
 	var/max_objectives = 5
 	exclude_modes = list(/datum/game_mode/nuclear)

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -1204,7 +1204,7 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	if(user.mind.special_role != "traitor")
 		return
 	if(user.mind.objectives.len >= max_objectives)
-		to_chat(user, "Our databases only have 10 available objectives. For more objectives, please contact your nearest syndicate commander.")
+		to_chat(user, "Our databases only have [max_objectives] available objectives. For more objectives, please contact your nearest syndicate commander.")
 		return
 	U.telecrystals -= cost
 


### PR DESCRIPTION
### Intent of your Pull Request

Adds a miscellaneous category, and adds the "extra objective" item to it. When bought, it adds 5 TC to the uplink and then gives the traitor an objective. Only traitors can use it.

You can use it till you have 5 objectives, so DA/hijack can get 15 TC more, whereas regular tatortots can get 10 more. It's not possible to get neither hijack nor glorious death, only steal, maroon, assassinate and destroy AI.

#### Changelog

:cl:  
rscadd: Traitors can now accept extra objectives from the syndicate through their PDA, in exchange for extra TC
/:cl:
