### PR TITLE
[admin] Orders MC subsystems alphabetically

### DIFF
--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -33,9 +33,7 @@ var/cmp_field = "name"
 	return b.init_order - a.init_order
 
 /proc/cmp_subsystem_display(datum/subsystem/a, datum/subsystem/b)
-	if(a.display_order == b.display_order)
-		return sorttext(b.name, a.name)
-	return a.display_order - b.display_order
+	return sorttext(b.name, a.name)
 
 /proc/cmp_subsystem_priority(datum/subsystem/a, datum/subsystem/b)
 	return a.priority - b.priority

--- a/code/controllers/subsystem.dm
+++ b/code/controllers/subsystem.dm
@@ -5,7 +5,6 @@
 	var/name = "fire coderbus" //name of the subsystem
 	var/init_order = 0		//order of initialization. Higher numbers are initialized first, lower numbers later. Can be decimal and negative values.
 	var/wait = 20			//time to wait (in deciseconds) between each call to fire(). Must be a positive integer.
-	var/display_order = 100	//display affects the order the subsystem is displayed in the MC tab
 	var/priority = 50		//When mutiple subsystems need to run in the same tick, higher priority subsystems will run first and be given a higher share of the tick before MC_TICK_CHECK triggers a sleep
 
 	var/flags = 0			//see MC.dm in __DEFINES Most flags must be set on world start to take full effect. (You can also restart the mc to force them to process again)

--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -13,7 +13,6 @@ var/datum/subsystem/air/SSair
 	priority = 20
 	wait = 5
 	flags = SS_BACKGROUND
-	display_order = 1
 
 	var/cost_turfs = 0
 	var/cost_groups = 0

--- a/code/controllers/subsystem/garbage.dm
+++ b/code/controllers/subsystem/garbage.dm
@@ -4,7 +4,6 @@ var/datum/subsystem/garbage_collector/SSgarbage
 	name = "Garbage"
 	priority = 15
 	wait = 5
-	display_order = 2
 	flags = SS_FIRE_IN_LOBBY|SS_POST_FIRE_TIMING|SS_BACKGROUND|SS_NO_INIT
 
 	var/collection_timeout = 3000// deciseconds to wait to let running procs finish before we just say fuck it and force del() the object

--- a/code/controllers/subsystem/lighting.dm
+++ b/code/controllers/subsystem/lighting.dm
@@ -9,7 +9,6 @@ var/datum/subsystem/lighting/SSlighting
 	wait = 1
 	flags = SS_POST_FIRE_TIMING
 	priority = 40
-	display_order = 5
 
 	var/list/changed_lights = list()		//list of all datum/light_source that need updating
 	var/changed_lights_workload = 0			//stats on the largest number of lights (max changed_lights.len)

--- a/code/controllers/subsystem/machines.dm
+++ b/code/controllers/subsystem/machines.dm
@@ -3,7 +3,6 @@ var/datum/subsystem/machines/SSmachine
 /datum/subsystem/machines
 	name = "Machines"
 	init_order = 9
-	display_order = 3
 	flags = SS_KEEP_TIMING
 	var/list/processing = list()
 	var/list/currentrun = list()

--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -4,7 +4,6 @@ var/datum/subsystem/mapping/SSmapping
 	name = "Mapping"
 	init_order = 100000
 	flags = SS_NO_FIRE
-	display_order = 50
 	var/datum/map_config/previous_map_config
 	var/datum/map_config/config
 	var/datum/map_config/next_map_config

--- a/code/controllers/subsystem/mobs.dm
+++ b/code/controllers/subsystem/mobs.dm
@@ -3,7 +3,6 @@ var/datum/subsystem/mobs/SSmob
 /datum/subsystem/mobs
 	name = "Mobs"
 	init_order = 4
-	display_order = 4
 	priority = 100
 	flags = SS_KEEP_TIMING|SS_NO_INIT
 

--- a/code/controllers/subsystem/npcpool.dm
+++ b/code/controllers/subsystem/npcpool.dm
@@ -3,7 +3,6 @@ var/datum/subsystem/npcpool/SSnpc
 /datum/subsystem/npcpool
 	name = "NPC Pool"
 	init_order = 17
-	display_order = 6
 	flags = SS_POST_FIRE_TIMING|SS_NO_INIT|SS_NO_TICK_CHECK
 	priority = 25
 

--- a/code/controllers/subsystem/tgui.dm
+++ b/code/controllers/subsystem/tgui.dm
@@ -4,7 +4,6 @@ var/datum/subsystem/tgui/SStgui
 	name = "tgui"
 	wait = 9
 	init_order = 16
-	display_order = 6
 	flags = SS_NO_INIT|SS_FIRE_IN_LOBBY
 	priority = 110
 

--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -4,7 +4,6 @@ var/datum/subsystem/timer/SStimer
 	name = "Timer"
 	wait = 2 //SS_TICKER subsystem, so wait is in ticks
 	init_order = 1
-	display_order = 3
 	can_fire = 0 //start disabled
 	flags = SS_FIRE_IN_LOBBY|SS_TICKER|SS_POST_FIRE_TIMING|SS_NO_INIT
 


### PR DESCRIPTION
Credits to Cyberboss.

Ports the following PRs:
- https://github.com/tgstation/tgstation/pull/24627

Refer to these for full information.

This orders subsystems alphabetically in the  MC tab. Makes it easier to find a specific SS.