### PR TITLE
readds the weightless event

### DIFF
--- a/code/modules/events/weightless.dm
+++ b/code/modules/events/weightless.dm
@@ -13,20 +13,22 @@
 	endWhen = rand(40,80)
 
 /datum/round_event/weightless/announce()
-	command_alert("Warning: Failsafes for the station's artificial gravity arrays have been triggered. Please be aware that if this problem recurs it may result in formation of gravitational anomalies. Nanotrasen wishes to remind you that the unauthorised formation of anomalies within Nanotrasen facilities is strictly prohibited by health and safety regulation [rand(99,9999)][pick("a","b","c")]:subclause[rand(1,20)][pick("a","b","c")].")
+	priority_announce("Warning: Failsafes for the station's artificial gravity arrays have been triggered. Please be aware that if this problem recurs it may result in formation of gravitational anomalies. Nanotrasen wishes to remind you that the unauthorised formation of anomalies within Nanotrasen facilities is strictly prohibited by health and safety regulation [rand(99,9999)][pick("a","b","c")]: subclause[rand(1,20)][pick("a","b","c")].")
 
 /datum/round_event/weightless/start()
-	for(var/area/A in world)
-		A.gravitychange(0)
-
-	if(control)
-		control.weight *= 2
+	for(var/obj/machinery/gravity_generator/main/G in world)
+		if(G.breaker)
+			G.breaker = !G.breaker
+			G.toggleable = FALSE
+			G.set_power()
+			G.charge_count = 20
 
 /datum/round_event/weightless/end()
-	for(var/area/A in world)
-		A.gravitychange(1)
+	for(var/obj/machinery/gravity_generator/main/G in world)
+		if(!G.toggleable)
+			G.breaker = !G.breaker
+			G.toggleable = TRUE
+			G.set_power()
 
 	if(announceWhen >= 0)
-		command_alert("Artificial gravity arrays are now functioning within normal parameters. Please report any irregularities to your respective head of staff.")
-
-
+		priority_announce("Artificial gravity arrays are now functioning within normal parameters. Please report any irregularities to your respective head of staff.")

--- a/code/modules/power/gravitygenerator.dm
+++ b/code/modules/power/gravitygenerator.dm
@@ -122,6 +122,7 @@ var/const/GRAV_NEEDS_WRENCH = 3
 	var/charge_count = 100
 	var/current_overlay = null
 	var/broken_state = 0
+	var/toggleable = TRUE
 
 /obj/machinery/gravity_generator/main/Destroy() // If we somehow get deleted, remove all of our other parts.
 	investigate_log("was destroyed!", "gravity")
@@ -254,6 +255,8 @@ var/const/GRAV_NEEDS_WRENCH = 3
 		return
 
 	if(href_list["gentoggle"])
+		if(!toggleable)
+			return
 		breaker = !breaker
 		investigate_log("was toggled [breaker ? "<font color='green'>ON</font>" : "<font color='red'>OFF</font>"] by [usr.key].", "gravity")
 		set_power()

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -1161,6 +1161,7 @@
 #include "code\modules\events\spider_infestation.dm"
 #include "code\modules\events\spontaneous_appendicitis.dm"
 #include "code\modules\events\vent_clog.dm"
+#include "code\modules\events\weightless.dm"
 #include "code\modules\events\wormholes.dm"
 #include "code\modules\events\holiday\aprilfools.dm"
 #include "code\modules\events\holiday\halloween.dm"


### PR DESCRIPTION
Now it turns off the grav gen instead of just toggling grav off/on for all areas.

#### Changelog

:cl:  
rscadd: Due to budget cuts, nanotrasen gravity generators may cut out randomly. If you wait a while they will usually turn back on!
/:cl:
