### PR TITLE
Makes gang dominating require a nuke disk

### DIFF
--- a/code/game/gamemodes/gang/dominator.dm
+++ b/code/game/gamemodes/gang/dominator.dm
@@ -41,7 +41,7 @@
 		else
 			to_chat(user, "<span class='notice'>Hostile Takeover of [station_name()] successful. Have a great day.</span>")
 	else
-		to_chat(user, "<span class='notice'>System on standby.</span>")
+		to_chat(user, "<span class='notice'>Nuclear Authentication Disk needed to initiate Hostile Takeover.</span>")
 	to_chat(user, "<span class='danger'>System Integrity: [round((health/maxhealth)*100,1)]%</span>")
 
 /obj/machinery/dominator/process()
@@ -92,6 +92,8 @@
 /obj/machinery/dominator/proc/set_broken()
 	if(gang)
 		gang.dom_timer = "OFFLINE"
+		for(var/obj/O in contents)
+			O.loc = src.loc
 
 		var/takeover_in_progress = 0
 		for(var/datum/gang/G in ticker.mode.gangs)
@@ -161,52 +163,7 @@
 	take_damage(110, BRUTE, 0)
 
 /obj/machinery/dominator/attack_hand(mob/user)
-	if(operating || (stat & BROKEN))
 		examine(user)
-		return
-
-	var/datum/gang/tempgang
-
-	if(user.mind in ticker.mode.get_all_gangsters())
-		tempgang = user.mind.gang_datum
-	else
-		examine(user)
-		return
-
-	if(isnum(tempgang.dom_timer))
-		to_chat(user, "<span class='warning'>Error: Hostile Takeover is already in progress.</span>")
-		return
-
-	if(!tempgang.dom_attempts)
-		to_chat(user, "<span class='warning'>Error: Unable to breach station network. Firewall has logged our signature and is blocking all further attempts.</span>")
-		return
-
-	var/time = round(get_domination_time(tempgang)/60,0.1)
-	if(alert(user,"With [round((tempgang.territory.len/start_state.num_territories)*100, 1)]% station control, a takeover will require [time] minutes.\nYour gang will be unable to gain influence while it is active.\nThe entire station will likely be alerted to it once it starts.\nYou have [tempgang.dom_attempts] attempt(s) remaining. Are you ready?","Confirm","Ready","Later") == "Ready")
-		if (isnum(tempgang.dom_timer) || !tempgang.dom_attempts || !in_range(src, user) || !istype(src.loc, /turf))
-			return 0
-
-		var/area/A = get_area(loc)
-		var/locname = initial(A.name)
-
-		gang = tempgang
-		gang.dom_attempts --
-		priority_announce("Network breach detected in [locname]. The [gang.name] Gang is attempting to seize control of the station!","Network Alert")
-		gang.domination()
-		src.name = "[gang.name] Gang [src.name]"
-		operating = 1
-		icon_state = "dominator-[gang.color]"
-
-		countdown.color = gang.color_hex
-		countdown.start()
-
-		SetLuminosity(3)
-		START_PROCESSING(SSmachine, src)
-
-		gang.message_gangtools("Hostile takeover in progress: Estimated [time] minutes until victory.[gang.dom_attempts ? "" : " This is your final attempt."]")
-		for(var/datum/gang/G in ticker.mode.gangs)
-			if(G != gang)
-				G.message_gangtools("Enemy takeover attempt detected in [locname]: Estimated [time] minutes until our defeat.",1,1)
 
 /obj/machinery/dominator/attack_hulk(mob/user)
 	user.visible_message("<span class='danger'>[user] smashes [src].</span>",\
@@ -215,7 +172,45 @@
 	take_damage(5)
 
 /obj/machinery/dominator/attacked_by(obj/item/I, mob/living/user)
+	if(istype(I, /obj/item/weapon/disk/nuclear) && user.mind in ticker.mode.get_all_gangsters())
+		var/datum/gang/tempgang = user.mind.gang_datum
+
+		if(isnum(tempgang.dom_timer))
+			to_chat(user, "<span class='warning'>Error: Hostile Takeover is already in progress.</span>")
+			return
+
+		if(!tempgang.dom_attempts)
+			to_chat(user, "<span class='warning'>Error: Unable to breach station network. Firewall has logged our signature and is blocking all further attempts.</span>")
+			return
+
+		var/time = round(get_domination_time(tempgang)/60,0.1)
+		if(alert(user,"With [round((tempgang.territory.len/start_state.num_territories)*100, 1)]% station control, a takeover will require [time] minutes.\nYour gang will be unable to gain influence while it is active.\nThe entire station will likely be alerted to it once it starts.\nYou have [tempgang.dom_attempts] attempt(s) remaining. Are you ready?","Confirm","Ready","Later") == "Ready")
+			if(isnum(tempgang.dom_timer) || !tempgang.dom_attempts || !in_range(src, user) || !istype(src.loc, /turf) || !user.drop_item())
+				return 0
+			I.loc = src
+
+			var/area/A = get_area(loc)
+			var/locname = initial(A.name)
+
+			gang = tempgang
+			gang.dom_attempts --
+			priority_announce("Network breach detected in [locname]. The [gang.name] Gang is attempting to seize control of the station!","Network Alert")
+			gang.domination()
+			src.name = "[gang.name] Gang [src.name]"
+			operating = 1
+			icon_state = "dominator-[gang.color]"
+
+			countdown.color = gang.color_hex
+			countdown.start()
+
+			SetLuminosity(3)
+			START_PROCESSING(SSmachine, src)
+
+			gang.message_gangtools("Hostile takeover in progress: Estimated [time] minutes until victory.[gang.dom_attempts ? "" : " This is your final attempt."]")
+			for(var/datum/gang/G in ticker.mode.gangs)
+				if(G != gang)
+					G.message_gangtools("Enemy takeover attempt detected in [locname]: Estimated [time] minutes until our defeat.",1,1)
+			return
+
 	add_fingerprint(user)
 	..()
-
-

--- a/code/game/gamemodes/gang/gang_datum.dm
+++ b/code/game/gamemodes/gang/gang_datum.dm
@@ -36,7 +36,8 @@
 		/datum/gang_item/equipment/pen,
 		/datum/gang_item/equipment/gangtool,
 		/datum/gang_item/equipment/necklace,
-		/datum/gang_item/equipment/dominator
+		/datum/gang_item/equipment/dominator,
+		/datum/gang_item/equipment/pinpointer
 	)
 
 /datum/gang/New(loc,gangname)

--- a/code/game/gamemodes/gang/gang_items.dm
+++ b/code/game/gamemodes/gang/gang_items.dm
@@ -208,7 +208,7 @@
 /datum/gang_item/equipment/pinpointer
 	name = "Pinpointer"
 	id= "pinpointer"
-	cost = 30
+	cost = 10
 	item_path = /obj/item/weapon/pinpointer
 
 // APRIL FOOLS START

--- a/code/game/gamemodes/gang/gang_items.dm
+++ b/code/game/gamemodes/gang/gang_items.dm
@@ -205,6 +205,12 @@
 	item_path = /obj/item/weapon/implanter/gang
 	spawn_msg = "<span class='notice'>The <b>implant breaker</b> is a single-use device that destroys all implants within the target before trying to recruit them to your gang. Also works on enemy gangsters.</span>"
 
+/datum/gang_item/equipment/pinpointer
+	name = "Pinpointer"
+	id= "pinpointer"
+	cost = 30
+	item_path = /obj/item/weapon/pinpointer
+
 // APRIL FOOLS START
 /datum/gang_item/equipment/banana
 	name = "Banana"


### PR DESCRIPTION
*gang 1 pops dom*
*gang 2 pops dom*
*both gangs sit and do nothing while waiting to win*
The gangs can also buy a pinpointer from their uplink, so they don't need cargo to buy more
:cl:
tweak: Gangs now need a nuke disk to dominate. Simply use the nuke disk on your dominator to activate it!
rscadd: Gangs can now buy pinpointers from the gang tool. The price has been set to 10credits!
/:cl: