### PR TITLE
Makes /client inherit from /datum

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -964,12 +964,9 @@ var/list/WALLITEMS_INVERSE = list(
 	tY = max(1, min(origin.y + 7 - tY, world.maxy))
 	return locate(tX, tY, tZ)
 
-/proc/IsValidSrc(A)
-	if(istype(A, /datum))
-		var/datum/B = A
-		return !qdeleted(B)
-	if(istype(A, /client))
-		return 1
+/proc/IsValidSrc(datum/D)
+	if(istype(D))
+		return !qdeleted(D)
 	return 0
 
 

--- a/code/controllers/subsystem/server_maintenance.dm
+++ b/code/controllers/subsystem/server_maintenance.dm
@@ -17,7 +17,7 @@ var/datum/subsystem/server_maint/SSserver
 				if(!istype(C.mob, /mob/dead))
 					log_access("AFK: [key_name(C)]")
 					to_chat(C, "<span class='danger'>You have been inactive for more than 10 minutes and have been disconnected.</span>")
-					del(C)
+					qdel(C)
 
 	if(config.sql_enabled)
 		sql_poll_players()

--- a/code/game/objects/effects/mines.dm
+++ b/code/game/objects/effects/mines.dm
@@ -55,7 +55,7 @@
 /obj/effect/mine/kickmine/mineEffect(mob/victim)
 	if(isliving(victim) && victim.client)
 		to_chat(victim, "<span class='userdanger'>You have been kicked FOR NO REISIN!</span>")
-		del(victim.client)
+		qdel(victim.client)
 
 
 /obj/effect/mine/gas

--- a/code/modules/admin/DB_ban/functions.dm
+++ b/code/modules/admin/DB_ban/functions.dm
@@ -136,7 +136,7 @@
 
 	if(kickbannedckey)
 		if(banned_mob && banned_mob.client && banned_mob.client.ckey == banckey)
-			del(banned_mob.client)
+			qdel(banned_mob.client)
 
 
 /datum/admins/proc/DB_ban_unban(ckey, bantype, job = "")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -808,7 +808,7 @@ var/global/BSACooldown = 0
 			if(message)
 				to_chat(C, message)
 			kicked_client_names.Add("[C.ckey]")
-			del(C)
+			qdel(C)
 	return kicked_client_names
 
 //returns 1 to let the dragdrop code know we are trapping this event

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -1134,7 +1134,7 @@
 			log_admin("[key_name(usr)] kicked [key_name(M)].")
 			message_admins("<span class='adminnotice'>[key_name_admin(usr)] kicked [key_name_admin(M)].</span>")
 			//M.client = null
-			del(M.client)
+			qdel(M.client)
 
 	//Player Notes
 	else if(href_list["addnote"])
@@ -1236,7 +1236,7 @@
 				log_admin("[usr.client.ckey] has banned [M.ckey].\nReason: [reason]\nThis will be removed in [mins] minutes.")
 				message_admins("<span class='adminnotice'>[usr.client.ckey] has banned [M.ckey].\nReason: [reason]\nThis will be removed in [mins] minutes.</span>")
 
-				del(M.client)
+				qdel(M.client)
 				//qdel(M)	// See no reason why to delete mob. Important stuff can be lost. And ban can be lifted before round ends.
 			if("No")
 				var/reason = stripped_multiline_input(usr,"Please State Reason","Reason")
@@ -1261,7 +1261,7 @@
 				feedback_inc("ban_perma",1)
 				DB_ban_record(BANTYPE_PERMA, M, -1, reason)
 
-				del(M.client)
+				qdel(M.client)
 				//qdel(M)
 			if("Cancel")
 				return

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -1,5 +1,9 @@
 
 /client
+		//////////////////////
+		//BLACK MAGIC THINGS//
+		//////////////////////
+	parent_type = /datum
 		////////////////
 		//ADMIN THINGS//
 		////////////////
@@ -54,9 +58,6 @@
 
 	//datum that controls the displaying and hiding of tooltips
 	var/datum/tooltip/tooltips
-
-	//Used for var edit flagging, also defined in datums (clients are not a child of datums for some reason)
-	var/var_edited = 0
 
 	var/last_cached_weight //For weight checking, prevents query spam
 	var/last_cached_total_weight //For weight checking, prevents query spam

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -250,7 +250,7 @@ var/next_external_rsc = 0
 		if (holder)
 			to_chat(src, "Because you are an admin, you are being allowed to walk past this limitation, But it is still STRONGLY suggested you upgrade")
 		else
-			del(src)
+			qdel(src)
 			return 0
 	else if (byond_version < config.client_warn_version)	//We have words for this client.
 		to_chat(src, "<span class='danger'><b>Your version of byond may be getting out of date:</b></span>")
@@ -262,11 +262,11 @@ var/next_external_rsc = 0
 	if (connection == "web")
 		if (!config.allowwebclient)
 			to_chat(src, "Web client is disabled")
-			del(src)
+			qdel(src)
 			return 0
 		if (config.webclientmembersonly && !IsByondMember())
 			to_chat(src, "Sorry, but the web client is restricted to byond members only.")
-			del(src)
+			qdel(src)
 			return 0
 
 	if( (world.address == address || !address) && !host )
@@ -294,7 +294,7 @@ var/next_external_rsc = 0
 			log_access("Failed Login: [key] - New account attempting to connect during panic bunker")
 			message_admins("<span class='adminnotice'>Failed Login: [key] - New account attempting to connect during panic bunker</span>")
 			to_chat(src, "Sorry but the server is currently not accepting connections from never before seen players.")
-			del(src)
+			qdel(src)
 			return 0
 
 		if (config.notify_new_player_age >= 0)
@@ -378,6 +378,9 @@ var/next_external_rsc = 0
 		return
 	var/DBQuery/query_logout = dbcon.NewQuery("UPDATE `[format_table_name("connection_log")]` SET `left`=Now() WHERE `id`=[number];")
 	query_logout.Execute()
+
+/client/Destroy()
+	return QDEL_HINT_HARDDEL_NOW
 
 /client/proc/set_client_age_from_db()
 	if (IsGuestKey(src.key))
@@ -517,7 +520,7 @@ var/next_external_rsc = 0
 
 			log_access("Failed Login: [key] [computer_id] [address] - CID randomizer confirmed (oldcid: [oldcid])")
 
-			del(src)
+			qdel(src)
 			return TRUE
 		else
 			if (cidcheck_failedckeys[ckey])
@@ -546,7 +549,7 @@ var/next_external_rsc = 0
 
 			//teeheehee (in case the above method doesn't work, its not 100% reliable.)
 			to_chat(src, "<pre class=\"system system\">Network connection shutting down due to read error.</pre>")
-			del(src)
+			qdel(src)
 			return TRUE
 
 /client/proc/note_randomizer_user()
@@ -572,7 +575,7 @@ var/next_external_rsc = 0
 			return
 	add_note(ckey, "Detected as using a cid randomizer.", null, adminckey, logged = 0)
 
-/client/proc/vv_edit_var(var_name, var_value)
+/client/vv_edit_var(var_name, var_value)
 	switch (var_name)
 		if ("holder")
 			return FALSE
@@ -580,3 +583,4 @@ var/next_external_rsc = 0
 			return FALSE
 		if ("key")
 			return FALSE
+	. = ..()


### PR DESCRIPTION
Credits to MrStonedOne

Ports the following PRs:
- https://github.com/tgstation/tgstation/pull/20394

Refer to these for full information.

This sets the parent type of /client to /datum which means that /client will inherit all procs from /datum. This also means doing ``istype(someclienthere, /datum`` will return true. This is intended behaviour considering literally everything inherits from /datum. This also fixes clicking on ``client`` in VV. 