### PR TITLE
Re-adds kudzu planting, adds a button to toggle kudzu growth

### DIFF
--- a/code/controllers/subsystem/objects.dm
+++ b/code/controllers/subsystem/objects.dm
@@ -16,6 +16,7 @@ var/datum/subsystem/objects/SSobj
 	var/list/processing = list()
 	var/list/currentrun = list()
 	var/list/burning = list()
+	var/allowVineGrowth = TRUE
 
 /datum/subsystem/objects/New()
 	NEW_SS_GLOBAL(SSobj)

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -130,6 +130,7 @@ var/list/admin_verbs_spawn = list(
 var/list/admin_verbs_server = list(
 	/client/proc/lag_fixer,
 	/client/proc/remove_all_vines,
+	/client/proc/toggle_vine_growth,
 	/datum/admins/proc/startnow,
 	/datum/admins/proc/restart,
 	/datum/admins/proc/end_round,
@@ -1073,3 +1074,14 @@ var/list/admin_verbs_hideable = list(
 
 	message_admins("[key_name_admin(usr)] has deleted all vines.")
 	log_admin("[key_name(usr)] has deleted all vines.")
+
+/client/proc/toggle_vine_growth()
+	set category = "Admin"
+	set name = "Toggle Vine Growth"
+	set desc = "Stops vines from speading any further"
+
+	if(!holder)
+		return
+
+	SSobj.allowVineGrowth = !SSobj.allowVineGrowth
+	message_admins("[src] has toggled vine growth [SSobj.allowVineGrowth? "on":"off"].")

--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -456,6 +456,7 @@
 		spread_cap *= production / 5
 		spread_multiplier /= production / 5
 		..()
+
 /obj/effect/spacevine_controller/ex_act() //only killing all vines will end this suffering
 	return
 
@@ -557,6 +558,8 @@
 		buckle_mob(V, TRUE)
 
 /obj/effect/spacevine/proc/spread()
+	if(!SSobj.allowVineGrowth)
+		return
 	var/direction = pick(cardinal)
 	var/turf/stepturf = get_step(src,direction)
 	for(var/datum/spacevine_mutation/SM in mutations)

--- a/code/modules/hydroponics/grown/kudzu.dm
+++ b/code/modules/hydroponics/grown/kudzu.dm
@@ -24,42 +24,25 @@
 
 /obj/item/seeds/kudzu/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] swallows the pack of kudzu seeds! It looks like \he's trying to commit suicide..</span>")
-	//plant(user)
+	plant(user)
 	return (BRUTELOSS)
 
 /obj/item/seeds/kudzu/proc/plant(mob/user, turf/T)
 	return
-	/*message_admins("Kudzu planted by [key_name_admin(user)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[user]'>FLW</A>) at ([T.x],[T.y],[T.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a>)",0,1)
+	message_admins("Kudzu planted by [key_name_admin(user)](<A HREF='?_src_=holder;adminmoreinfo=\ref[user]'>?</A>) (<A HREF='?_src_=holder;adminplayerobservefollow=\ref[user]'>FLW</A>) at ([T.x],[T.y],[T.z] - <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a>)",0,1)
 	investigate_log("was planted by [key_name(user)] at ([T.x],[T.y],[T.z])","kudzu")
 	new /obj/effect/spacevine_controller(user.loc, mutations, potency, production)
-	qdel(src)*/
+	qdel(src)
 
 /obj/item/seeds/kudzu/attack_self(mob/user)
 	to_chat(user, "Nothing happens.")
-	/*if(istype(user.loc,/turf/open/space))
+	if(istype(user.loc,/turf/open/space))
 		return
 	var/turf/T = get_turf(src)
 	to_chat(user, "<span class='notice'>You start planting the kudzu...</span>")
-	for(var/client/admeme in admins)
-		if(admeme.prefs.toggles & SOUND_ADMINHELP)
-			admeme << 'sound/effects/adminhelp.ogg'
-	message_admins("[key_name_admin(user)] wants to place vines at <A HREF='?_src_=holder;adminplayerobservecoodjump=1;X=[T.x];Y=[T.y];Z=[T.z]'>(JMP)</a>. Click <A href='?src=\ref[src];approval=1'>HERE</a> to approve.")
 	if(do_after(user, 100, target=src))
-		if(admin_approved)
-			plant(user, T)
-			to_chat(user, "<span class='notice'>You plant the kudzu. You monster.</span>")
-		else
-			to_chat(user, "<span class='warning'>The seeds don't seem to be in the mood right now!</span>")
-
-/obj/item/seeds/kudzu/Topic(href, list/href_list)
-	if(..())
-		return TRUE
-	if(!check_rights())
-		return
-	if(href_list["approval"])
-		admin_approved = TRUE
-		message_admins("[key_name_admin(usr)] has allowed vines to be planted.")
-		return TRUE*/
+		plant(user, T)
+		to_chat(user, "<span class='notice'>You plant the kudzu. You monster.</span>")
 
 /obj/item/seeds/kudzu/get_analyzer_text()
 	var/text = ..()


### PR DESCRIPTION
:cl:  
rscadd: Kudzu can now be planted again!
/:cl:

for admins, the "toggle kudzu growth" verb stops kudzu from growing. use this before mass-deleting kudzu, so they can't outgrow deletion.