### PR TITLE
Moves spacedrift to a subsystem

### DIFF
--- a/code/controllers/subsystem/spacedrift.dm
+++ b/code/controllers/subsystem/spacedrift.dm
@@ -1,0 +1,63 @@
+var/datum/subsystem/spacedrift/SSspacedrift
+
+/datum/subsystem/spacedrift
+	name = "Space Drift"
+	priority = 30
+	wait = 5
+	flags = SS_NO_INIT|SS_KEEP_TIMING
+
+	var/list/currentrun = list()
+	var/list/processing = list()
+
+/datum/subsystem/spacedrift/New()
+	NEW_SS_GLOBAL(SSspacedrift)
+
+
+/datum/subsystem/spacedrift/stat_entry()
+	..("P:[processing.len]")
+
+
+/datum/subsystem/spacedrift/fire(resumed = 0)
+	if (!resumed)
+		src.currentrun = processing.Copy()
+
+	//cache for sanic speed (lists are references anyways)
+	var/list/currentrun = src.currentrun
+
+	while (currentrun.len)
+		var/atom/movable/AM = currentrun[currentrun.len]
+		currentrun.len--
+		if (!AM)
+			processing -= AM
+			if (MC_TICK_CHECK)
+				return
+			continue
+
+		if (AM.inertia_next_move > world.time)
+			if (MC_TICK_CHECK)
+				return
+			continue
+
+		if (!AM.loc || AM.loc != AM.inertia_last_loc || AM.Process_Spacemove(0))
+			AM.inertia_dir = 0
+
+		if (!AM.inertia_dir)
+			AM.inertia_last_loc = null
+			processing -= AM
+			if (MC_TICK_CHECK)
+				return
+			continue
+
+		var/old_dir = AM.dir
+		var/old_loc = AM.loc
+		AM.inertia_moving = TRUE
+		step(AM, AM.inertia_dir)
+		AM.inertia_moving = FALSE
+		AM.inertia_next_move = world.time + AM.inertia_move_delay
+		if (AM.loc == old_loc)
+			AM.inertia_dir = 0
+
+		AM.dir = old_dir	// Change this to AM.setDir(old_dir) in the future
+		AM.inertia_last_loc = AM.loc
+		if (MC_TICK_CHECK)
+			return

--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -14,6 +14,10 @@
 	var/verb_exclaim = "exclaims"
 	var/verb_yell = "yells"
 	var/inertia_dir = 0
+	var/atom/inertia_last_loc
+	var/inertia_moving = 0
+	var/inertia_next_move = 0
+	var/inertia_move_delay = 5
 	var/pass_flags = 0
 	var/moving_diagonally = 0 //0: not doing a diagonal move. 1 and 2: doing the first/second step of the diagonal move
 	var/list/mobs_in_contents // This contains all the client mobs within this container
@@ -72,16 +76,14 @@
 
 	last_move = direct
 
-	spawn(5)	// Causes space drifting. /tg/station has no concept of speed, we just use 5
-		if(loc && direct && last_move == direct)
-			if(loc == newloc) //Remove this check and people can accelerate. Not opening that can of worms just yet.
-				newtonian_move(last_move)
-
 	if(. && has_buckled_mobs() && !handle_buckled_mob_movement(loc,direct)) //movement failed due to buckled mob(s)
 		. = 0
 
 //Called after a successful Move(). By this point, we've already moved
 /atom/movable/proc/Moved(atom/OldLoc, Dir)
+	if(!inertia_moving)
+		inertia_next_move = world.time + inertia_move_delay
+		newtonian_move(Dir)
 	update_parallax_contents()
 	return 1
 
@@ -173,11 +175,15 @@
 
 	if(pulledby)
 		return 1
+		
+	if(throwing)
+		return 1
 
 	if(locate(/obj/structure/lattice) in range(1, get_turf(src))) //Not realistic but makes pushing things in space easier
 		return 1
 
 	return 0
+
 
 /atom/movable/proc/newtonian_move(direction) //Only moves the object if it's under no gravity
 
@@ -189,9 +195,9 @@
 	if(!direction)
 		return 1
 
-	var/old_dir = dir
-	. = step(src, direction)
-	dir = old_dir
+	inertia_last_loc = loc
+	SSspacedrift.processing[src] = src
+	return 1
 
 /atom/movable/proc/checkpass(passflag)
 	return pass_flags&passflag
@@ -299,6 +305,7 @@
 				return 1
 
 		throw_impact(get_turf(src))  // we haven't hit something yet and we still must, let's hit the ground.
+	newtonian_move(init_dir)
 	return 1
 
 /atom/movable/proc/prethrow_at(var/target) // If an item is thrown by a mob, but it's still currently held.

--- a/code/modules/vehicles/pimpin_ride.dm
+++ b/code/modules/vehicles/pimpin_ride.dm
@@ -49,7 +49,7 @@
 			for(var/A in tile)
 				if(is_cleanable(A))
 					qdel(A)
-
+	. = ..()
 
 /obj/vehicle/janicart/examine(mob/user)
 	..()

--- a/yogstation.dme
+++ b/yogstation.dme
@@ -164,6 +164,7 @@
 #include "code\controllers\subsystem\radio.dm"
 #include "code\controllers\subsystem\server_maintenance.dm"
 #include "code\controllers\subsystem\shuttles.dm"
+#include "code\controllers\subsystem\spacedrift.dm"
 #include "code\controllers\subsystem\stickyban.dm"
 #include "code\controllers\subsystem\sun.dm"
 #include "code\controllers\subsystem\tgui.dm"


### PR DESCRIPTION
Credits to MrStonedOne.

Ports the following PRs:
- tgstation/tgstation#20441
- tgstation/tgstation#20571
- tgstation/tgstation#21025

Refer to these for full information.

This is needed for #3010. Together, this increases performance when there's a lot of objects drifting in space like after a meteor event. MrStonedOne even said: ``removes all of the lag from button mashing the meteor event on metastation``. Tested by drifting around space, toggling jetpack (stabilization) and throwing stuff to change direction.

## Note to HC
This should be merged right after #3010 gets merged for maximum perfomance.