### PR TITLE
The emergency shuttle now gets recalled on rev

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -94,7 +94,7 @@
 			ticker.mode.check_win()
 		check_counter = 0
 	if(SSshuttle.emergency.mode == SHUTTLE_CALL)
-		if(prob(check_counter) || SSshuttle.emergency.timeLeft(10) <= 360)
+		if(prob(0.1) || SSshuttle.emergency.timeLeft(10) <= 360)
 			SSshuttle.emergency.cancel(null, TRUE)
 	return 0
 

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -93,6 +93,9 @@
 			check_heads()
 			ticker.mode.check_win()
 		check_counter = 0
+	if(SSshuttle.emergency.mode == SHUTTLE_CALL)
+		if(prob(check_counter) || SSshuttle.emergency.timeLeft(10) <= 360)
+			SSshuttle.emergency.cancel(null, TRUE)
 	return 0
 
 


### PR DESCRIPTION
:cl:
tweak: The shuttle will now be randomly recalled during revolutions!
/:cl:

L0rd_english talked about it on discord, and it seems like a harmless thing that makes more sense than "shuttle doesn't leave lul".