### PR TITLE
Closed shutters prevent grille shocks

### DIFF
--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -228,6 +228,10 @@
 		return 0
 	if(!in_range(src, user))//To prevent TK and mech users from getting shocked
 		return 0
+	for(var/obj/machinery/door/poddoor/door in loc)	// Don't get shocked if there's a closed poddoor
+		if(door.density)
+			return
+
 	var/turf/T = get_turf(src)
 	var/obj/structure/cable/C = T.get_cable_node()
 	if(C)


### PR DESCRIPTION
Closes #2832.

This shouldn't happen since the shutters cover the grille completely, giving no visual indicator to the player there's an electrified grille on the tile.

:cl:  
tweak: You won't get shocked by an electrified grille if there are closed shutters over it.
/:cl:
