### PR TITLE
Removes randseed from NTSL

### DIFF
--- a/code/modules/scripting/Implementations/_Logic.dm
+++ b/code/modules/scripting/Implementations/_Logic.dm
@@ -207,7 +207,7 @@
 	return prob(chance)
 
 /proc/n_randseed(seed)
-	rand_seed(seed)
+	//rand_seed(seed)	// Commented out because there is literally no reason NTSL should have access to this.
 	return 0
 
 /proc/n_rand(low, high)


### PR DESCRIPTION
There is literally no reason NTSL should be able to alter the random seed. This can potentially be used to trigger random events at will.
