### PR TITLE
Fixes instakilling cosmic ashwalker eggs

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -166,6 +166,7 @@
 		else
 			health -= weapon.force
 	playsound(loc, weapon.hitsound, 50, 1, 1)
+	user.changeNext_move(CLICK_CD_MELEE)
 
 /obj/effect/cyrogenicbubble/attack_animal(mob/living/simple_animal/M)
 	var/damage = rand(M.melee_damage_lower, M.melee_damage_upper)


### PR DESCRIPTION
There was no click cooldown so you could instantly destroy it by clicking fast enough.
:cl:
fix: The cosmic ashwalker has evolved, and his stasis egg isn't weak to quick blows anymore
/:cl:
