### PR TITLE
reenables wizard academy

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/Academy.dmm
+++ b/_maps/RandomRuins/SpaceRuins/Academy.dmm
@@ -1,4 +1,4 @@
-//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE 
+//MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "aa" = (
 /turf/open/space,
 /area/space)
@@ -4713,18 +4713,12 @@
 /turf/open/floor/plasteel,
 /area/awaymission/academy/academycellar)
 "mM" = (
-/obj/machinery/computer/teleporter,
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/awaymission/academy/academygate)
 "mN" = (
-/obj/machinery/teleport/station,
 /obj/structure/cable,
-/turf/open/floor/carpet,
-/area/awaymission/academy/academygate)
-"mO" = (
-/obj/machinery/teleport/hub,
-/obj/structure/cable,
+/obj/item/device/radio/beacon,
 /turf/open/floor/carpet,
 /area/awaymission/academy/academygate)
 "mP" = (
@@ -10497,7 +10491,7 @@ mj
 lM
 lM
 mk
-mO
+mM
 lM
 lM
 mX

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -177,7 +177,7 @@
 	description = "In the darkest times, we will find our way home."
 
 
-/*/datum/map_template/ruin/space/wizard_academy
+/datum/map_template/ruin/space/wizard_academy
 	id = "wizard-academy"
 	suffix = "Academy.dmm"
 	name = "Wizard Academy"
@@ -189,7 +189,6 @@
 		some doofus with an EVA suit and jetpack can just waltz around \
 		in space and find it..."
 
-*/
 
 /datum/map_template/ruin/space/hippie_shuttle
 	id = "hippie_shuttle"


### PR DESCRIPTION
but replaces the teleporter with a teleport beacon. The whole "hey, let's teleport 20 npc wizards to the station" thing is kinda shit, and letting people teleport to the wiz base just increases the chance that the wizard on board actually gets something to do. Do note that the NPCs still exist though, so it's gonna be a pain in the arse to get to the d20

🆑 
rscadd: The wizard academy exists again
/🆑 