### PR TITLE
Add AZERTY support to hotkeys

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -29,6 +29,7 @@ var/list/preferences_datums = list()
 
 	var/UI_style = "Midnight"
 	var/hotkeys = FALSE
+	var/hotkeysmode = FALSE		// FALSE = QWERTY, TRUE = AZERTY
 	var/tgui_fancy = TRUE
 	var/tgui_lock = TRUE
 	var/toggles = TOGGLES_DEFAULT
@@ -360,6 +361,7 @@ var/list/preferences_datums = list()
 			dat += "<h2>General Settings</h2>"
 			dat += "<b>UI Style:</b> <a href='?_src_=prefs;preference=ui'>[UI_style]</a><br>"
 			dat += "<b>Keybindings:</b> <a href='?_src_=prefs;preference=hotkeys'>[(hotkeys) ? "Hotkeys" : "Default"]</a><br>"
+			dat += "<b>Hotkeys mode:</b> <a href='?_src_=prefs;preference=hotkeysmode'>[(hotkeysmode) ? "AZERTY" : "QWERTY"]</a><br>"
 			dat += "<b>tgui Style:</b> <a href='?_src_=prefs;preference=tgui_fancy'>[(tgui_fancy) ? "Fancy" : "No Frills"]</a><br>"
 			dat += "<b>tgui Monitors:</b> <a href='?_src_=prefs;preference=tgui_lock'>[(tgui_lock) ? "Primary" : "All"]</a><br>"
 			dat += "<b>Play admin midis:</b> <a href='?_src_=prefs;preference=hear_midis'>[(toggles & SOUND_MIDI) ? "Yes" : "No"]</a><br>"
@@ -1195,6 +1197,9 @@ var/list/preferences_datums = list()
 
 				if("hotkeys")
 					hotkeys = !hotkeys
+
+				if("hotkeysmode")
+					hotkeysmode = !hotkeysmode
 
 				if("tgui_fancy")
 					tgui_fancy = !tgui_fancy

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -212,6 +212,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["lastchangelog"]		>> lastchangelog
 	S["UI_style"]			>> UI_style
 	S["hotkeys"]			>> hotkeys
+	S["hotkeysmode"]		>> hotkeysmode
 	S["tgui_fancy"]			>> tgui_fancy
 	S["tgui_lock"]			>> tgui_lock
 
@@ -249,6 +250,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	lastchangelog	= sanitize_text(lastchangelog, initial(lastchangelog))
 	UI_style		= sanitize_inlist(UI_style, list("Midnight", "Plasmafire", "Retro", "Slimecore", "Operative"), initial(UI_style))
 	hotkeys			= sanitize_integer(hotkeys, 0, 1, initial(hotkeys))
+	hotkeysmode		= sanitize_integer(hotkeysmode, 0, 1, initial(hotkeysmode))
 	tgui_fancy		= sanitize_integer(tgui_fancy, 0, 1, initial(tgui_fancy))
 	tgui_lock		= sanitize_integer(tgui_lock, 0, 1, initial(tgui_lock))
 	default_slot	= sanitize_integer(default_slot, 1, max_save_slots, initial(default_slot))
@@ -280,6 +282,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["lastchangelog"]		<< lastchangelog
 	S["UI_style"]			<< UI_style
 	S["hotkeys"]			<< hotkeys
+	S["hotkeysmode"]		<< hotkeysmode
 	S["tgui_fancy"]			<< tgui_fancy
 	S["tgui_lock"]			<< tgui_lock
 	S["be_special"]			<< be_special

--- a/code/modules/client/verbs/sethotkeys.dm
+++ b/code/modules/client/verbs/sethotkeys.dm
@@ -1,7 +1,7 @@
 /client/verb/sethotkeys(from_pref = 0 as num)
 	set name = "Set Hotkeys"
 	set hidden = 1
-	set desc = "Used to set mob-specific hotkeys or load hoykey mode from preferences"
+	set desc = "Used to set mob-specific hotkeys or load hotkey mode from preferences"
 
 	var/hotkey_default = "default"
 	var/hotkey_macro = "hotkeys"
@@ -18,7 +18,46 @@
 		hotkey_macro = mob.macro_hotkeys
 		hotkey_default = mob.macro_default
 
+	if(prefs.hotkeysmode)
+		hotkey_macro += "-azerty"
+		hotkey_default += "-azerty"
+
 	if(current_setting in default_macros)
 		winset(src, null, "mainwindow.macro=[hotkey_default] input.focus=true input.background-color=#d3b5b5")
 	else
 		winset(src, null, "mainwindow.macro=[hotkey_macro] mapwindow.map.focus=true input.background-color=#e0e0e0")
+
+/client/verb/togglehotkeys()
+	set name = "Toggle Hotkeys"
+	set hidden = 1
+	set desc = "Toggles between default mode and hotkeys mode"
+
+	var/hotkey_default = "default"
+	var/hotkey_macro = "hotkeys"
+
+	var/list/default_macros = list("default", "robot-default")
+	var/new_setting
+	var/default
+
+	var/current_setting = winget(src, "mainwindow", "macro")
+
+	if(mob)
+		hotkey_macro = mob.macro_hotkeys
+		hotkey_default = mob.macro_default
+
+
+	if(current_setting in default_macros)
+		new_setting = hotkey_macro
+		default = FALSE
+	else
+		new_setting = hotkey_default
+		default = TRUE
+
+	//Don't add the suffix if it's the default mode
+	if(prefs.hotkeysmode && !default)
+		new_setting += "-azerty"
+
+	if(default)
+		winset(src, null, "mainwindow.macro=[new_setting] input.focus=true input.background-color=#d3b5b5")
+	else
+		winset(src, null, "mainwindow.macro=[new_setting] mapwindow.map.focus=true input.background-color=#e0e0e0")

--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -1,7 +1,7 @@
 macro "default"
 	elem 
 		name = "TAB"
-		command = ".winset \"mainwindow.macro=hotkeys mapwindow.map.focus=true input.background-color=#e0e0e0\""
+		command = "Toggle-Hotkeys"
 	elem 
 		name = "CENTER+REP"
 		command = ".center"
@@ -135,7 +135,7 @@ macro "default"
 macro "hotkeys"
 	elem 
 		name = "Tab"
-		command = ".winset \"mainwindow.macro=default input.focus=true input.background-color=#d3b5b5\""
+		command = "Toggle-Hotkeys"
 	elem 
 		name = "Center+REP"
 		command = ".center"
@@ -332,10 +332,211 @@ macro "hotkeys"
 		name = "."
 		command = "dsay"
 
+macro "hotkeys-azerty"
+	elem 
+		name = "Tab"
+		command = "Toggle-Hotkeys"
+	elem 
+		name = "Center+REP"
+		command = ".center"
+	elem 
+		name = "Northeast"
+		command = ".northeast"
+	elem 
+		name = "Southeast"
+		command = ".southeast"
+	elem 
+		name = "Southwest"
+		command = ".southwest"
+	elem 
+		name = "Northwest"
+		command = ".northwest"
+	elem 
+		name = "CTRL+West"
+		command = "westface"
+	elem 
+		name = "West+REP"
+		command = ".moveleft"
+	elem 
+		name = "CTRL+North"
+		command = "northface"
+	elem 
+		name = "North+REP"
+		command = ".moveup"
+	elem 
+		name = "CTRL+East"
+		command = "eastface"
+	elem 
+		name = "East+REP"
+		command = ".moveright"
+	elem 
+		name = "CTRL+South"
+		command = "southface"
+	elem 
+		name = "South+REP"
+		command = ".movedown"
+	elem 
+		name = "Insert"
+		command = "a-intent right"
+	elem 
+		name = "Delete"
+		command = "delete-key-pressed"
+	elem 
+		name = "1"
+		command = "a-intent help"
+	elem 
+		name = "CTRL+1"
+		command = "a-intent help"
+	elem 
+		name = "2"
+		command = "a-intent disarm"
+	elem 
+		name = "CTRL+2"
+		command = "a-intent disarm"
+	elem 
+		name = "3"
+		command = "a-intent grab"
+	elem 
+		name = "CTRL+3"
+		command = "a-intent grab"
+	elem 
+		name = "4"
+		command = "a-intent harm"
+	elem 
+		name = "CTRL+4"
+		command = "a-intent harm"
+	elem 
+		name = "Q+REP"
+		command = ".moveleft"
+	elem 
+		name = "CTRL+Q+REP"
+		command = ".moveleft"
+	elem 
+		name = "B"
+		command = "resist"
+	elem 
+		name = "CTRL+B"
+		command = "resist"
+	elem 
+		name = "D+REP"
+		command = ".moveright"
+	elem 
+		name = "CTRL+D+REP"
+		command = ".moveright"
+	elem 
+		name = "E"
+		command = "quick-equip"
+	elem 
+		name = "CTRL+E"
+		command = "quick-equip"
+	elem 
+		name = "F"
+		command = "a-intent left"
+	elem 
+		name = "CTRL+F"
+		command = "a-intent left"
+	elem 
+		name = "G"
+		command = "a-intent right"
+	elem 
+		name = "CTRL+G"
+		command = "a-intent right"
+	elem 
+		name = "M"
+		command = "me"
+	elem 
+		name = "O"
+		command = "ooc"
+	elem 
+		name = "CTRL+O"
+		command = "ooc"
+	elem 
+		name = "A"
+		command = ".northwest"
+	elem 
+		name = "CTRL+A"
+		command = ".northwest"
+	elem 
+		name = "R"
+		command = ".southwest"
+	elem 
+		name = "CTRL+R"
+		command = ".southwest"
+	elem "s_key"
+		name = "S+REP"
+		command = ".movedown"
+	elem 
+		name = "CTRL+S+REP"
+		command = ".movedown"
+	elem 
+		name = "T"
+		command = "say"
+	elem "z_key"
+		name = "Z+REP"
+		command = ".moveup"
+	elem 
+		name = "CTRL+Z+REP"
+		command = ".moveup"
+	elem 
+		name = "X"
+		command = ".northeast"
+	elem 
+		name = "CTRL+X"
+		command = ".northeast"
+	elem 
+		name = "Y"
+		command = "Activate-Held-Object"
+	elem 
+		name = "CTRL+Y"
+		command = "Activate-Held-Object"
+	elem 
+		name = "W"
+		command = "Activate-Held-Object"
+	elem 
+		name = "CTRL+W"
+		command = "Activate-Held-Object"
+	elem 
+		name = "F1"
+		command = "adminhelp"
+	elem 
+		name = "CTRL+SHIFT+F1+REP"
+		command = ".options"
+	elem 
+		name = "F2+REP"
+		command = ".screenshot auto"
+	elem 
+		name = "SHIFT+F2+REP"
+		command = ".screenshot"
+	elem 
+		name = "F5"
+		command = "Aghost"
+	elem 
+		name = "F6"
+		command = "Player-Panel"
+	elem 
+		name = "F7"
+		command = "Admin-PM"
+	elem 
+		name = "F8"
+		command = "Invisimin"
+	elem 
+		name = "F9"
+		command = "Adminlisttickets"
+	elem 
+		name = "F12"
+		command = "F12"
+	elem "asay"
+		name = ","
+		command = "asay"
+	elem "dsay"
+		name = "."
+		command = "dsay"
+		
+		
 macro "robot-default"
 	elem 
 		name = "TAB"
-		command = ".winset \"mainwindow.macro=robot-hotkeys mapwindow.map.focus=true input.background-color=#e0e0e0\""
+		command = "Toggle-Hotkeys"
 	elem 
 		name = "CENTER+REP"
 		command = ".center"
@@ -456,11 +657,17 @@ macro "robot-default"
 	elem 
 		name = "F12"
 		command = "F12"
-
+	elem "asay"
+		name = ","
+		command = "asay"
+	elem "dsay"
+		name = "."
+		command = "dsay"
+		
 macro "robot-hotkeys"
 	elem 
 		name = "TAB"
-		command = ".winset \"mainwindow.macro=robot-default input.focus=true input.background-color=#d3b5b5\""
+		command = "Toggle-Hotkeys"
 	elem 
 		name = "CENTER+REP"
 		command = ".center"
@@ -632,7 +839,195 @@ macro "robot-hotkeys"
 	elem 
 		name = "F12"
 		command = "F12"
+	elem "asay"
+		name = ","
+		command = "asay"
+	elem "dsay"
+		name = "."
+		command = "dsay"
 
+macro "robot-hotkeys-azerty"
+	elem 
+		name = "TAB"
+		command = "Toggle-Hotkeys"
+	elem 
+		name = "CENTER+REP"
+		command = ".center"
+	elem 
+		name = "NORTHEAST"
+		command = ".northeast"
+	elem 
+		name = "SOUTHEAST"
+		command = ".southeast"
+	elem 
+		name = "NORTHWEST"
+		command = "unequip-module"
+	elem 
+		name = "CTRL+WEST"
+		command = "westface"
+	elem 
+		name = "WEST+REP"
+		command = ".moveleft"
+	elem 
+		name = "CTRL+NORTH"
+		command = "northface"
+	elem 
+		name = "NORTH+REP"
+		command = ".moveup"
+	elem 
+		name = "CTRL+EAST"
+		command = "eastface"
+	elem 
+		name = "EAST+REP"
+		command = ".moveright"
+	elem 
+		name = "CTRL+SOUTH"
+		command = "southface"
+	elem 
+		name = "SOUTH+REP"
+		command = ".movedown"
+	elem 
+		name = "INSERT"
+		command = "a-intent right"
+	elem 
+		name = "DELETE"
+		command = "delete-key-pressed"
+	elem 
+		name = "1"
+		command = "toggle-module 1"
+	elem 
+		name = "CTRL+1"
+		command = "toggle-module 1"
+	elem 
+		name = "2"
+		command = "toggle-module 2"
+	elem 
+		name = "CTRL+2"
+		command = "toggle-module 2"
+	elem 
+		name = "3"
+		command = "toggle-module 3"
+	elem 
+		name = "CTRL+3"
+		command = "toggle-module 3"
+	elem 
+		name = "4"
+		command = "a-intent left"
+	elem 
+		name = "CTRL+4"
+		command = "a-intent left"
+	elem 
+		name = "Q+REP"
+		command = ".moveleft"
+	elem 
+		name = "CTRL+Q+REP"
+		command = ".moveleft"
+	elem 
+		name = "B"
+		command = "resist"
+	elem 
+		name = "CTRL+B"
+		command = "resist"
+	elem 
+		name = "O"
+		command = "ooc"
+	elem 
+		name = "CTRL+O"
+		command = "ooc"
+	elem 
+		name = "D+REP"
+		command = ".moveright"
+	elem 
+		name = "CTRL+D+REP"
+		command = ".moveright"
+	elem 
+		name = "F"
+		command = "a-intent left"
+	elem 
+		name = "CTRL+F"
+		command = "a-intent left"
+	elem 
+		name = "G"
+		command = "a-intent right"
+	elem 
+		name = "CTRL+G"
+		command = "a-intent right"
+	elem 
+		name = "A"
+		command = "unequip-module"
+	elem 
+		name = "CTRL+A"
+		command = "unequip-module"
+	elem "s_key"
+		name = "S+REP"
+		command = ".movedown"
+	elem 
+		name = "CTRL+S+REP"
+		command = ".movedown"
+	elem 
+		name = "T"
+		command = "say"
+	elem "w_key"
+		name = "Z+REP"
+		command = ".moveup"
+	elem 
+		name = "CTRL+Z+REP"
+		command = ".moveup"
+	elem 
+		name = "X"
+		command = ".northeast"
+	elem 
+		name = "CTRL+X"
+		command = ".northeast"
+	elem 
+		name = "Y"
+		command = "Activate-Held-Object"
+	elem 
+		name = "CTRL+Y"
+		command = "Activate-Held-Object"
+	elem 
+		name = "W"
+		command = "Activate-Held-Object"
+	elem 
+		name = "CTRL+W"
+		command = "Activate-Held-Object"
+	elem 
+		name = "F1"
+		command = "adminhelp"
+	elem 
+		name = "CTRL+SHIFT+F1+REP"
+		command = ".options"
+	elem 
+		name = "F2+REP"
+		command = ".screenshot auto"
+	elem 
+		name = "SHIFT+F2+REP"
+		command = ".screenshot"
+	elem 
+		name = "F5"
+		command = "Aghost"
+	elem 
+		name = "F6"
+		command = "Player-Panel"
+	elem 
+		name = "F7"
+		command = "Admin-PM"
+	elem 
+		name = "F8"
+		command = "Invisimin"
+	elem 
+		name = "F9"
+		command = "Adminlisttickets"
+	elem 
+		name = "F12"
+		command = "F12"
+	elem "asay"
+		name = ","
+		command = "asay"
+	elem "dsay"
+		name = "."
+		command = "dsay"
+		
 
 menu "menu"
 	elem 


### PR DESCRIPTION
This makes playing on AZERTY a lot less painful. It adds a toggleable button to the game preferences to toggle between QWERTY mode and AZERTY mode. It defaults to QWERTY as to not bother people that play with it.

:cl:  
rscadd: Added AZERTY support to the hotkeys.
/:cl:
