### PR TITLE
Fix AI spam

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -199,7 +199,7 @@
 			to_chat(user, "<span class='notice'>The camera turns away as you hold up the paper.</span>")
 			return
 
-		last_paper_time = world.time + 300		// 30 second cooldown between showing paper
+		last_paper_time = world.time + 100		// 10 second cooldown between showing paper
 
 		var/mob/living/U = user
 		var/obj/item/weapon/paper/X = null

--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -31,6 +31,8 @@
 	var/alarm_on = 0
 	var/busy = 0
 	var/emped = 0  //Number of consecutive EMP's on this camera
+	
+	var/last_paper_time = 0
 
 	// Upgrades bitflag
 	var/upgrades = 0
@@ -193,6 +195,12 @@
 
 	// OTHER
 	if((istype(W, /obj/item/weapon/paper) || istype(W, /obj/item/device/pda)) && isliving(user))
+		if(last_paper_time > world.time)
+			to_chat(user, "<span class='notice'>The camera turns away as you hold up the paper.</span>")
+			return
+
+		last_paper_time = world.time + 300		// 30 second cooldown between showing paper
+
 		var/mob/living/U = user
 		var/obj/item/weapon/paper/X = null
 		var/obj/item/device/pda/P = null


### PR DESCRIPTION
Closes #3041.

There is no cooldown on showing paper to the AI which means you can spam it to annoy the AI. This adds a 10s cooldown between each attempt on each camera.

#### Changelog

:cl:  
tweak: The AI can't be spammed anymore by showing paper to a camera.
/:cl:
