### PR TITLE
Hide blood cult floor from meson scanners

### DIFF
--- a/code/game/objects/effects/overlays.dm
+++ b/code/game/objects/effects/overlays.dm
@@ -130,6 +130,24 @@
 		dir = mimiced_atom.dir
 	animate(src, alpha = 0, time = duration)
 
+/obj/effect/overlay/cult
+	mouse_opacity = 0
+	var/atom/linked
+
+/obj/effect/overlay/cult/ex_act()
+	return FALSE
+
+/obj/effect/overlay/cult/Destroy()
+	if(linked)
+		linked = null
+	..()
+	return QDEL_HINT_PUTINPOOL
+
+/obj/effect/overlay/cult/floor
+	icon = 'icons/turf/floors.dmi'
+	icon_state = "cult"
+	layer = TURF_LAYER
+
 /obj/effect/overlay/temp/cult
 	randomdir = 0
 	duration = 10

--- a/code/game/turfs/simulated/floor/plating.dm
+++ b/code/game/turfs/simulated/floor/plating.dm
@@ -152,7 +152,27 @@
 
 /turf/open/floor/engine/cult
 	name = "engraved floor"
-	icon_state = "cult"
+	icon_state = "plating"
+	var/obj/effect/clockwork/overlay/floor/realappearence
+
+/turf/open/floor/engine/cult/New()
+	..()
+	PoolOrNew(/obj/effect/overlay/temp/cult/turf/open/floor, src)
+	realappearence = PoolOrNew(/obj/effect/overlay/cult/floor, src)
+	realappearence.linked = src
+
+/turf/open/floor/engine/cult/Destroy()
+	be_removed()
+	return ..()
+
+/turf/open/floor/engine/cult/ChangeTurf(path, defer_change = FALSE)
+	if(path != type)
+		be_removed()
+	return ..()
+
+/turf/open/floor/engine/cult/proc/be_removed()
+	qdel(realappearence)
+	realappearence = null
 
 /turf/open/floor/engine/cult/New()
 	PoolOrNew(/obj/effect/overlay/temp/cult/turf/open/floor, src)


### PR DESCRIPTION
Stops powergaming using mesons. Ported from https://github.com/tgstation/tgstation/pull/19662.

:cl:  
bugfix: Blood cult floors won't be visible to meson scanners anymore
/:cl:
