### PR TITLE
Gives memory flavourtext to certain roles

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -284,6 +284,7 @@
 		carbon_mob.flash_eyes(1, 1)
 	rev_mind.current.Stun(5)
 
+	rev_mind.store_memory("Help your cause. Do not harm your fellow freedom fighters. Help them kill the heads to win the revolution!")
 	to_chat(rev_mind.current, "<span class='danger'><FONT size = 3> You are now a revolutionary! Help your cause. Do not harm your fellow freedom fighters. Help them kill the heads to win the revolution!</FONT></span>")
 	explain_rev_hud(rev_mind.current)
 	rev_mind.current.attack_log += "\[[gameTimestamp()]\] <font color='red'>Has been converted to the revolution!</font>"

--- a/code/modules/golem/golem_spawners.dm
+++ b/code/modules/golem/golem_spawners.dm
@@ -146,7 +146,7 @@
 	if(!slaved_to)
 		return
 	var/mob/living/user = slaved_to
-	G.mind.store_memory("<b>Serve [user.real_name], your creator.</b>")
+	G.add_memory("<b>Serve [user.real_name], your creator.</b>")
 
 	var/golem_becomes_antag = FALSE
 	if(iscultist(user)) //If the golem's master is a part of a team antagonist, immediately make the golem one, too
@@ -239,7 +239,7 @@
 	G.loc = src.loc
 	G.key = ghost.key
 	to_chat(G, "You are an adamantine golem. You move slowly, but are highly resistant to heat and cold as well as blunt trauma. You are unable to wear clothes, but can still use most tools. Serve [user], and assist them in completing their goals at any cost.")
-	G.mind.store_memory("<b>Serve [user.real_name], your creator.</b>")
+	G.add_memory("<b>Serve [user.real_name], your creator.</b>")
 
 	var/golem_becomes_antag = FALSE
 	if(iscultist(user)) //If the golem's master is a part of a team antagonist, immediately make the golem one, too

--- a/code/modules/projectiles/projectile/magic.dm
+++ b/code/modules/projectiles/projectile/magic.dm
@@ -322,7 +322,9 @@
 				S.color = change.color
 				if(H.mind)
 					H.mind.transfer_to(S)
-					to_chat(S, "<span class='userdanger'>You are an animate statue. You cannot move when monitored, but are nearly invincible and deadly when unobserved! Do not harm [firer.name], your creator.</span>")
+
+				H.add_memory("<b>Serve [firer.real_name], your creator.</b>")
+				to_chat(S, "<span class='userdanger'>You are an animate statue. You cannot move when monitored, but are nearly invincible and deadly when unobserved! Do not harm [firer.real_name], your creator.</span>")
 				H = change
 				H.loc = S
 				qdel(src)

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -181,6 +181,7 @@
 		SM.languages_understood |= HUMAN
 		SM.faction |= user.faction
 		SM.sentience_act()
+		SM.add_memory("<b>Serve [user], and assist them in completing their goals at any cost.</b>")
 		to_chat(SM, "<span class='warning'>All at once it makes sense: you know what you are and who you are! Self awareness is yours!</span>")
 		to_chat(SM, "<span class='userdanger'>You are grateful to be self aware and owe [user] a great debt. Serve [user], and assist them in completing their goals at any cost.</span>")
 		to_chat(user, "<span class='notice'>[SM] accepts the potion and suddenly becomes attentive and aware. It worked!</span>")


### PR DESCRIPTION
This simply adds some memory flavourtext to certain roles which didn't have it before. This way, people will remember better what they are supposed to do. Tell me if I missed any roles.

:cl:  
tweak: Certain roles have been given better memory to help remember their intentions
/:cl:
