### PR TITLE
Comments out morph event code

### DIFF
--- a/code/game/gamemodes/miniantags/morph/morph.dm
+++ b/code/game/gamemodes/miniantags/morph/morph.dm
@@ -195,9 +195,9 @@
 			return
 	target.attack_animal(src)
 
-//Spawn Event
+//Spawn Event --- Commented out as it spawned despite being weight 0 :thonk:
 
-/datum/round_event_control/morph
+/*/datum/round_event_control/morph
 	name = "Spawn Morph"
 	typepath = /datum/round_event/ghost_role/morph
 	weight = 0 //Admin only
@@ -229,3 +229,4 @@
 	log_game("[selected.key] was spawned as a morph by an event.")
 	spawned_mobs += S
 	return SUCCESSFUL_SPAWN
+*/


### PR DESCRIPTION
their weight is set to 0, yet they still happen. I'm too lazy to find the actual reason, but this achieves the same thing, and is as easily revertable

:cl:  
bugfix: Morphs shouldn't happen any more.
/:cl:
