### PR TITLE
Only non-braindead crew get antag weight increase at round end

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -440,6 +440,9 @@ var/datum/subsystem/ticker/ticker
 			else
 				to_chat(Player, "<font color='red'><b>You did not survive the events on [station_name()]...</b></FONT>")
 
+	if(mode.name != "extended (secret)" && mode.name != "extended (announced)")
+		mode.update_not_chosen_candidates() //reward non-antags for making it thru round
+
 	//Round statistics report
 	var/datum/station_state/end_state = new /datum/station_state()
 	end_state.count()

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -441,7 +441,7 @@ var/datum/subsystem/ticker/ticker
 				to_chat(Player, "<font color='red'><b>You did not survive the events on [station_name()]...</b></FONT>")
 
 	if(mode.name != "extended (secret)" && mode.name != "extended (announced)")
-		mode.update_not_chosen_candidates() //reward non-antags for making it thru round
+		mode.update_not_chosen_candidates() //reward non-antags with antag weight increase
 
 	//Round statistics report
 	var/datum/station_state/end_state = new /datum/station_state()

--- a/code/game/gamemodes/blob/blob.dm
+++ b/code/game/gamemodes/blob/blob.dm
@@ -39,7 +39,6 @@ var/list/blobs_legit = list() //used for win-score calculations, contains only b
 	blobwincount = initial(blobwincount) * cores_to_spawn
 
 	var/list/datum/mind/infestators = pick_candidate(amount = cores_to_spawn)
-	update_not_chosen_candidates()
 
 	for(var/v in infestators)
 		var/datum/mind/blob = v

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -109,7 +109,6 @@ This file's folder contains:
 	roundstart_player_count = num_players()
 
 	var/list/datum/mind/followers_of_holy_light = pick_candidate(amount = starter_servants)
-	update_not_chosen_candidates()
 
 	for(var/v in followers_of_holy_light)
 		var/datum/mind/servant = v

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -71,7 +71,6 @@
 	recommended_enemies = 3 + round(num_players()/15)
 
 	var/list/datum/mind/cultists = pick_candidate(amount = recommended_enemies)
-	update_not_chosen_candidates()
 
 	for(var/v in cultists)
 		var/datum/mind/cultist = v

--- a/code/game/gamemodes/cybermen/cybermen.dm
+++ b/code/game/gamemodes/cybermen/cybermen.dm
@@ -57,7 +57,6 @@ var/datum/cyberman_network/cyberman_network
 	#endif
 
 	var/list/datum/mind/tinmen = pick_candidate(amount = cybermen_num)
-	update_not_chosen_candidates()
 
 	for(var/v in tinmen)
 		var/datum/mind/cyberman = v

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -474,7 +474,7 @@
 		for(var/v in not_chosen)
 			var/datum/mind/candidate = v
 
-			if(candidate.current && candidate.current.client)
+			if(candidate.current && candidate.current.client && candidate.current.stat != DEAD) //dead and braindead people wont get their weight increased
 				var/client/C = candidate.current.client
 
 				if(C && C.last_cached_weight) //if it's not null, we've updated it during the picking stage
@@ -484,6 +484,7 @@
 					var/DBQuery/query = dbcon.NewQuery("UPDATE [format_table_name("player")] SET `antag_weight` = [weight] WHERE `ckey` = '[SQL_ckey]'")
 					query.Execute()
 					C.last_cached_weight = weight
+					to_chat(candidate.current, "<font color='green'><b>Your chance to become an antagonist in next round increased!</b></FONT>")
 
 /datum/game_mode/proc/get_players_for_role(role)
 	var/list/players = list()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -484,7 +484,7 @@
 					var/DBQuery/query = dbcon.NewQuery("UPDATE [format_table_name("player")] SET `antag_weight` = [weight] WHERE `ckey` = '[SQL_ckey]'")
 					query.Execute()
 					C.last_cached_weight = weight
-					to_chat(candidate.current, "<font color='green'><b>For playing thru the whole round your chance to become an antagonist increased!</b></FONT>")
+					to_chat(candidate.current, "<font color='green'><b>For playing through the whole round your chance to become an antagonist increased!</b></FONT>")
 
 /datum/game_mode/proc/get_players_for_role(role)
 	var/list/players = list()

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -474,7 +474,7 @@
 		for(var/v in not_chosen)
 			var/datum/mind/candidate = v
 
-			if(candidate.current && candidate.current.client && candidate.current.stat != DEAD) //dead and braindead people wont get their weight increased
+			if(candidate.current && candidate.current.client) //braindead people wont get their weight increased
 				var/client/C = candidate.current.client
 
 				if(C && C.last_cached_weight) //if it's not null, we've updated it during the picking stage
@@ -484,7 +484,7 @@
 					var/DBQuery/query = dbcon.NewQuery("UPDATE [format_table_name("player")] SET `antag_weight` = [weight] WHERE `ckey` = '[SQL_ckey]'")
 					query.Execute()
 					C.last_cached_weight = weight
-					to_chat(candidate.current, "<font color='green'><b>Your chance to become an antagonist in next round increased!</b></FONT>")
+					to_chat(candidate.current, "<font color='green'><b>For playing thru the whole round your chance to become an antagonist increased!</b></FONT>")
 
 /datum/game_mode/proc/get_players_for_role(role)
 	var/list/players = list()

--- a/code/game/gamemodes/gang/gang.dm
+++ b/code/game/gamemodes/gang/gang.dm
@@ -54,7 +54,6 @@ var/list/gang_colors_pool = list("red","orange","yellow","green","blue","purple"
 		gangs_to_create ++
 
 	var/list/datum/mind/mafiosos = pick_candidate(amount = gangs_to_create)
-	update_not_chosen_candidates()
 
 	for(var/v in mafiosos)
 		//Create the gang

--- a/code/game/gamemodes/handofgod/_handofgod.dm
+++ b/code/game/gamemodes/handofgod/_handofgod.dm
@@ -51,7 +51,6 @@ var/global/list/global_handofgod_structuretypes = list()
 		restricted_jobs += "Assistant"
 
 	var/list/datum/mind/hogs = pick_candidate(amount = recommended_enemies)
-	update_not_chosen_candidates()
 
 	for(var/F in hogs)
 		var/datum/mind/follower = F

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -30,7 +30,6 @@
 		n_agents = antag_candidates.len
 
 	var/list/datum/mind/new_cops = pick_candidate(amount = n_agents)
-	update_not_chosen_candidates()
 
 	for(var/v in new_cops)
 		var/datum/mind/new_syndicate = v

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -45,7 +45,6 @@
 		restricted_jobs += "Assistant"
 
 	var/list/datum/mind/communists = pick_candidate(amount = max_headrevs)
-	update_not_chosen_candidates()
 
 	for(var/v in communists)
 		var/datum/mind/lenin = v

--- a/code/game/gamemodes/shadowling/shadowling.dm
+++ b/code/game/gamemodes/shadowling/shadowling.dm
@@ -89,7 +89,6 @@ Made by Xhuis
 	var/shadowlings = max(2, round(num_players()/10))
 
 	var/list/datum/mind/shadowmen = pick_candidate(amount = shadowlings)
-	update_not_chosen_candidates()
 
 	for(var/v in shadowmen)
 		var/datum/mind/shadow = v

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -43,7 +43,6 @@
 		num_traitors = max(1, min(num_players(), traitors_possible))
 
 	var/list/datum/mind/backstabbers = pick_candidate(amount = num_traitors)
-	update_not_chosen_candidates()
 
 	for(var/v in backstabbers)
 		var/datum/mind/traitor = v

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -22,7 +22,6 @@
 /datum/game_mode/wizard/pre_setup()
 	//Potential here, people. Magin' Rages Light
 	var/list/datum/mind/selected_wizards = pick_candidate(amount = required_enemies)
-	update_not_chosen_candidates()
 
 	for(var/v in selected_wizards)
 		var/datum/mind/wizard = v

--- a/code/game/gamemodes/zombie/zombie.dm
+++ b/code/game/gamemodes/zombie/zombie.dm
@@ -19,7 +19,6 @@
 /datum/game_mode/zombies/pre_setup()
 	carriers_to_make = max(round(num_players()/players_per_carrier, 1), 1)
 	var/list/datum/mind/patient_zeros = pick_candidate(amount = carriers_to_make)
-	update_not_chosen_candidates()
 
 	for(var/j in patient_zeros)
 		var/datum/mind/carrier = j

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-extended
+traitor


### PR DESCRIPTION
This PR is to force players to value their life and to actually play in a round and not go braindead.
Antag weight (probability to become antag in next round) increases now at round end. Only alive, not braindead people who didnt roll antag are eligible for antag weight increase.

**EDIT: as people dont appreciate punishing crew who died now this only punish crew who were braindead when round ended**

:cl:    
tweak: Increased probability to become an antagonist is now awarded for non-antag players who were active during the round.
/:cl:
