### PR TITLE
Spellbook Improvements

### DIFF
--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -52,8 +52,8 @@
 						aspell.name = "Instant [aspell.name]"
 				if(aspell.spell_level >= aspell.level_max)
 					to_chat(user, "<span class='notice'>This spell cannot be strengthened any further.</span>")
-				else
-					levels_owned++
+
+				levels_owned++
 				return 1
 	//No same spell found - just learn it
 	feedback_add_details("wizard_spell_learned",log_name)
@@ -93,7 +93,7 @@
 	if(!S)
 		S = new spell_type()
 	var/dat =""
-	dat += "<b>[S.name_at_level(levels_owned+1)]</b>"
+	dat += "<b>[S.name_at_level(levels_owned)]</b>"
 	if(S.charge_type == "recharge")
 		dat += " Cooldown:[S.charge_max/10] - Next Level: [S.cost_at_level(levels_owned+1)]"
 	dat += " Cost:[cost]<br>"

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -341,6 +341,33 @@
 		user.mind.AddSpell(new /obj/effect/proc_holder/spell/aoe_turf/conjure/construct(null))
 	return .
 
+/datum/spellbook_entry/item/soulstones/TryRefund(mob/user,obj/item/summoned_item)
+	if(!..())
+		return 0
+
+	if(!istype(summoned_item,/obj/item/weapon/storage/belt/soulstone/full))
+		return 0
+
+	var/obj/item/weapon/storage/belt/soulstone/belt = summoned_item
+	var/stone_count = 0
+	for(var/obj/item/belt_item in belt)
+		if(istype(belt_item,/obj/item/device/soulstone))
+			stone_count++
+
+	if(stone_count < 6)
+		to_chat(user,"<span class='warning'>You cannot refund a soul stone belt that's missing stones!</span>")
+		return 0
+
+	if(!istype(user,/mob/living/carbon/human))
+		return 0
+
+	var/mob/living/carbon/human/wiz = user
+	for(var/obj/effect/proc_holder/spell/aspell in user.mind.spell_list)
+		if("Artificer" == aspell.name)
+			wiz.mind.spell_list.Remove(aspell)
+
+	return 1
+
 /datum/spellbook_entry/item/necrostone
 	name = "A Necromantic Stone"
 	desc = "A Necromantic stone is able to resurrect three dead individuals as skeletal thralls for you to command."
@@ -406,15 +433,6 @@
 		return 0
 	return 1
 
-/datum/spellbook_entry/item/bloodbottle
-	name = "Bottle of Blood"
-	desc = "A bottle of magically infused blood, the smell of which will attract extradimensional beings when broken. Be careful though, the kinds of creatures summoned by blood magic are indiscriminate in their killing, and you yourself may become a victim."
-	item_path = /obj/item/weapon/antag_spawner/slaughter_demon
-	log_name = "BB"
-	limit = 3
-	category = "Assistance"
-	refund_message = "On second thought, maybe summoning a demon is a bad idea.  You refund the bottle."
-
 /datum/spellbook_entry/item/hugbottle
 	name = "Bottle of Tickles"
 	desc = "A bottle of magically infused fun, the smell of which will \
@@ -429,6 +447,15 @@
 	log_name = "HB"
 	limit = 3
 	category = "Assistance"
+
+/datum/spellbook_entry/item/bloodbottle
+	name = "Bottle of Blood"
+	desc = "A bottle of magically infused blood, the smell of which will attract extradimensional beings when broken. Be careful though, the kinds of creatures summoned by blood magic are indiscriminate in their killing, and you yourself may become a victim."
+	item_path = /obj/item/weapon/antag_spawner/slaughter_demon
+	log_name = "BB"
+	limit = 3
+	category = "Assistance"
+	refund_message = "On second thought, maybe summoning a demon is a bad idea.  You refund the bottle."
 
 /datum/spellbook_entry/item/mjolnir
 	name = "Mjolnir"

--- a/code/game/gamemodes/wizard/spellbook.dm
+++ b/code/game/gamemodes/wizard/spellbook.dm
@@ -258,30 +258,26 @@
 /datum/spellbook_entry/item/proc/TryRefund(mob/user, obj/item/summoned_item)
 	return 1
 
-/datum/spellbook_entry/item/staff
-	name = "Staff of Errors"
-	refund_message = "You refund the staff."
-
-/datum/spellbook_entry/item/staff/change
+/datum/spellbook_entry/item/change
 	name = "Staff of Change"
 	desc = "An artefact that spits bolts of coruscating energy which cause the target's very form to reshape itself."
 	item_path = /obj/item/weapon/gun/magic/staff/change
 	log_name = "ST"
 
-/datum/spellbook_entry/item/staff/animation
+/datum/spellbook_entry/item/animation
 	name = "Staff of Animation"
 	desc = "An arcane staff capable of shooting bolts of eldritch energy which cause inanimate objects to come to life. This magic doesn't affect machines."
 	item_path = /obj/item/weapon/gun/magic/staff/animate
 	log_name = "SA"
 	category = "Assistance"
 
-/datum/spellbook_entry/item/staff/chaos
+/datum/spellbook_entry/item/chaos
 	name = "Staff of Chaos"
 	desc = "A caprious tool that can fire all sorts of magic without any rhyme or reason. Using it on people you care about is not recommended."
 	item_path = /obj/item/weapon/gun/magic/staff/chaos
 	log_name = "SC"
 
-/datum/spellbook_entry/item/staff/door
+/datum/spellbook_entry/item/door
 	name = "Staff of Door Creation"
 	desc = "A particular staff that can mold solid metal into ornate doors. Useful for getting around in the absence of other transportation. Does not work on glass."
 	item_path = /obj/item/weapon/gun/magic/staff/door
@@ -289,7 +285,7 @@
 	cost = 1
 	category = "Mobility"
 
-/datum/spellbook_entry/item/staff/healing
+/datum/spellbook_entry/item/healing
 	name = "Staff of Healing"
 	desc = "An altruistic staff that can heal the lame and raise the dead."
 	item_path = /obj/item/weapon/gun/magic/staff/healing
@@ -359,7 +355,7 @@
 	log_name = "WA"
 	category = "Defensive"
 
-/datum/spellbook_entry/item/contract/TryRefund(mob/user,obj/item/summoned_item)
+/datum/spellbook_entry/item/wands/TryRefund(mob/user,obj/item/summoned_item)
 	if(!..())
 		return 0
 
@@ -605,14 +601,15 @@
 		to_chat(user, "<span class='warning'>Without the power of your ship availible, you can't refund that.</span>")
 		return
 
-	var/list/datum/spellbook_entry/item/item_types = subtypesof(/datum/spellbook_entry/item) - /datum/spellbook_entry/item - /datum/spellbook_entry/item/staff
+	var/list/datum/spellbook_entry/item/item_types = subtypesof(/datum/spellbook_entry/item) - /datum/spellbook_entry/item
 
-	for(var/datum/spellbook_entry/item/type in item_types)
-		if(istype(O, type.item_path))
-			var/can_refund = type.TryRefund(user,O)
+	for(var/type in item_types)
+		var/datum/spellbook_entry/item/entry_type = new type
+		if(istype(O, entry_type.item_path))
+			var/can_refund = entry_type.TryRefund(user,O)
 			if(can_refund)
-				to_chat(user, "<span class='notice'>[type.refund_message]</span>")
-				uses = uses + type.cost
+				to_chat(user, "<span class='notice'>[entry_type.refund_message]</span>")
+				uses = uses + entry_type.cost
 				qdel(O)
 				return
 			else

--- a/code/modules/projectiles/guns/magic.dm
+++ b/code/modules/projectiles/guns/magic.dm
@@ -26,7 +26,7 @@
 	newshot()
 	if(no_den_usage)
 		var/area/A = get_area(user)
-		if(istype(A, /area/wizard_station))
+		if(istype(A, /area/wizard_station) && !istype(target,/obj/item/weapon/spellbook))
 			to_chat(user, "<span class='warning'>You know better than to violate the security of The Den, best wait until you leave to use [src].<span>")
 			return
 		else

--- a/code/modules/projectiles/guns/magic/wand.dm
+++ b/code/modules/projectiles/guns/magic/wand.dm
@@ -105,6 +105,7 @@
 	icon_state = "polywand"
 	fire_sound = "sound/magic/Staff_Change.ogg"
 	max_charges = 10 //10, 5, 5, 4
+	no_den_usage = 1
 
 /obj/item/weapon/gun/magic/wand/polymorph/zap_self(mob/living/user)
 	..() //because the user mob ceases to exists by the time wabbajack fully resolves

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -66,6 +66,25 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 	var/action_icon_state = "spell_default"
 	var/action_background_icon_state = "bg_spell"
 
+/obj/effect/proc_holder/spell/proc/cost_at_level(level = 0)
+	if(level_max == 0)
+		return charge_max
+	return (round(initial(charge_max) - level * (initial(charge_max) - cooldown_min)/ level_max)/10)
+
+/obj/effect/proc_holder/spell/proc/name_at_level(level = 0)
+	switch(level)
+		if(0)
+			return "[initial(name)]"
+		if(1)
+			return "Efficient [initial(name)]"
+		if(2)
+			return "Quickened [initial(name)]"
+		if(3)
+			return "Free [initial(name)]"
+		if(4)
+			return "Instant [initial(name)]"
+	return "[initial(name)]"
+
 /obj/effect/proc_holder/spell/proc/cast_check(skipcharge = 0,mob/user = usr) //checks if the spell can be cast based on its settings; skipcharge is used when an additional cast_check is called inside the spell
 
 	if(player_lock)

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -69,6 +69,10 @@ var/list/spells = typesof(/obj/effect/proc_holder/spell) //needed for the badmin
 /obj/effect/proc_holder/spell/proc/cost_at_level(level = 0)
 	if(level_max == 0)
 		return charge_max
+
+	if(level > level_max)
+		return cost_at_level(level_max)
+
 	return (round(initial(charge_max) - level * (initial(charge_max) - cooldown_min)/ level_max)/10)
 
 /obj/effect/proc_holder/spell/proc/name_at_level(level = 0)


### PR DESCRIPTION
Closes #2810 .

### SPELLBOOK FIXES

While I was investigating #2810, I did a full readthrough of the spellbook code.  The actual fix for the bug was a single erroneous line of code, but it struck me as odd that only a few items could be refunded at all.  I replaced the snowflake item refund code with a more general solution, and now every type of summonable item can be refunded from the wizard's ship.

I also made some minor changes to the way that spells are displayed in the spellbook.  The book now shows the 'upgraded name' of the spell, as well as the cooldown of the next upgrade.  That way, it's more clear to people what they're spending points on.

Obviously, refunds can only be processed while on the wizard's ship; The refund code also ensures that players can't, say, empty the wand belt into their backpack and refund the belt.

#### Changelog

:cl:  
bugfix: Apprentice Contracts and Slaughter Demon vials will now be refunded for their full value.  The SWF apologizes for the pricing mixup.
tweak: The Space Wizard Federation has announced a new 'try-before-you-buy' program for magical artifacts.  All wizards may now test out magical items in their ships, and return unwanted goods for a full refund.
rscadd: A new edition of spellbooks has been released to wizards across the galaxy, allowing users to more clearly see the improvement offered by spell upgrades.
/:cl:
