### PR TITLE
Makes forcesay check for lowercase

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -122,7 +122,8 @@
 		if(client)
 			var/virgin = 1	//has the text been modified yet?
 			var/temp = winget(client, "input", "text")
-			if((findtextEx(temp, "Say \"", 1, 7) && length(temp) > 5) || (findtextEx(temp, "say \"", 1, 7) && length(temp) > 5))	//"case sensitive means
+			temp = lowertext(temp)
+			if(findtextEx(temp, "say \"", 1, 7) && length(temp) > 5)
 
 				temp = replacetext(temp, ";", "")	//general radio
 

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -122,7 +122,7 @@
 		if(client)
 			var/virgin = 1	//has the text been modified yet?
 			var/temp = winget(client, "input", "text")
-			if(findtextEx(temp, "Say \"", 1, 7) && length(temp) > 5)	//"case sensitive means
+			if((findtextEx(temp, "Say \"", 1, 7) && length(temp) > 5) || (findtextEx(temp, "say \"", 1, 7) && length(temp) > 5))	//"case sensitive means
 
 				temp = replacetext(temp, ";", "")	//general radio
 


### PR DESCRIPTION
Previously it'd only trigger if you manually typed in "Say "". Which meant that anyone using the "toggle chat" preference weren't affected by it, since it autofills with a lowercase "say "".
