### PR TITLE
Fixes Suit Storage Units losing auxiliary slots

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -178,7 +178,7 @@
 	mask = null
 	shoes = null
 	occupant = null
-	extra_items = null
+	extra_items = list()
 
 /obj/machinery/suit_storage_unit/ex_act(severity, target)
 	switch(severity)
@@ -253,6 +253,7 @@
 			qdel(shoes)
 			extra_items = null
 			qdel(extra_items)
+			extra_items = list()
 			// The wires get damaged too.
 			wires.cut_all()
 		else


### PR DESCRIPTION
This fixes Suit Storage Units losing their auxiliary slots when a human is
placed inside of and then removed from a Suit Storage Unit or the items
inside are incinerated. Instead of setting extra_items to null when
drop_contents is called, it now just sets it to an empty list.

Refer to issue #2995. Closes #2995.

:cl:  
bugfix: fixed suit storage units losing their auxiliary slots  
/:cl:
