### PR TITLE
Extends possible name lengths to support normal use

### DIFF
--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -28,7 +28,7 @@
 
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
 #define MAX_MESSAGE_LEN			1024
-#define MAX_NAME_LEN			26
+#define MAX_NAME_LEN			
 #define MAX_BROADCAST_LEN		512
 
 //MINOR TWEAKS/MISC

--- a/code/_compile_options.dm
+++ b/code/_compile_options.dm
@@ -28,7 +28,7 @@
 
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
 #define MAX_MESSAGE_LEN			1024
-#define MAX_NAME_LEN			
+#define MAX_NAME_LEN			40
 #define MAX_BROADCAST_LEN		512
 
 //MINOR TWEAKS/MISC


### PR DESCRIPTION
Previous limit blocked you from naming rooms with their original name: I.E. "Heads of Staff Meeting Room" was too long.

closes: #481

### Intent of your Pull Request

Increases the frankly arbitrary name length limit

#### Changelog

:cl:  
tweak: You can now name things up to 40 characters. Huzzah!
/:cl:
