### PR TITLE
Fixes virology shutter access

### DIFF
--- a/_maps/map_files/Yogstation/yogstation.2.1.3.dmm
+++ b/_maps/map_files/Yogstation/yogstation.2.1.3.dmm
@@ -54554,7 +54554,7 @@
 	name = "Monkey Pen Shutters";
 	pixel_x = -24;
 	pixel_y = 0;
-	req_access_txt = "24"
+	req_access_txt = "39"
 	},
 /obj/structure/cable/yellow{
 	d1 = 1;


### PR DESCRIPTION
Closes #2838.

tfw Partheo never fixed this.

:cl:  
bugfix: Virologists can now open and close the virology monkey pen shutters.
/:cl:
