### PR TITLE
Fixes donors not having access to extra slots.

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -236,6 +236,7 @@ var/next_external_rsc = 0
 		if(prefs.toggles & QUIET_ROUND)
 			prefs.toggles &= ~QUIET_ROUND
 			prefs.save_preferences()
+	prefs.update_character_slots(src)
 	sethotkeys(1) //use preferences to set hotkeys (from_pref = 1)
 
 	. = ..()	//calls mob.Login()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -110,14 +110,6 @@ var/list/preferences_datums = list()
 	custom_names["cyborg"] = pick(ai_names)
 	custom_names["clown"] = pick(clown_names)
 	custom_names["mime"] = pick(mime_names)
-	if(istype(C))
-		if(!IsGuestKey(C.key))
-			load_path(C.ckey)
-			unlock_content |= C.IsByondMember()
-			if(unlock_content)
-				max_save_slots = 8
-			else if(is_donator(C))
-				max_save_slots = DONOR_CHARACTER_SLOTS
 	var/loaded_preferences_successfully = load_preferences()
 	if(loaded_preferences_successfully)
 		if(load_character())
@@ -1352,5 +1344,15 @@ var/list/preferences_datums = list()
 	if(character.dna)
 		features = character.dna.features.Copy()
 		pref_species = character.dna.species
+
+/datum/preferences/proc/update_character_slots(client/C)
+	if(istype(C))
+		if(!IsGuestKey(C.key))
+			load_path(C.ckey)
+			unlock_content |= C.IsByondMember()
+			if(unlock_content)
+				max_save_slots = 8
+			else if(is_donator(C))
+				max_save_slots = DONOR_CHARACTER_SLOTS
 
 #undef DONOR_CHARACTER_SLOTS


### PR DESCRIPTION
Previously the preferences datum would check to see if a user had donor before the client could assign themselves a donor status.

:cl:
bugfix: Donors now have access to 6 character slots!
/:cl: