### PR TITLE
Adds roller beds to crafting menu

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -370,6 +370,16 @@
 	reqs = list(/obj/item/stack/sheet/cloth = 4)
 	category = CAT_MISC
 
+/datum/crafting_recipe/roller_bed
+	name = "Roller bed"
+	result = /obj/structure/bed/roller
+	time = 50
+	reqs = list(/obj/item/weapon/bedsheet = 1,
+				/obj/item/stack/sheet/metal = 2,
+				/obj/item/stack/rods = 4)
+	category = CAT_MISC
+
+
 // TRIBAL //
 /datum/crafting_recipe/bonearmor
 	name = "Bone Armor"

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -377,6 +377,8 @@
 	reqs = list(/obj/item/weapon/bedsheet = 1,
 				/obj/item/stack/sheet/metal = 2,
 				/obj/item/stack/rods = 4)
+	tools = list(/obj/item/weapon/wrench = 1,
+			/obj/item/weapon/weldingtool = 1)
 	category = CAT_MISC
 
 


### PR DESCRIPTION

### Intent of your Pull Request
Adds roller beds to the crafting menu. Requirements are 4 metal rods, 2 metal sheets and 1 bedsheet.
[#631](https://github.com/yogstation13/yogstation/issues/631) is the feature request of craftable roller beds.

#### Changelog

:cl:  
rscadd: Adds roller beds to the crafting menu.
/:cl:
