### PR TITLE
Fix transit tube pods eating the air

### DIFF
--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -153,7 +153,12 @@
 		open_animation()
 		sleep(OPEN_DURATION + 2)
 		pod_moving = 0
-		pod.mix_air()
+		if(!qdeleted(pod))
+			var/datum/gas_mixture/floor_mixture = loc.return_air()
+			floor_mixture.archive()
+			pod.air_contents.archive()
+			pod.air_contents.share(floor_mixture, 1) //mix the pod's gas mixture with the tile it's on
+			air_update_turf()
 
 // Tube station directions are simply 90 to either side of
 //  the exit.

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -11,8 +11,8 @@
 /obj/structure/transit_tube_pod/New(loc)
 	..(loc)
 
-	air_contents.assert_gases("o2", "n2")
-	air_contents.gases["o2"][MOLES] = MOLES_O2STANDARD * 2
+	air_contents.add_gases("o2", "n2")
+	air_contents.gases["o2"][MOLES] = MOLES_O2STANDARD
 	air_contents.gases["n2"][MOLES] = MOLES_N2STANDARD
 	air_contents.temperature = T20C
 


### PR DESCRIPTION
Turns out transit tube pods are some slippery thieves that need to be taught some manners. This forces them to follow the law and stop stealing the air around them. Credits to https://github.com/tgstation/tgstation/pull/30597.

:cl:  
bugfix: Transit tube pods will no longer eat the air around them and pull you into them.
/:cl:
