### PR TITLE
Fix runtime errors caused by attack_verb

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -59,7 +59,7 @@ var/global/image/fire_overlay = image("icon" = 'icons/effects/fire.dmi', "icon_s
 	var/needs_permit = 0			//Used by security bots to determine if this item is safe for public use.
 	var/scarab_usable = FALSE //can clockwork cogscarabs use this item?
 
-	var/list/attack_verb //Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
+	var/list/attack_verb = list() //Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
 	var/list/species_exception = null // even if a species cannot put items in a certain slot, if the species id is in the item's exception list, it will be able to wear that item
 
 	var/suittoggled = 0

--- a/code/game/objects/items/weapons/cigs_lighters.dm
+++ b/code/game/objects/items/weapons/cigs_lighters.dm
@@ -65,7 +65,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		item_state = "cigoff"
 		name = "burnt match"
 		desc = "A match. This one has seen better days."
-		attack_verb = null
+		attack_verb = list("attacked", "hit")
 		STOP_PROCESSING(SSobj, src)
 
 /obj/item/weapon/match/dropped(mob/user)
@@ -537,7 +537,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 			update_icon()
 			hitsound = "swing_hit"
 			force = 0
-			attack_verb = null //human_defense.dm takes care of it
+			attack_verb = list("attacked", "hit")
 			if(!istype(src, /obj/item/weapon/lighter/greyscale))
 				user.visible_message("You hear a quiet click, as [user] shuts off [src] without even looking at what they're doing. Wow.", "<span class='notice'>You quietly shut off [src] without even looking at what you're doing. Wow.</span>")
 			else
@@ -549,21 +549,46 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 	return
 
 /obj/item/weapon/lighter/attack(mob/living/carbon/M, mob/living/carbon/user)
-	if(lit)
-		M.IgniteMob()
-	var/obj/item/clothing/mask/cigarette/cig = help_light_cig(M,user)
-	if(lit && cig && user.a_intent == "help")
-		if(cig.lit)
-			to_chat(user, "<span class='notice'>The [cig.name] is already lit.</span>")
-		if(M == user)
-			cig.attackby(src, user)
-		else
-			if(!istype(src, /obj/item/weapon/lighter/greyscale))
-				cig.light("<span class='rose'>[user] whips the [name] out and holds it for [M]. Their arm is as steady as the unflickering flame they light \the [cig] with.</span>")
-			else
-				cig.light("<span class='notice'>[user] holds the [name] out for [M], and lights the [cig.name].</span>")
+	if(ishuman(M))
+		var/mob/living/carbon/human/H = M
+		if(lit && user.a_intent == "help")
+			if(H.bleed_rate && !H.bleedsuppress)	// Prioritize cauterizing over lighting a cig.
+				var/hitzone = user.zone_selected
+				H.suppress_bloodloss(stop_bleeding)
+				H.apply_damage(rand(5,10), BURN, hitzone)
+				if (H.bleed_rate >= 1.5) // a simple lighter won't fix your problems.
+					to_chat(user, "<span class='alert'>There is too much blood coming out of the wound for you to fix it with [src] and you screw up!</span>")
+					H.visible_message("<span class='alert'>[H]'s wounds are burned by [src], but are unable to be closed by it's flame!</span>")
+					return
+
+				if(H == user)
+					to_chat(user, "<span class='notice'>You mend your bleeding wound with [src], sealing it completely. Also looking like a total badass.</span>")
+					H.visible_message("<span class='alert'>[user] mends their bleeding wounds with a lighter! What a badass.</span>")
+				else
+					H.visible_message("<span class='alert'>[user] uses [src] to close some of [H]'s wounds by burning them fiercly!</span>")
+
+				H.cauterized = 1
+				return
+
+			var/obj/item/clothing/mask/cigarette/cig = help_light_cig(H, user)
+			if(cig)
+				if(cig.lit)
+					to_chat(user, "<span class='notice'>The [cig.name] is already lit.</span>")
+					return
+
+				if(H == user)
+					cig.attackby(src, user)
+				else
+					if(!istype(src, /obj/item/weapon/lighter/greyscale))
+						cig.light("<span class='rose'>[user] whips the [name] out and holds it for [M]. Their arm is as steady as the unflickering flame they light \the [cig] with.</span>")
+					else
+						cig.light("<span class='notice'>[user] holds the [name] out for [M], and lights the [cig.name].</span>")
+				return
 	else
-		..()
+		if(lit)
+			M.IgniteMob()
+
+	..()
 
 /obj/item/weapon/lighter/process()
 	var/turf/location = get_turf(src)
@@ -589,25 +614,6 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 
 /obj/item/weapon/lighter/is_hot()
 	return lit * heat
-
-/obj/item/weapon/lighter/attack(mob/living/carbon/human/H, mob/living/carbon/user)
-	if(src.lit && !H.bleedsuppress && user.a_intent == "help" && H.bleed_rate)
-		var/hitzone = user.zone_selected
-		H.suppress_bloodloss(src.stop_bleeding)
-		H.apply_damage(rand(5,10), BURN, hitzone)
-		if (H.bleed_rate >= 1.5) // a simple lighter won't fix your problems.
-			user.visible_message("<span class='alert'>There is too much blood coming out of the wound for you to fix it with [src] and you screw up!</span>")
-			visible_message("<span class='alert'>[H]'s wounds are burned by [src], but are unable to be closed by it's flame!</span>")
-			return
-		if(user == H)
-			user.visible_message("<span class='notice'>You mend your bleeding wound with [src], sealing it completely. Also looking like a total badass.</span>")
-			visible_message("<span class='alert'>[user] mends their bleeding wounds with a lighter! What a badass.</span>")
-		else
-			visible_message("<span class='alert'>[user] uses [src] to close some of [H]'s wounds by burning them fiercly!</span>")
-		H.cauterized = 1
-	else
-		..()
-
 
 ///////////
 //ROLLING//


### PR DESCRIPTION
For some reason, ``attack_verb`` was being set to ``null`` when turning off a lighter which causes runtime errors when you tried attack someone with it. This fixes that and also provides a default value to ``attack_verb`` to prevent any items that don't set  ``attack_verb`` to runtime error aswell.

Also fixes ``/obj/item/weapon/lighter/attack``.

:cl:  
bugfix: All items will now have an attack message.
bugfix: You can now light someone else's cigarette using a lighter.
/:cl:
