### PR TITLE
[admin] Show disease outbreak events in Investigate>viro

### DIFF
--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -47,4 +47,8 @@
 			D = new virus_type()
 		D.carrier = 1
 		H.AddDisease(D)
+
+		message_admins("[H.real_name]/([H.key]) has been infected with [D.name] by an event.")
+		log_game("[H.real_name]/([H.key]) has been infected with [D.name] by an event.")
+		H.investigate_log("[H.real_name]/([H.key]) has been infected with [D.name] by an event.", "viro")
 		break


### PR DESCRIPTION
Requested by @Ikoden. Closes #3012.

Like the name suggests, it just shows the patient zero of disease outbreaks in investigate>viro. Also prints a message in chat for admins.