### PR TITLE
Fixes OOC

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -22,6 +22,7 @@
 		return
 
 	if(!holder)
+		return
 		if(!ooc_allowed)
 			to_chat(src, "<span class='danger'>OOC is globally muted.</span>")
 			return


### PR DESCRIPTION
No more ick ock, no more salt, only pure sweet admemes

:cl:
fix: players can no longer use OOC
/:cl: