### PR TITLE
Ghostrole Cooldown

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -339,6 +339,11 @@ var/list/bloody_footprints_cache = list()
 #define SENTIENCE_MINEBOT 4
 #define SENTIENCE_BOSS 5
 
+
+//Ghost role timers
+#define DEFAULT_RESPAWN_TIME 18000 //In decimals. 30 minutes
+#define DRONE_WAIT 18000  //In decimals. 30 minutes
+
 //Fire stuff, for burn_state
 #define LAVA_PROOF -2
 #define FIRE_PROOF -1

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -23,7 +23,7 @@
 	anchored = 1
 	var/jobban_type
 
-/obj/effect/mob_spawn/attack_ghost(mob/user)
+/obj/effect/mob_spawn/attack_ghost(mob/dead/observer/user)
 	if(ticker.current_state != GAME_STATE_PLAYING || !loc)
 		return
 	if(!uses)
@@ -31,6 +31,8 @@
 		return
 	if(jobban_type && jobban_isbanned(user, jobban_type))
 		to_chat(user, "<span class='warning'>You are banned from this role.</span>")
+		return
+	if(!user.respawn_check(mob_name, DEFAULT_RESPAWN_TIME))
 		return
 	var/ghost_role = alert("Become [mob_name]? (Warning, You can no longer be cloned!)",,"Yes","No")
 	if(ghost_role == "No" || !loc)
@@ -69,6 +71,7 @@
 
 /obj/effect/mob_spawn/proc/create(ckey)
 	var/mob/living/M = new mob_type(get_turf(src)) //living mobs only
+	M.is_ghostrole = TRUE
 	if(!random)
 		M.real_name = mob_name ? mob_name : M.name
 		M.gender = mob_gender

--- a/code/modules/mob/living/carbon/brain/posibrain.dm
+++ b/code/modules/mob/living/carbon/brain/posibrain.dm
@@ -63,8 +63,11 @@ var/global/posibrain_notif_cooldown = 0
 	activate(user)
 
 //Two ways to activate a positronic brain. A clickable link in the ghost notif, or simply clicking the object itself.
-/obj/item/device/mmi/posibrain/proc/activate(mob/user)
+/obj/item/device/mmi/posibrain/proc/activate(mob/dead/observer/user)
 	if(used || (brainmob && brainmob.key) || jobban_isbanned(user,"posibrain"))
+		return
+
+	if(!user.respawn_check(name, DEFAULT_RESPAWN_TIME))
 		return
 
 	var/posi_ask = alert("Become a [name]? (Warning, You can no longer be cloned, and all past lives will be forgotten!)","Are you positive?","Yes","No")

--- a/code/modules/mob/living/living_defines.dm
+++ b/code/modules/mob/living/living_defines.dm
@@ -72,5 +72,5 @@
 	var/obj/effect/proc_holder/ranged_ability //Any ranged ability the mob has, as a click override
 
 	var/list/status_effects //a list of all status effects the mob has
-	
+
 	var/gunfiring = list()

--- a/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/drones_as_items.dm
@@ -14,7 +14,7 @@
 	icon = 'icons/mob/drone.dmi'
 	icon_state = "drone_maint_hat"//yes reuse the _hat state.
 	origin_tech = "programming=2;biotech=4"
-	var/drone_type = /mob/living/simple_animal/drone //Type of drone that will be spawned
+	var/mob/living/simple_animal/drone/drone_type = /mob/living/simple_animal/drone //Type of drone that will be spawned
 
 /obj/item/drone_shell/New()
 	..()
@@ -22,7 +22,7 @@
 	if(A)
 		notify_ghosts("A drone shell has been created in \the [A.name].", source = src, action=NOTIFY_ATTACK)
 
-/obj/item/drone_shell/attack_ghost(mob/user)
+/obj/item/drone_shell/attack_ghost(mob/dead/observer/user)
 	if(jobban_isbanned(user,"drone"))
 		return
 	if(config.use_age_restriction_for_jobs)
@@ -34,11 +34,20 @@
 	if(!ticker.mode)
 		to_chat(user, "Can't become a drone before the game has started.")
 		return
+
+	if(world.time < DRONE_WAIT)
+		to_chat(user, "<span class='warning'>You can only be a drone after the [round(DRONE_WAIT / 600)] mark has passed.</span>")
+		return
+
+	if(!user.respawn_check("a drone", DEFAULT_RESPAWN_TIME))
+		return
+
 	var/be_drone = alert("Become a drone? (Warning, You can no longer be cloned!)",,"Yes","No")
 	if(be_drone == "No" || qdeleted(src))
 		return
 	var/mob/living/simple_animal/drone/D = new drone_type(get_turf(loc))
 	D.key = user.key
+	D.is_ghostrole = TRUE
 	qdel(src)
 
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -152,3 +152,5 @@
 	var/list/observers = null	//The list of people observing this mob.
 
 	var/list/progressbars = null	//for stacking do_after bars
+
+	var/is_ghostrole = FALSE //Only for stuff you select. Like drones and ashwalkers, not stuff that pops up, like revenants.


### PR DESCRIPTION
Requested by THE COUNCIL. 
Ports https://github.com/tgstation/tgstation/pull/33953 by @coiax 
Also has some of my own magic worked into it so you don't have to wait 30 minutes even if you observed or just died as a non-ghostrole

Adds a 30 minute cooldown between ghost role spawns. 
Drones can't be activated before the 30 minute mark
:cl:
tweak: Adds a 30 minute cooldown between ghost role spawns. Ported from coiax
tweak: Drones can't be activated before the 30 minute mark
/:cl:

  
  