### PR TITLE
Throwing a baton at people now stuns them

### DIFF
--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -140,29 +140,38 @@
 	else
 		if(!deductcharge(hitcost))
 			return 0
-
-	user.lastattacked = L
-	L.lastattacker = user
+	if(user)
+		user.lastattacked = L
+		L.lastattacker = user
+		L.visible_message("<span class='danger'>[user] has stunned [L] with [src]!</span>", \
+								"<span class='userdanger'>[user] has stunned you with [src]!</span>")
+		add_logs(user, L, "stunned")
 
 	L.Stun(stunforce)
 	L.Weaken(stunforce)
 	L.apply_effect(STUTTER, stunforce)
 
-	L.visible_message("<span class='danger'>[user] has stunned [L] with [src]!</span>", \
-							"<span class='userdanger'>[user] has stunned you with [src]!</span>")
 	playsound(loc, 'sound/weapons/Egloves.ogg', 50, 1, -1)
 
 	if(ishuman(L))
 		var/mob/living/carbon/human/H = L
 		H.forcesay(hit_appends)
-
-	add_logs(user, L, "stunned")
 	return 1
 
 /obj/item/weapon/melee/baton/emp_act(severity)
 	if(bcell)
 		deductcharge(round(bcell.charge / severity))
 	..()
+
+/obj/item/weapon/melee/baton/throw_impact(atom/target)
+	..()
+
+	if(!isliving(target) || !status || loc == target)
+		return
+	var/mob/living/L = target
+	baton_stun(L)
+
+
 
 //Makeshift stun baton. Replacement for stun gloves.
 /obj/item/weapon/melee/baton/cattleprod

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -166,7 +166,7 @@
 /obj/item/weapon/melee/baton/throw_impact(atom/target)
 	..()
 
-	if(!isliving(target) || !status || loc == target)
+	if(!isliving(target) || !status || loc == target || !prob(50))
 		return
 	var/mob/living/L = target
 	baton_stun(L)

--- a/code/game/objects/items/weapons/stunbaton.dm
+++ b/code/game/objects/items/weapons/stunbaton.dm
@@ -13,6 +13,7 @@
 	var/status = 0
 	var/obj/item/weapon/stock_parts/cell/high/bcell = null
 	var/hitcost = 1000
+	var/throw_hit_chance = 50
 
 /obj/item/weapon/melee/baton/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is putting the live [name] in \his mouth! It looks like \he's trying to commit suicide.</span>")
@@ -166,7 +167,7 @@
 /obj/item/weapon/melee/baton/throw_impact(atom/target)
 	..()
 
-	if(!isliving(target) || !status || loc == target || !prob(50))
+	if(!isliving(target) || !status || loc == target || prob(throw_hit_chance))
 		return
 	var/mob/living/L = target
 	baton_stun(L)
@@ -186,6 +187,7 @@
 	hitcost = 2500
 	slot_flags = null
 	var/obj/item/device/assembly/igniter/sparkler = 0
+	throw_hit_chance = 10
 
 /obj/item/weapon/melee/baton/cattleprod/New()
 	..()


### PR DESCRIPTION
Closes #3049 

:cl:
rscadd: Stunbatons will now stun if you throw them at people. Be careful as your target may just catch the baton instead!
/:cl:

EDIT: third commit uses something from this: https://github.com/tgstation/tgstation/pull/19083/files