### PR TITLE
Change update_label logic

### DIFF
--- a/code/game/gamemodes/sandbox/h_sandbox.dm
+++ b/code/game/gamemodes/sandbox/h_sandbox.dm
@@ -199,10 +199,8 @@ var/hsboxspawn = 1
 			//
 			if("hsbaaid")
 				var/obj/item/weapon/card/id/gold/ID = new(usr.loc)
-				ID.registered_name = usr.real_name
-				ID.assignment = "Sandbox"
 				ID.access = get_all_accesses()
-				ID.update_label()
+				ID.update_label(usr.real_name, "Sandbox")
 
 			//
 			// RCD - starts with full clip

--- a/code/game/gamemodes/wizard/artefact.dm
+++ b/code/game/gamemodes/wizard/artefact.dm
@@ -483,9 +483,7 @@ var/global/list/multiverse = list()
 	var/obj/item/weapon/card/id/W = new /obj/item/weapon/card/id
 	W.icon_state = "centcom"
 	W.access += access_maint_tunnels
-	W.assignment = "Multiverse Traveller"
-	W.registered_name = M.real_name
-	W.update_label(M.real_name)
+	W.update_label(M.real_name, "Multiverse Traveller")
 	M.equip_to_slot_or_del(W, slot_wear_id)
 
 

--- a/code/game/objects/items/weapons/cards_ids.dm
+++ b/code/game/objects/items/weapons/cards_ids.dm
@@ -131,9 +131,11 @@ update_label("John Doe", "Clowny")
 	Properly formats the name and occupation and sets the id name to the arguments
 */
 /obj/item/weapon/card/id/proc/update_label(newname, newjob)
-	if(newname || newjob)
-		name = "[(!newname)	? "identification card"	: "[newname]'s ID Card"][(!newjob) ? "" : " ([newjob])"]"
-		return
+	if(newname)
+		registered_name = newname
+	
+	if(newjob)
+		assignment = newjob
 
 	name = "[(!registered_name)	? "identification card"	: "[registered_name]'s ID Card"][(!assignment) ? "" : " ([assignment])"]"
 	ID_fluff()
@@ -180,21 +182,23 @@ update_label("John Doe", "Clowny")
 	if(istype(user, /mob/living) && user.mind)
 		if(!restricted || user.mind.special_role)
 			if(alert(user, "Action", "Agent ID", "Show", "Forge") == "Forge")
-				var t = name_input(user, "What name would you like to put on this card?", "Agent card name", registered_name ? registered_name : (ishuman(user) ? user.real_name : user.name))
-				if(!t || t == "Unknown" || t == "floor" || t == "wall" || t == "r-wall") //Same as mob/new_player/prefrences.dm
-					if (t)
-						alert("Invalid name.")
+				var/new_name = name_input(user, "What name would you like to put on this card?", "Agent card name", registered_name ? registered_name : (ishuman(user) ? user.real_name : user.name))
+				if(!new_name)
 					return
-				registered_name = t
 
-				var u = stripped_input(user, "What occupation would you like to put on this card?\nNote: This will not grant any access levels other than Maintenance.", "Agent card job assignment", "Assistant", MAX_MESSAGE_LEN)
-				if(!u)
-					registered_name = ""
+				if(new_name == "Unknown" || new_name == "floor" || new_name == "wall" || new_name == "r-wall") //Same as mob/new_player/prefrences.dm
+					to_chat(user, "<span class='warning'>You have entered an invalid name.</span>")
 					return
-				assignment = u
-				update_label()
+
+
+				var/new_job = stripped_input(user, "What occupation would you like to put on this card?\nNote: This will not grant any access levels other than Maintenance.", "Agent card job assignment", assignment, MAX_MESSAGE_LEN)
+				if(!new_job)
+					return
+
+				update_label(new_name, new_job)
 				to_chat(user, "<span class='notice'>You successfully forge the ID card.</span>")
 				return
+
 	..()
 
 /obj/item/weapon/card/id/syndicate_command
@@ -325,43 +329,44 @@ update_label("John Doe", "Clowny")
 /obj/item/weapon/card/id/proc/ID_fluff()
 	var/job = assignment
 	var/list/idfluff = list(
-	"Assistant" = list("civillian","green"),
-	"Captain" = list("captain","gold"),
-	"Head of Personnel" = list("civillian","silver"),
-	"Head of Security" = list("security","silver"),
-	"Chief Engineer" = list("engineering","silver"),
-	"Research Director" = list("science","silver"),
-	"Chief Medical Officer" = list("medical","silver"),
-	"Station Engineer" = list("engineering","yellow"),
-	"Atmospheric Technician" = list("engineering","white"),
-	"Signal Technician" = list("engineering","green"),
-	"Medical Doctor" = list("medical","blue"),
-	"Geneticist" = list("medical","purple"),
-	"Virologist" = list("medical","green"),
-	"Chemist" = list("medical","orange"),
-	"Paramedic" = list("medical","white"),
-	"Psychiatrist" = list("medical","brown"),
-	"Scientist" = list("science","purple"),
-	"Roboticist" = list("science","black"),
-	"Quartermaster" = list("cargo","silver"),
-	"Cargo Technician" = list("cargo","brown"),
-	"Shaft Miner" = list("cargo","black"),
-	"Mining Medic" = list("cargo","blue"),
-	"Bartender" = list("civillian","black"),
-	"Botanist" = list("civillian","blue"),
-	"Cook" = list("civillian","white"),
-	"Janitor" = list("civillian","purple"),
-	"Librarian" = list("civillian","purple"),
-	"Chaplain" = list("civillian","black"),
-	"Clown" = list("clown","rainbow"),
-	"Mime" = list("mime","white"),
-	"Clerk" = list("civillian","blue"),
-	"Tourist" = list("civillian","yellow"),
-	"Warden" = list("security","black"),
-	"Security Officer" = list("security","red"),
-	"Detective" = list("security","brown"),
-	"Lawyer" = list("security","purple")
+		"Assistant" = list("civillian","green"),
+		"Captain" = list("captain","gold"),
+		"Head of Personnel" = list("civillian","silver"),
+		"Head of Security" = list("security","silver"),
+		"Chief Engineer" = list("engineering","silver"),
+		"Research Director" = list("science","silver"),
+		"Chief Medical Officer" = list("medical","silver"),
+		"Station Engineer" = list("engineering","yellow"),
+		"Atmospheric Technician" = list("engineering","white"),
+		"Signal Technician" = list("engineering","green"),
+		"Medical Doctor" = list("medical","blue"),
+		"Geneticist" = list("medical","purple"),
+		"Virologist" = list("medical","green"),
+		"Chemist" = list("medical","orange"),
+		"Paramedic" = list("medical","white"),
+		"Psychiatrist" = list("medical","brown"),
+		"Scientist" = list("science","purple"),
+		"Roboticist" = list("science","black"),
+		"Quartermaster" = list("cargo","silver"),
+		"Cargo Technician" = list("cargo","brown"),
+		"Shaft Miner" = list("cargo","black"),
+		"Mining Medic" = list("cargo","blue"),
+		"Bartender" = list("civillian","black"),
+		"Botanist" = list("civillian","blue"),
+		"Cook" = list("civillian","white"),
+		"Janitor" = list("civillian","purple"),
+		"Librarian" = list("civillian","purple"),
+		"Chaplain" = list("civillian","black"),
+		"Clown" = list("clown","rainbow"),
+		"Mime" = list("mime","white"),
+		"Clerk" = list("civillian","blue"),
+		"Tourist" = list("civillian","yellow"),
+		"Warden" = list("security","black"),
+		"Security Officer" = list("security","red"),
+		"Detective" = list("security","brown"),
+		"Lawyer" = list("security","purple")
 	)
+	
 	if(job in idfluff)
 		has_fluff = 1
 	else
@@ -369,6 +374,7 @@ update_label("John Doe", "Clowny")
 			return
 		else
 			job = "Assistant" //Loads up the basic green ID
+
 	overlays.Cut()
 	overlays += idfluff[job][1]
 	overlays += idfluff[job][2]

--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -455,9 +455,7 @@ var/global/list/g_fancy_list_of_types = null
 		else
 			id = new /obj/item/weapon/card/id/gold(H.loc)
 			id.access = get_all_accesses()+get_all_centcom_access()+get_all_syndicate_access()
-			id.registered_name = H.real_name
-			id.assignment = "Captain"
-			id.update_label()
+			id.update_label(H.real_name, "Captain")
 
 			if(worn)
 				if(istype(worn,/obj/item/device/pda))

--- a/code/modules/admin/verbs/onlyone.dm
+++ b/code/modules/admin/verbs/onlyone.dm
@@ -41,9 +41,7 @@
 		W.icon_state = "centcom"
 		W.access = get_all_accesses()
 		W.access += get_all_centcom_access()
-		W.assignment = "Highlander"
-		W.registered_name = H.real_name
-		W.update_label(H.real_name)
+		W.update_label(H.real_name, "Highlander")
 		H.equip_to_slot_or_del(W, slot_wear_id)
 
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] used THERE CAN BE ONLY ONE!</span>")
@@ -84,9 +82,7 @@
 		W.icon_state = "centcom"
 		W.access = get_all_accesses()
 		W.access += get_all_centcom_access()
-		W.assignment = "Multiverse Summoner"
-		W.registered_name = H.real_name
-		W.update_label(H.real_name)
+		W.update_label(H.real_name, "Multiverse Summoner")
 		H.equip_to_slot_or_del(W, slot_wear_id)
 
 	message_admins("<span class='adminnotice'>[key_name_admin(usr)] used THERE CAN BE ONLY ME!</span>")

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -175,10 +175,11 @@
 				W.access = jobdatum.get_access()
 			else
 				W.access = list()
+
 		if(id_job)
 			W.assignment = id_job
-		W.registered_name = H.real_name
-		W.update_label()
+
+		W.update_label(H.real_name)
 		H.equip_to_slot_or_del(W, slot_wear_id)
 
 	for(var/I in implants)

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -24,8 +24,7 @@
 	R.freqlock = 1
 
 	var/obj/item/weapon/card/id/W = H.wear_id
-	W.registered_name = H.real_name
-	W.update_label(W.registered_name, W.assignment)
+	W.update_label(H.real_name, W.assignment)
 
 /datum/outfit/ert/commander
 	name = "ERT Commander"
@@ -280,6 +279,4 @@
 	W.icon_state = "centcom"
 	W.access = get_centcom_access("Centcom Official")
 	W.access += access_weapons
-	W.assignment = "Centcom Official"
-	W.registered_name = H.real_name
-	W.update_label()
+	W.update_label(H.real_name, "Centcom Official")

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -113,9 +113,7 @@
 
 	var/obj/item/weapon/card/id/W = H.wear_id
 	W.access = get_all_accesses()
-	W.assignment = "Tunnel Clown!"
-	W.registered_name = H.real_name
-	W.update_label(H.real_name)
+	W.update_label(H.real_name, "Tunnel Clown!")
 
 /datum/outfit/psycho
 	name = "Masked Killer"
@@ -176,9 +174,7 @@
 
 	var/obj/item/weapon/card/id/syndicate/W = H.wear_id
 	W.access = get_all_accesses()
-	W.assignment = "Reaper"
-	W.registered_name = H.real_name
-	W.update_label(H.real_name)
+	W.update_label(H.real_name, "Reaper")
 
 /datum/outfit/centcom_commander
 	name = "Centcom Commander"
@@ -205,9 +201,7 @@
 	W.icon_state = "centcom"
 	W.access = get_all_accesses()
 	W.access += get_centcom_access("Centcom Commander")
-	W.assignment = "Centcom Commander"
-	W.registered_name = H.real_name
-	W.update_label()
+	W.update_label(H.real_name, "Centcom Commander")
 
 /datum/outfit/spec_ops
 	name = "Special Ops Officer"
@@ -233,9 +227,7 @@
 	W.icon_state = "centcom"
 	W.access = get_all_accesses()
 	W.access += get_centcom_access("Special Ops Officer")
-	W.assignment = "Special Ops Officer"
-	W.registered_name = H.real_name
-	W.update_label()
+	W.update_label(H.real_name, "Special Ops Officer")
 
 	var/obj/item/device/radio/headset/R = H.ears
 	R.set_frequency(CENTCOM_FREQ)
@@ -291,9 +283,7 @@
 	W.icon_state = "centcom"
 	W.access = get_all_accesses()
 	W.access += get_centcom_access("Admiral")
-	W.assignment = "Admiral"
-	W.registered_name = H.real_name
-	W.update_label()
+	W.update_label(H.real_name, "Admiral")
 
 /datum/outfit/mobster
 	name = "Mobster"
@@ -312,9 +302,7 @@
 		return
 
 	var/obj/item/weapon/card/id/W = H.wear_id
-	W.assignment = "Assistant"
-	W.registered_name = H.real_name
-	W.update_label()
+	W.update_label(H.real_name, "Assistant")
 
 /datum/outfit/plasmaman
 	name = "Plasmaman"
@@ -367,9 +355,7 @@
 	W.icon_state = "centcom"
 	W.access = get_all_accesses()//They get full station access.
 	W.access += get_centcom_access("Death Commando")//Let's add their alloted Centcom access.
-	W.assignment = "Death Commando"
-	W.registered_name = H.real_name
-	W.update_label(W.registered_name, W.assignment)
+	W.update_label(H.real_name, "Death Commando")
 
 /datum/outfit/death_commando/officer
 	name = "Death Commando Officer"
@@ -412,9 +398,7 @@
 	H.sec_hud_set_implants()
 
 	var/obj/item/weapon/card/id/W = H.wear_id
-	W.assignment = "Recovery Agent"
-	W.registered_name = H.real_name
-	W.update_label()
+	W.update_label(H.real_name, "Recovery Agent")
 
 
 	to_chat(H, "<span class='alert'>You are NOT security. You are NOT a head of department. You will NOT challenge a head of department and nor will you meddle in securities affairs. You have a gun ONLY to defend your valuable all-access ID. If you see criminals, you MAY stun them, and take the body they are holding. Nothing more. You MAY report their location, Nothing more. You are NOT security. Your job is to recover bodies to the morgue to ensure more players get to play a fair game. ( for more information https://wiki.yogstation.net/index.php?title=Recovery_Agent_manual )</span>")
@@ -444,9 +428,7 @@
 		return
 
 	var/obj/item/weapon/card/id/W = H.wear_id
-	W.assignment = "Recovery Agent"
-	W.registered_name = "[H.real_name] Throwback"
-	W.update_label()
+	W.update_label("[H.real_name] Throwback", "Recovery Agent")
 
 	var/obj/item/weapon/implant/mindshield/L = new/obj/item/weapon/implant/mindshield(H)
 	L.imp_in = H

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -223,9 +223,7 @@
 	if(istype(C))
 		var/datum/job/J = SSjob.GetJob(H.job) // Not sure the best idea
 		C.access = J.get_access()
-		C.registered_name = H.real_name
-		C.assignment = H.job
-		C.update_label()
+		C.update_label(H.real_name, H.job)
 		H.sec_hud_set_ID()
 
 	var/obj/item/device/pda/PDA = H.get_item_by_slot(pda_slot)
@@ -233,6 +231,7 @@
 		PDA.owner = H.real_name
 		PDA.ownjob = H.job
 		PDA.update_label()
+
 	if(H.job != "Mime" && H.job != "Clown")
 		log_game("[H.real_name]/[H.ckey] joined the round as [H.job].")
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -916,10 +916,10 @@ var/next_mob_id = 0
 		if( search_id && istype(A,/obj/item/weapon/card/id) )
 			var/obj/item/weapon/card/id/ID = A
 			if(ID.registered_name == oldname)
-				ID.registered_name = newname
-				ID.update_label()
+				ID.update_label(newname)
 				if(!search_pda)
 					break
+
 				search_id = 0
 
 		else if( search_pda && istype(A,/obj/item/device/pda) )
@@ -929,6 +929,7 @@ var/next_mob_id = 0
 				PDA.update_label()
 				if(!search_id)
 					break
+
 				search_pda = 0
 
 /mob/proc/update_stat()

--- a/code/modules/paperwork/contract.dm
+++ b/code/modules/paperwork/contract.dm
@@ -221,15 +221,13 @@
 		id = worn.GetID()
 	if(id)
 		id.icon_state = "gold"
-		id.access = get_all_accesses()+get_all_centcom_access()
+		id.access = get_all_accesses() + get_all_centcom_access()
 		id.assignment = "Captain"
 		id.update_label()
 	else
 		id = new /obj/item/weapon/card/id/gold(user.loc)
-		id.registered_name = user.real_name
-		id.access = get_all_accesses()+get_all_centcom_access()
-		id.assignment = "Captain"
-		id.update_label()
+		id.access = get_all_accesses() + get_all_centcom_access()
+		id.update_label(user.real_name, "Captain")
 		if(worn)
 			if(istype(worn,/obj/item/device/pda))
 				var/obj/item/device/pda/PDA = worn

--- a/code/modules/paperwork/handlabeler.dm
+++ b/code/modules/paperwork/handlabeler.dm
@@ -24,8 +24,7 @@
 			if(their_card.registered_name != old_real_name)
 				continue
 
-			their_card.registered_name = user.real_name
-			their_card.update_label()
+			their_card.update_label(user.real_name)
 
 	// NOT EVEN DEATH WILL TAKE AWAY THE STAIN
 	user.mind.name += " (suicide)"


### PR DESCRIPTION
Closes #2974.

This allows ``/obj/item/weapon/card/id/proc/update_label`` to update the ``assignment`` and ``registered_name`` vars of the ID. This means you no longer have to manually edit those vars when making an ID. This also fixes #2974.

:cl:  
bugfix: Pressing cancel while you are forging an agent ID no longer turns your name blank.
/:cl:
