### PR TITLE
Revokes mineral withdrawal access from miners

### DIFF
--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -73,7 +73,7 @@ Shaft Miner
 	outfit = /datum/outfit/job/miner
 
 	access = list(access_maint_tunnels, access_mailsorting, access_cargo, access_cargo_bot, access_qm, access_mining, access_mining_station, access_mineral_storeroom)
-	minimal_access = list(access_mining, access_mining_station, access_mailsorting, access_mineral_storeroom)
+	minimal_access = list(access_mining, access_mining_station, access_mailsorting)
 
 /datum/outfit/job/miner
 	name = "Shaft Miner"


### PR DESCRIPTION
:cl:
tweak: Shaft-miners can no longer withdraw the minerals they got paid for bringing up, since its not their property anymore
/:cl:

Closes #2055 