### PR TITLE
Re enables lone operative event

### DIFF
--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -1,7 +1,6 @@
 /datum/round_event_control/operative
 	name = "Lone Operative"
 	typepath = /datum/round_event/ghost_role/operative
-	weight = 10
 	max_occurrences = 1
 	gamemode_blacklist = list("nuclear","wizard","revolution","blob")
 

--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -1,8 +1,9 @@
 /datum/round_event_control/operative
 	name = "Lone Operative"
 	typepath = /datum/round_event/ghost_role/operative
-	weight = 0 //Admin only
+	weight = 10 //Admin only
 	max_occurrences = 1
+	gamemode_blacklist = list("nuclear","wizard","revolution","blob")
 
 /datum/round_event/ghost_role/operative
 	minimum_required = 1

--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/operative
 	name = "Lone Operative"
 	typepath = /datum/round_event/ghost_role/operative
-	weight = 10 //Admin only
+	weight = 10
 	max_occurrences = 1
 	gamemode_blacklist = list("nuclear","wizard","revolution","blob")
 


### PR DESCRIPTION
One nuke op with 25tc, a stetchkin, and a bulldog. Can't happen in nuke ops, blob, rev and wiz.

#### Changelog

:cl:  
rscadd: The syndicate is now sending lone operatives to blow up stations!
/:cl:
