### PR TITLE
(Hopefully) Fixes apostrophes in discord ooc

### DIFF
--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -78,7 +78,7 @@
 			keyname += "<img style='width:9px;height:9px;' class=icon src=\ref['icons/member_content.dmi'] iconstate=yogdon>"
 
 	keyname += "[key]"
-	webhook_send_ooc(key, msg)
+	webhook_send_ooc(key, fix_apostrophes(msg))
 	msg = emoji_parse(msg)
 
 	for(var/client/C in clients)


### PR DESCRIPTION
I hope this works. Untested because I can't into bot.

:cl:  
tweak: Apostrophes now work in discord ooc
/:cl:
