### PR TITLE
Buffs the bulletproof helmet

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -31,7 +31,7 @@
 	desc = "A bulletproof combat helmet that excels in protecting the wearer against traditional projectile weaponry and explosives to a minor extent."
 	icon_state = "helmetalt"
 	item_state = "helmetalt"
-	armor = list(melee = 15, bullet = 40, laser = 10, energy = 10, bomb = 40, bio = 0, rad = 0)
+	armor = list(melee = 15, bullet = 80, laser = 10, energy = 10, bomb = 40, bio = 0, rad = 0)
 	can_flashlight = 1
 	dog_fashion = null
 


### PR DESCRIPTION
I painfully discovered that the bulletproof helmet actually only gives you 10 extra armor compared to the normal helmet. While bulletproof ARMOR has 80 bulletresistence. Since literally everyone aims for the head, it only makes sense to have the gear actually matter in a fight, instead of it still being a three shot kill.
For reference:
Normal helmet: 30 bulletresistence
Bulletproof helmet : 40 resistence (now 80 as of this PR)
Bulletproof armor: 80 bullet resistence

:cl:
tweak: Bulletproof helmets are actually resistent to bullets now. 
/:cl: