### PR TITLE
Removes clothing from absorbs/DNA-sting

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -376,21 +376,6 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 	prof.undershirt = H.undershirt
 	prof.socks = H.socks
 
-	var/list/slots = list("head", "wear_mask", "back", "wear_suit", "w_uniform", "shoes", "belt", "gloves", "glasses", "ears", "wear_id", "s_store")
-	for(var/slot in slots)
-		if(slot in H.vars)
-			var/obj/item/I = H.vars[slot]
-			if(!I)
-				continue
-			prof.name_list[slot] = I.name
-			prof.appearance_list[slot] = I.appearance
-			prof.flags_cover_list[slot] = I.flags_cover
-			prof.item_color_list[slot] = I.item_color
-			prof.item_state_list[slot] = I.item_state
-			prof.exists_list[slot] = 1
-		else
-			continue
-
 	return prof
 
 /datum/changeling/proc/add_profile(datum/changelingprofile/prof)
@@ -511,4 +496,3 @@ var/list/slot2type = list("head" = /obj/item/clothing/head/changeling, "wear_mas
 	var/datum/atom_hud/antag/hud = huds[ANTAG_HUD_CHANGELING]
 	hud.leave_hud(changling_mind.current)
 	set_antag_hud(changling_mind.current, null)
-

--- a/code/game/gamemodes/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/changeling/powers/absorb.dm
@@ -116,6 +116,7 @@
 //datum/changeling/proc/store_dna(datum/dna/new_dna, mob/user)
 
 
+
 //BELOW IS DISABLED DUE TO COUNCIL VOTE, TOO MUCH GRIEF
 /*
 /obj/effect/proc_holder/changeling/swap_form

--- a/code/game/gamemodes/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/changeling/powers/absorb.dm
@@ -116,7 +116,8 @@
 //datum/changeling/proc/store_dna(datum/dna/new_dna, mob/user)
 
 
-
+//BELOW IS DISABLED DUE TO COUNCIL VOTE, TOO MUCH GRIEF
+/*
 /obj/effect/proc_holder/changeling/swap_form
 	name = "Swap Forms"
 	desc = "We force ourselves into the body of another form, pushing their consciousness into the form we left behind."
@@ -168,3 +169,4 @@
 
 	user.Paralyse(2)
 	to_chat(target, "<span class='warning'>Our genes cry out as we swap our [user] form for [target].</span>")
+*/

--- a/code/game/gamemodes/changeling/powers/absorb.dm
+++ b/code/game/gamemodes/changeling/powers/absorb.dm
@@ -117,8 +117,6 @@
 
 
 
-//BELOW IS DISABLED DUE TO COUNCIL VOTE, TOO MUCH GRIEF
-/*
 /obj/effect/proc_holder/changeling/swap_form
 	name = "Swap Forms"
 	desc = "We force ourselves into the body of another form, pushing their consciousness into the form we left behind."
@@ -170,4 +168,3 @@
 
 	user.Paralyse(2)
 	to_chat(target, "<span class='warning'>Our genes cry out as we swap our [user] form for [target].</span>")
-*/

--- a/code/game/gamemodes/changeling/powers/transform.dm
+++ b/code/game/gamemodes/changeling/powers/transform.dm
@@ -127,10 +127,7 @@
 	if(!chosen_name)
 		return
 
-	if(chosen_name == "Drop Flesh Disguise")
-		for(var/slot in slots)
-			if(istype(user.vars[slot], slot2type[slot]))
-				qdel(user.vars[slot])
+
 
 	var/datum/changelingprofile/prof = get_dna(chosen_name)
 	return prof


### PR DESCRIPTION
Requested by @alexandria404

Clothing is no longer saved by absorbs/DNA-stings

:cl:  
tweak: DNA-sting/absorbing as a ling no longer brings over their clothing
/:cl:
