### PR TITLE
Updates the abductor surgery manual

### DIFF
--- a/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
+++ b/code/game/gamemodes/miniantags/abduction/abduction_gear.dm
@@ -325,15 +325,16 @@
 <br>
  1.Acquire fresh specimen.<br>
  2.Put the specimen on operating table<br>
- 3.Apply surgical drapes preparing for dissection<br>
+ 3.Apply surgical drapes preparing for experimental dissection<br>
  4.Apply scalpel to specimen torso<br>
- 5.Retract skin from specimen's torso<br>
- 6.Apply scalpel to specimen's torso<br>
- 7.Search through the specimen's torso with your hands to remove any organs<br>
- 8.Insert replacement gland (Retrieve one from gland storage)<br>
- 9.Consider dressing the specimen back to not disturb the habitat <br>
- 10.Put the specimen in the experiment machinery<br>
- 11.Choose one of the machine options and follow displayed instructions<br>
+ 5.Clamp bleeders from specimen's torso.<br>
+ 6.Retract skin from specimen's torso<br>
+ 7.Apply scalpel to specimen's torso<br>
+ 8.Search through the specimen's torso with your hands to remove any organs<br>
+ 9.Insert replacement gland (Retrieve one from gland storage)<br>
+ 10.Consider dressing the specimen back to not disturb the habitat <br>
+ 11.Put the specimen in the experiment machinery<br>
+ 12.Choose one of the machine options and follow displayed instructions<br>
 <br>
 Congratulations! You are now trained for xenobiology research!"}
 


### PR DESCRIPTION
Adds the hemostat in the steps: without this fix it may confuse first time abductors. Also specifies the "experimental" dissection option for the drapes, for that _tiny_ bit of extra clarity.
closes #2858 

:cl: retrosquid64
tweak: Abduction surgery manual updated to include vital steps
/:cl: