### PR TITLE
Adds holodeck investigation.

### DIFF
--- a/code/modules/admin/admin_investigate.dm
+++ b/code/modules/admin/admin_investigate.dm
@@ -25,13 +25,13 @@
 	F << "<small>[time_stamp()] \ref[src] ([x],[y],[z])</small> || [src] [message]<br>"
 
 //ADMINVERBS
-/client/proc/investigate_show( subject in list("hrefs","notes","watchlist","singulo","wires","telesci", "gravity", "records", "cargo", "supermatter", "atmos", "experimentor", "kudzu", "viro", "tcomms", "pda", "ntsl", "chemistry", "arrivalmessage") )
+/client/proc/investigate_show( subject in list("hrefs","notes","watchlist","singulo","wires","telesci", "gravity", "records", "cargo", "supermatter", "atmos", "experimentor", "kudzu", "viro", "tcomms", "pda", "ntsl", "chemistry", "arrivalmessage", "holodeck") )
 	set name = "Investigate"
 	set category = "Admin"
 	if(!holder)
 		return
 	switch(subject)
-		if("singulo", "wires", "telesci", "gravity", "records", "cargo", "supermatter", "atmos", "kudzu", "viro", "tcomms", "pda", "ntsl", "chemistry", "arrivalmessage") //general one-round-only stuff
+		if("singulo", "wires", "telesci", "gravity", "records", "cargo", "supermatter", "atmos", "kudzu", "viro", "tcomms", "pda", "ntsl", "chemistry", "arrivalmessage", "holodeck") //general one-round-only stuff
 			var/F = investigate_subject2file(subject)
 			if(!F)
 				to_chat(src, "<font color='red'>Error: admin_investigate: [INVESTIGATE_DIR][subject] is an invalid path or cannot be accessed.</font>")

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -163,6 +163,7 @@
 			return
 		if(area == offline_program || (area in program_cache) || (emagged && (area in emag_programs)))
 			load_program(area)
+			investigate_log("[usr.real_name]([usr.ckey]) activated the [program.name].","holodeck")
 	else if("safety" in href_list)
 		if(!isaiorborg(usr))
 			message_admins("EXPLOIT: [usr] attempted to override [src]'s safeties without being a silicon.")
@@ -192,6 +193,7 @@
 		to_chat(user, "<span class='warning'>You vastly increase projector power and override the safety and security protocols.</span>")
 		to_chat(user, "Warning.  Automatic shutoff and derezing protocols have been corrupted.  Please call Nanotrasen maintenance and do not use the simulator.")
 		log_game("[key_name(user)] emagged the Holodeck Control Console")
+		investigate_log("[key_name(user)] emagged the [src].", "holodeck")
 		updateUsrDialog()
 		nerf(!emagged)
 


### PR DESCRIPTION
### Intent of your Pull Request

Adds a holodeck option in the investigate tab, so you can find out who keep turning on the atmospheric burn test all the time.

I _could_ make this `message_admins("cancer")` but I felt like doing an investigate category since spam and all that.

Works fine, I tested it, nothing of errors.

#### Changelog

:cl:  
rscadd: Added tools to let admins figure out who fucked with the holodeck.
/:cl:
