### PR TITLE
Stunbatons faintly glow when turned on

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -94,6 +94,16 @@
 			to_chat(user, "<span class='warning'>[src] does not have a power source!</span>")
 		else
 			to_chat(user, "<span class='warning'>[src] is out of charge.</span>")
+	if(status == 1)
+		if(loc == user)
+			user.SetLuminosity(0.9)
+		else if(isturf(loc))
+			SetLuminosity(0.9)
+	else
+		if(loc == user)
+			user.SetLuminosity(0)
+		else if(isturf(loc))
+			SetLuminosity(0)
 	update_icon()
 	add_fingerprint(user)
 


### PR DESCRIPTION
This PR makes stunbatons glow softly when turned on. Barely enough to see anything in the dark, but the wielder will be visible. Luminosity is 0.9 .
#### Changelog

:cl:  retrosquid64
tweak: Stunbatons now glow faintly when turned on
/:cl:
