### PR TITLE
Removes extraction sting, changes absorb objective

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -128,7 +128,7 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 
 	var/datum/objective/absorb/absorb_objective = new
 	absorb_objective.owner = changeling
-	absorb_objective.gen_amount_goal(6, 8)
+	absorb_objective.gen_amount_goal(10)
 	changeling.objectives += absorb_objective
 
 	if(prob(60))
@@ -511,4 +511,3 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 	var/datum/atom_hud/antag/hud = huds[ANTAG_HUD_CHANGELING]
 	hud.leave_hud(changling_mind.current)
 	set_antag_hud(changling_mind.current, null)
-

--- a/code/game/gamemodes/changeling/powers/tiny_prick.dm
+++ b/code/game/gamemodes/changeling/powers/tiny_prick.dm
@@ -161,6 +161,7 @@
 	target.update_inv_l_hand()
 	target.update_inv_r_hand()
 
+/* EXTRACT DNA STING REMOVED, TO ALLOW AND ENCOURAGE LINGS TO ABSORB INSTEAD
 /obj/effect/proc_holder/changeling/sting/extract_dna
 	name = "Extract DNA Sting"
 	desc = "We stealthily sting a target and extract their DNA."
@@ -187,6 +188,7 @@
 	user.mind.changeling.add_new_profile(target, user, protect)
 	feedback_add_details("changeling_powers","ED")
 	return 1
+*/
 
 /obj/effect/proc_holder/changeling/sting/mute
 	name = "Mute Sting"

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -698,7 +698,7 @@ var/global/list/possible_items_special = list()
 			for(var/mob/living/carbon/human/P in player_list)
 				if(P.client && !(P.mind in ticker.mode.changelings) && P.mind!=owner)
 					n_p ++
-		target_amount = min(10, max(2, round(n_p/5))) //
+		target_amount = min(10, max(2, round(n_p/10))) //
 
 	explanation_text = "Extract [target_amount] compatible genome\s."
 	return target_amount

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -687,8 +687,7 @@ var/global/list/possible_items_special = list()
 /datum/objective/absorb
 	dangerrating = 10
 
-/datum/objective/absorb/proc/gen_amount_goal(lowbound = 4, highbound = 6)
-	target_amount = rand (lowbound,highbound)
+/datum/objective/absorb/proc/gen_amount_goal(maximum = 10)
 	if (ticker)
 		var/n_p = 1 //autowin
 		if (ticker.current_state == GAME_STATE_SETTING_UP)
@@ -699,7 +698,7 @@ var/global/list/possible_items_special = list()
 			for(var/mob/living/carbon/human/P in player_list)
 				if(P.client && !(P.mind in ticker.mode.changelings) && P.mind!=owner)
 					n_p ++
-		target_amount = min(target_amount, n_p)
+		target_amount = min(10, max(2, round(n_p/5))) //
 
 	explanation_text = "Extract [target_amount] compatible genome\s."
 	return target_amount
@@ -940,6 +939,3 @@ var/global/list/possible_items_special = list()
 /datum/objective/changeling_team_objective/impersonate_department/impersonate_heads
 	explanation_text = "Have X or more heads of staff escape on the shuttle disguised as heads, while the real heads are dead"
 	command_staff_only = TRUE
-
-
-

--- a/data/mode.txt
+++ b/data/mode.txt
@@ -1,1 +1,1 @@
-extended
+changeling


### PR DESCRIPTION
Absorb objective changed to somewhere between 2 and 10, depending on server pop. for every 5 pop, the amount increments by 1, up to a max of 10, at 50

Closes #2656 Closes #2765 

#### Changelog

:cl:  
rscdel: Extraction Sting has been removed from changelings, absorbing is now necessary
tweak: absorb objective scaling changed, for more information check github
/:cl:
