### PR TITLE
Fix runtimes caused by /mob/living/carbon/handle_status_effects

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -302,7 +302,7 @@
 /mob/living/carbon/handle_status_effects()
 	..()
 
-	if(staminaloss || dna.species.stamina_recover_normal < 0)
+	if(staminaloss || (dna && dna.species && dna.species.stamina_recover_normal < 0))
 		regenStamina()
 
 	if(sleeping)


### PR DESCRIPTION
The following runtime
```
The following runtime has occurred 523 time(s).
runtime error: Cannot read null.species
```
was caused by /mob/living/carbon/handle_status_effects getting called on carbons that don't have DNA. It would try to get the species but because dna was null, it would runtime. This fixes the runtime.