### PR TITLE
Reduces lag during roundstart and roundend

### DIFF
--- a/code/__DEFINES/tick.dm
+++ b/code/__DEFINES/tick.dm
@@ -1,7 +1,7 @@
 #define TICK_LIMIT_RUNNING 80
 #define TICK_LIMIT_TO_RUN 75
 #define TICK_LIMIT_MC 80
-#define TICK_LIMIT_MC_INIT 100
+#define TICK_LIMIT_MC_INIT_DEFAULT 98
 
 #define TICK_CHECK ( world.tick_usage > CURRENT_TICKLIMIT ? stoplag() : 0 )
 #define CHECK_TICK if (world.tick_usage > CURRENT_TICKLIMIT)  stoplag()

--- a/code/controllers/configuration.dm
+++ b/code/controllers/configuration.dm
@@ -48,6 +48,7 @@
 	var/Tickcomp = 0
 	var/allow_holidays = 0				//toggles whether holiday-specific content should be used
 	var/admin_who_blocked = 0	// log OOC channel
+	var/tick_limit_mc_init = TICK_LIMIT_MC_INIT_DEFAULT	//SSinitialization throttling
 
 	var/hostedby = null
 	var/respawn = 1
@@ -366,6 +367,8 @@
 					var/ticklag = text2num(value)
 					if(ticklag > 0)
 						fps = 10 / ticklag
+				if("tick_limit_mc_init")
+					tick_limit_mc_init = text2num(value)
 				if("fps")
 					fps = text2num(value)
 				if("tickcomp")

--- a/code/controllers/master.dm
+++ b/code/controllers/master.dm
@@ -123,7 +123,7 @@ var/CURRENT_TICKLIMIT = TICK_LIMIT_RUNNING
 	sortTim(subsystems, /proc/cmp_subsystem_init)
 
 	// Initialize subsystems.
-	CURRENT_TICKLIMIT = TICK_LIMIT_MC_INIT
+	CURRENT_TICKLIMIT = config.tick_limit_mc_init
 	for (var/datum/subsystem/SS in subsystems)
 		if (SS.flags & SS_NO_INIT)
 			continue

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -264,6 +264,7 @@ var/datum/subsystem/air/SSair
 		if (T.blocks_air)
 			continue
 		T.Initalize_Atmos(times_fired)
+		CHECK_TICK
 
 	if(active_turfs.len)
 		var/starting_ats = active_turfs.len
@@ -279,6 +280,7 @@ var/datum/subsystem/air/SSair
 			var/list/new_turfs_to_check = list()
 			for(var/turf/open/T in turfs_to_check)
 				new_turfs_to_check += T.resolve_active_graph()
+			CHECK_TICK
 
 			active_turfs += new_turfs_to_check
 			turfs_to_check = new_turfs_to_check
@@ -289,6 +291,7 @@ var/datum/subsystem/air/SSair
 			var/datum/excited_group/EG = thing
 			EG.self_breakdown(space_is_all_consuming = 1)
 			EG.dismantle()
+			CHECK_TICK
 
 		var/msg = "HEY! LISTEN! [(world.timeofday - timer)/10] Seconds were wasted processing [starting_ats] turf(s) (connected to [ending_ats] other turfs) with atmos differences at round start."
 		to_chat(world, "<span class='boldannounce'>[msg]</span>")

--- a/code/controllers/subsystem/jobs.dm
+++ b/code/controllers/subsystem/jobs.dm
@@ -400,7 +400,11 @@ var/datum/subsystem/job/SSjob
 		to_chat(H, "<b>You are playing a job that is important for Game Progression. If you have to disconnect, please notify the admins via adminhelp.</b>")
 	if(config.minimal_access_threshold)
 		to_chat(H, "<FONT color='blue'><B>As this station was initially staffed with a [config.jobs_have_minimal_access ? "full crew, only your job's necessities" : "skeleton crew, additional access may"] have been added to your ID card.</B></font>")
-	return 1
+	
+	if(job && H)
+		job.equip_items(H)
+
+	return H
 
 
 /datum/subsystem/job/proc/setup_officer_positions()

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -69,14 +69,17 @@ var/datum/subsystem/lighting/SSlighting
 			if (A.lighting_use_dynamic == DYNAMIC_LIGHTING_IFSTARLIGHT)
 				A.luminosity = 0
 
+	CHECK_TICK
 	for(var/thing in changed_lights)
 		var/datum/light_source/LS = thing
 		LS.check()
+		CHECK_TICK
 	changed_lights.Cut()
 
 	for(var/thing in turfs_to_init)
 		var/turf/T = thing
 		T.init_lighting()
+		CHECK_TICK
 	changed_turfs.Cut()
 
 	..()

--- a/code/modules/mob/transform_procs.dm
+++ b/code/modules/mob/transform_procs.dm
@@ -314,7 +314,7 @@
 	O.rename_self("ai")
 	. = O
 	qdel(src)
-	return O
+	return 0
 
 
 //human -> robot

--- a/config/config.txt
+++ b/config/config.txt
@@ -162,6 +162,10 @@ ALLOW_HOLIDAYS
 ##Remove the # mark if you are going to use the SVN irc bot to relay adminhelps
 #USEIRCBOT
 
+##Defines the ticklimit for subsystem initialization (In percents of a byond tick). Lower makes world start smoother. Higher makes it faster.
+##This is currently a testing optimized setting. A good value for production would be 98.
+TICK_LIMIT_MC_INIT 500
+
 ##Defines the ticklag for the world.  0.9 is the normal one, 0.5 is smoother.
 TICKLAG 0.65
 


### PR DESCRIPTION
Credits to MrStonedOne and ike709.

This ports the following PRs:
- https://github.com/tgstation/tgstation/pull/23140
- https://github.com/tgstation/tgstation/pull/23278
- https://github.com/tgstation/tgstation/pull/23552 (Part of it)

Refer to these for full information.

This reduces lag during roundstart and roundend. It should also be smoother now. Tested by starting and ending a round. No runtime errors and my loadout was fine. Would still require some more testing though.

## Note to HC
This edits the config.

:cl:  
tweak: Reduced lag during roundstart and roundend
/:cl:
