### PR TITLE
Fix examine exploit v2

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -276,6 +276,16 @@ var/next_mob_id = 0
 	set name = "Examine"
 	set category = "IC"
 
+	var/see_turfs = FALSE
+	if(ishuman(src))
+		var/mob/living/carbon/human/H = src
+		if(H.glasses && H.glasses.vision_flags & SEE_TURFS)
+			see_turfs = TRUE
+
+	if(!isobserver(src) && isturf(A) && !(A in view(src)))
+		if(!see_turfs)
+			return
+
 	if(is_blind(src))
 		to_chat(src, "<span class='notice'>Something is there but you can't see it.</span>")
 		return


### PR DESCRIPTION
Ok, this is more thoroughly tested this time. You can no longer examine items that more than 1 tile away from you and are pitch dark. You can still examine stuff you can see, including stuff in your hands/equipped stuff. This effect is bypassed by equipping mesons, which will allow you to examine any tile again.