### PR TITLE
Fixes paintballs!

### DIFF
--- a/code/modules/projectiles/guns/projectile/paintball.dm
+++ b/code/modules/projectiles/guns/projectile/paintball.dm
@@ -102,15 +102,18 @@
 
 
 /obj/item/ammo_casing/paintball/Crossed(atom/movable/mover)
-	to_chat(mover, "SPLAT!")
-	var/spreadem = rand(1,100)
-	var/turf/theturf = get_turf(src)
-	theturf.color = src.color
-	if(spreadem < 2 || spreadem == 1)
-		src.visible_message("[src] explodes in a shower of paint! covering everything around it in sticky horridness.")
-		for(var/atom/movable/T in orange(3, src))
-			T.color = src.color //ohhhhh you're gonna hate me after this Enka ;)
-	qdel(src)
+	if(isliving(mover))
+		to_chat(mover, "SPLAT!")
+		var/turf/theturf = get_turf(src)
+		theturf.color = src.color
+		if(prob(1))
+			src.visible_message("[src] explodes in a shower of paint! covering everything around it in sticky horridness.")
+			for(var/atom/movable/T in orange(3, src))
+				if(!istype(T,/mob/dead))
+					T.color = src.color //ohhhhh you're gonna hate me after this Enka ;)
+		qdel(src)
+	else
+		. = ..()
 
 /obj/item/ammo_box/magazine/paintball/blue
 	name = "paintball ammo cartridge (blue)"

--- a/code/modules/projectiles/guns/projectile/paintball.dm
+++ b/code/modules/projectiles/guns/projectile/paintball.dm
@@ -101,13 +101,13 @@
 	max_ammo = 20
 
 
-/obj/item/ammo_casing/paintball/Crossed(atom/movable/mover)
+/obj/item/ammo_casing/paintball/Crossed(mob/living/mover)
 	if(isliving(mover))
 		to_chat(mover, "SPLAT!")
 		var/turf/theturf = get_turf(src)
 		theturf.color = src.color
 		if(prob(1))
-			src.visible_message("[src] explodes in a shower of paint! covering everything around it in sticky horridness.")
+			src.visible_message("[src] explodes in a shower of paint, covering everything around it in sticky horridness!")
 			for(var/atom/movable/T in orange(3, src))
 				if(!istype(T,/mob/dead))
 					T.color = src.color //ohhhhh you're gonna hate me after this Enka ;)

--- a/code/modules/projectiles/guns/projectile/paintball.dm
+++ b/code/modules/projectiles/guns/projectile/paintball.dm
@@ -1,4 +1,3 @@
-
 /obj/item/weapon/gun/projectile/automatic/paintball
 	name = "paintball gun (blue)"
 	desc = "An entry level paintball gun. This one comes in blue."
@@ -101,6 +100,18 @@
 	icon_state = "paintballmag"
 	max_ammo = 20
 
+
+/obj/item/ammo_casing/paintball/Crossed(atom/movable/mover)
+	to_chat(mover, "SPLAT!")
+	var/spreadem = rand(1,100)
+	var/turf/theturf = get_turf(src)
+	theturf.color = src.color
+	if(spreadem < 2 || spreadem == 1)
+		src.visible_message("[src] explodes in a shower of paint! covering everything around it in sticky horridness.")
+		for(var/atom/movable/T in orange(3, src))
+			T.color = src.color //ohhhhh you're gonna hate me after this Enka ;)
+	qdel(src)
+
 /obj/item/ammo_box/magazine/paintball/blue
 	name = "paintball ammo cartridge (blue)"
 	ammo_type = /obj/item/ammo_casing/paintball/blue
@@ -116,13 +127,22 @@
 /obj/item/projectile/bullet/paintball/on_hit(atom/target, blocked = 0)
 	if(iscarbon(target))
 		var/mob/living/carbon/human/H = target
-		var/image/paintoverlay = image('icons/effects/paintball.dmi')
-		paintoverlay.color = color //colour the paint splats in
-		paintoverlay.icon_state = pick("1","2","3","4","5","6","7")
-		H.overlays += paintoverlay
+		if(prob(10))
+			H.color = color
+		if(H.wear_suit)
+			H.wear_suit.add_blood(H)
+			H.update_inv_wear_suit(1)    //updates mob overlays to show the new blood (no refresh)
+		else if(H.w_uniform)
+			H.w_uniform.add_blood(H)
+			H.update_inv_w_uniform(1)    //updates mob overlays to show the new blood (no refresh)
 		H << "<span class='warning'>Your feel a sharp sting.</span>"
-	else if(isturf(target))
-		target.color = color //paints walls that it hits with paint
+	else
+		target.color = color //paints EVERYTHING THAT IT HITS WITH FUCKING PAINT
+
+/obj/effect/decal/cleanable/paintball_splat
+	name = "paintball splat"
+	icon = 'icons/effects/paintball.dmi'
+	icon_state = "1"
 
 //Colour list reference, in case you wanna make more ammo types
 	//		if("red")


### PR DESCRIPTION
Refer to issue #2890

### Intent of your Pull Request

This PR fixes paintballs! I got rid of the shitty overlay thing I did and they now just make your clothes progressively more bloody with each hit. The casings now POP when you walk on them, covering the tile below in paint, with a small chance to cover EVERYTHING around it in paint (1/100), it also has a 1/10 chance to colour you in when hit, which won't be easy to remove. 

You have been warned!

My copy of yogstation lagged pretty badly so I didn't get footage :^(

#### Changelog

:cl:Kmc2000
tweak: Paintballs are now cleanable, they will make your clothes appear bloody
tweak: Paintball ammo can now be squashed by walking over it, getting rid of the pellet and staining the floor below - Small chance to splat paint everywhere when you do.
/:cl:
