### PR TITLE
Fix examine exploit

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -276,6 +276,9 @@ var/next_mob_id = 0
 	set name = "Examine"
 	set category = "IC"
 
+	if(!src || !isturf(src.loc) || !(A in view(src.loc)))
+		return
+
 	if(is_blind(src))
 		to_chat(src, "<span class='notice'>Something is there but you can't see it.</span>")
 		return


### PR DESCRIPTION
Currently, you can examine tiles you cannot see. This will show you what type of floor the tile has but will give you no information about any possible items. This information can still be used to identify cults.
