### PR TITLE
Nerfs slaughter demons a tad

### DIFF
--- a/code/game/gamemodes/miniantags/slaughter/slaughter.dm
+++ b/code/game/gamemodes/miniantags/slaughter/slaughter.dm
@@ -72,6 +72,9 @@
 	speed = 0
 	boost = world.time + 20
 
+/mob/living/simple_animal/slaughter/bloodpool_sink(obj/effect/decal/cleanable/B)
+	if(boost<world.time) //Wait till the boost has ended before re-entering a period
+		..()
 
 //The loot from killing a slaughter demon - can be consumed to allow the user to blood crawl
 /obj/item/organ/heart/demon
@@ -170,7 +173,6 @@
 /mob/living/simple_animal/slaughter/laughter/proc/release_friends()
 	if(!consumed_mobs)
 		return
-
 	for(var/mob/living/M in consumed_mobs)
 		if(!M)
 			continue


### PR DESCRIPTION
Slaughter demons need to wait 2 seconds for the speed boost to wear off before re-entering the blood. 

This is to discourage the extreme bitchiness that they got going on. It won't change much, but it's a step in the right direction.

:cl:
tweak: help im having a stro
/:cl: