### PR TITLE
makes the cargo console use seconds

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -156,3 +156,15 @@
 			sold_atoms += recursive_sell(thing, level)
 	qdel(O)
 	return sold_atoms
+
+/obj/docking_port/mobile/supply/getStatusText()
+	var/obj/docking_port/stationary/dockedAt = get_docked()
+	. = (dockedAt && dockedAt.name) ? dockedAt.name : "unknown"
+	if(istype(dockedAt, /obj/docking_port/stationary/transit))
+		var/obj/docking_port/stationary/dst
+		if(mode == SHUTTLE_RECALL)
+			dst = previous
+		else
+			dst = destination
+		. += " towards [dst ? dst.name : "unknown location"] ([timeLeft(10)] seconds)"
+#undef DOCKING_PORT_HIGHLIGHT


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/20558591/33807972-0897a10e-dddf-11e7-89f4-bb3a9ac52f57.png)

"0 minutes" isn't helpful information.

#### Changelog

:cl:  
tweak: Nanotrasen Supply Shuttle Consoles have now been tweaked to state the shuttle timers in seconds
/:cl:
