### PR TITLE
fixes a bug with helmets and beheaded people

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -35,6 +35,8 @@
 	if(on)
 		user.AddLuminosity(brightness_on)
 		SetLuminosity(0)
+	if(suit)
+		qdel(src)
 
 /obj/item/clothing/head/helmet/space/hardsuit/dropped(mob/user)
 	..()


### PR DESCRIPTION
if a helmet that should be part of a suit is on the ground and it is picked up, it is stuck in the persons hands. Now it is gone forever. Original issue was about shaft miner hoods but this applies to all suits that function this way.

Refer to issue #2834. Closes #2834.

### Intent of your Pull Request

shittily fixing a problem

#### Changelog

:cl:  

bugfix: ghost hardsuit helmets will no longer persist in your hands

/:cl:
