### PR TITLE
Fire Axe Cabinet Improvements

### DIFF
--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -153,16 +153,19 @@
 		overlays += "glass_raised"
 
 /obj/structure/fireaxecabinet/proc/reset_lock(mob/user)
-	to_chat(user, "<span class = 'caution'>Resetting circuitry...</span>")
-	if(do_after(user, 20, target = src))
-		to_chat(user, "<span class='caution'>You [locked ? "disable" : "re-enable"] the locking modules.</span>")
-		toggle_lock(user)
+	if(!open)
+		to_chat(user, "<span class = 'caution'>Resetting circuitry...</span>")
+		if(do_after(user, 20, target = src))
+			to_chat(user, "<span class='caution'>You [locked ? "disable" : "re-enable"] the locking modules.</span>")
+			src.add_fingerprint(user)
+			toggle_lock(user)
 
 /obj/structure/fireaxecabinet/proc/toggle_lock(mob/user)
-	audible_message("You hear an audible clunk as the [name]'s bolt [locked ? "retracts" : "locks into place"].")
-	playsound(src, lock_sound, 50, 1)
-	locked = !locked
-	update_icon()
+	if(!open)
+		audible_message("You hear an audible clunk as the [name]'s bolt [locked ? "retracts" : "locks into place"].")
+		playsound(src, lock_sound, 50, 1)
+		locked = !locked
+		update_icon()
 
 /obj/structure/fireaxecabinet/verb/toggle_open()
 	set name = "Open/Close"

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -17,7 +17,11 @@
 /obj/structure/fireaxecabinet/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/wrench) && !(flags&NODECONSTRUCT) && !fireaxe && (open || health <= 0))
 		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
-		deconstruct()
+		if(do_after(user, 40/I.toolspeed, target = src))
+			to_chat(user, "<span class='notice'>You disassemble the [name].</span>")
+			var/obj/item/stack/sheet/metal/M = new (loc, 3)//spawn three metal for deconstruction
+			M.add_fingerprint(user)
+			deconstruct()
 	if(isrobot(user) || istype(I,/obj/item/device/multitool))
 		toggle_lock(user)
 		return
@@ -65,12 +69,6 @@
 		update_icon()
 		if(health <= 0)
 			playsound(src, 'sound/effects/Glassbr3.ogg', 100, 1)
-
-/obj/structure/fireaxecabinet/deconstruct()
-	// If we don't have the NODECONSTRUCT flag
-	if (!(flags & NODECONSTRUCT))
-		new /obj/item/stack/sheet/metal(loc,3)//produce 3 metal
-	..()
 
 
 /obj/structure/fireaxecabinet/ex_act(severity, target)

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -15,6 +15,9 @@
 	update_icon()
 
 /obj/structure/fireaxecabinet/attackby(obj/item/I, mob/user, params)
+	if(istype(I, /obj/item/weapon/wrench) && !(flags&NODECONSTRUCT) && !fireaxe && (open || health <= 0))
+		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+		deconstruct()
 	if(isrobot(user) || istype(I,/obj/item/device/multitool))
 		toggle_lock(user)
 		return
@@ -62,6 +65,12 @@
 		update_icon()
 		if(health <= 0)
 			playsound(src, 'sound/effects/Glassbr3.ogg', 100, 1)
+
+/obj/structure/fireaxecabinet/deconstruct()
+	// If we don't have the NODECONSTRUCT flag
+	if (!(flags & NODECONSTRUCT))
+		new /obj/item/stack/sheet/metal(loc,3)//produce 3 metal
+	..()
 
 
 /obj/structure/fireaxecabinet/ex_act(severity, target)

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -6,9 +6,10 @@
 	icon_state = "fireaxe"
 	anchored = 1
 	density = 0
+	req_access = list(access_atmospherics)
 	var/locked = 1
 	var/open = 0
-	var/health = 60
+	var/health = 100
 	var/open_sound = 'sound/machines/click.ogg'
 	var/close_sound = 'sound/machines/click.ogg'
 	var/deconstruct_sound = 'sound/items/Ratchet.ogg'
@@ -26,6 +27,7 @@
 			var/obj/item/stack/sheet/metal/M = new (loc, 3)//spawn three metal for deconstruction
 			M.add_fingerprint(user)
 			deconstruct()
+			return
 	if(isrobot(user) || istype(I,/obj/item/device/multitool))
 		reset_lock(user)
 		return
@@ -44,6 +46,12 @@
 			return
 		else if(health > 0)
 			toggle_open()
+			return
+	else if(I.GetID())
+		if (allowed(user))
+			toggle_lock()
+		else
+			to_chat(user, "<span class='danger'>Access denied.</span>")
 	else
 		return ..()
 
@@ -137,13 +145,13 @@
 		switch(health)
 			if(-INFINITY to 0)
 				overlays += "glass4"
-			if(1 to 20)
+			if(1 to 32)
 				overlays += "glass3"
-			if(21 to 40)
+			if(33 to 65)
 				overlays += "glass2"
-			if(41 to 59)
+			if(66 to 99)
 				overlays += "glass1"
-			if(60)
+			if(100)
 				overlays += "glass"
 		if(locked)
 			overlays += "locked"
@@ -155,7 +163,7 @@
 /obj/structure/fireaxecabinet/proc/reset_lock(mob/user)
 	if(!open)
 		to_chat(user, "<span class = 'caution'>Resetting circuitry...</span>")
-		if(do_after(user, 20, target = src))
+		if(do_after(user, 60, target = src))
 			to_chat(user, "<span class='caution'>You [locked ? "disable" : "re-enable"] the locking modules.</span>")
 			src.add_fingerprint(user)
 			toggle_lock(user)
@@ -163,7 +171,7 @@
 /obj/structure/fireaxecabinet/proc/toggle_lock(mob/user)
 	if(!open)
 		audible_message("You hear an audible clunk as the [name]'s bolt [locked ? "retracts" : "locks into place"].")
-		playsound(src, lock_sound, 50, 1)
+		playsound(loc, lock_sound, 30, 1, -3)
 		locked = !locked
 		update_icon()
 

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -9,6 +9,10 @@
 	var/locked = 1
 	var/open = 0
 	var/health = 60
+	var/open_sound = 'sound/machines/click.ogg'
+	var/close_sound = 'sound/machines/click.ogg'
+	var/deconstruct_sound = 'sound/items/Ratchet.ogg'
+	var/lock_sound = 'sound/machines/locktoggle.ogg'
 
 /obj/structure/fireaxecabinet/New()
 	..()
@@ -16,7 +20,7 @@
 
 /obj/structure/fireaxecabinet/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/wrench) && !(flags&NODECONSTRUCT) && !fireaxe && (open || health <= 0))
-		playsound(src.loc, 'sound/items/Ratchet.ogg', 50, 1)
+		playsound(src.loc, deconstruct_sound, 50, 1)
 		if(do_after(user, 40/I.toolspeed, target = src))
 			to_chat(user, "<span class='notice'>You disassemble the [name].</span>")
 			var/obj/item/stack/sheet/metal/M = new (loc, 3)//spawn three metal for deconstruction
@@ -101,16 +105,11 @@
 			fireaxe = null
 			to_chat(user, "<span class='caution'>You take the fire axe from the [name].</span>")
 			src.add_fingerprint(user)
-			add_logs(user, src, "has taken the fire axe from the [name].")
+			add_logs(user, src, "has taken fire axe from [name]")
 			update_icon()
 			return
-	if(locked)
-		user <<"<span class='warning'>The [name] won't budge!</span>"
-		return
-	else
-		open = !open
-		update_icon()
-		return
+	toggle_open()
+	return
 
 /obj/structure/fireaxecabinet/attack_paw(mob/living/user)
 	attack_hand(user)
@@ -161,7 +160,7 @@
 
 /obj/structure/fireaxecabinet/proc/toggle_lock(mob/user)
 	audible_message("You hear an audible clunk as the [name]'s bolt [locked ? "retracts" : "locks into place"].")
-	playsound(src, 'sound/machines/locktoggle.ogg', 50, 1)
+	playsound(src, lock_sound, 50, 1)
 	locked = !locked
 	update_icon()
 
@@ -174,6 +173,10 @@
 		usr <<"<span class='warning'>The [name] won't budge!</span>"
 		return
 	else
+		if(open)
+			playsound(loc, close_sound, 15, 1, -3)
+		else
+			playsound(loc, open_sound, 15, 1, -3)
 		open = !open
 		update_icon()
 		return

--- a/code/game/objects/structures/fireaxe.dm
+++ b/code/game/objects/structures/fireaxe.dm
@@ -23,7 +23,7 @@
 			M.add_fingerprint(user)
 			deconstruct()
 	if(isrobot(user) || istype(I,/obj/item/device/multitool))
-		toggle_lock(user)
+		reset_lock(user)
 		return
 	if(open || health <= 0)
 		if(istype(I, /obj/item/weapon/twohanded/fireaxe) && !fireaxe)
@@ -101,10 +101,11 @@
 			fireaxe = null
 			to_chat(user, "<span class='caution'>You take the fire axe from the [name].</span>")
 			src.add_fingerprint(user)
+			add_logs(user, src, "has taken the fire axe from the [name].")
 			update_icon()
 			return
 	if(locked)
-		user <<"<span class='warning'> The [name] won't budge!</span>"
+		user <<"<span class='warning'>The [name] won't budge!</span>"
 		return
 	else
 		open = !open
@@ -152,13 +153,17 @@
 	else
 		overlays += "glass_raised"
 
-/obj/structure/fireaxecabinet/proc/toggle_lock(mob/user)
-	to_chat(user, "<span class = 'caution'> Resetting circuitry...</span>")
-	playsound(src, 'sound/machines/locktoggle.ogg', 50, 1)
+/obj/structure/fireaxecabinet/proc/reset_lock(mob/user)
+	to_chat(user, "<span class = 'caution'>Resetting circuitry...</span>")
 	if(do_after(user, 20, target = src))
 		to_chat(user, "<span class='caution'>You [locked ? "disable" : "re-enable"] the locking modules.</span>")
-		locked = !locked
-		update_icon()
+		toggle_lock(user)
+
+/obj/structure/fireaxecabinet/proc/toggle_lock(mob/user)
+	audible_message("You hear an audible clunk as the [name]'s bolt [locked ? "retracts" : "locks into place"].")
+	playsound(src, 'sound/machines/locktoggle.ogg', 50, 1)
+	locked = !locked
+	update_icon()
 
 /obj/structure/fireaxecabinet/verb/toggle_open()
 	set name = "Open/Close"
@@ -166,7 +171,7 @@
 	set src in oview(1)
 
 	if(locked)
-		usr <<"<span class='warning'> The [name] won't budge!</span>"
+		usr <<"<span class='warning'>The [name] won't budge!</span>"
 		return
 	else
 		open = !open


### PR DESCRIPTION
### Fire Axe Cabinet Improvements

![fireaxe](https://user-images.githubusercontent.com/2159739/36022293-394ff104-0d4e-11e8-8c13-5bef6357dd8e.PNG)

The Fire Axe is a truly robust and powerful weapon, and as such the Cabinet that holds it should be equally as robust and well-built. 

As is only reasonable, I have made some slight modifications to improve the Fire Axe Cabinet:

- Cabinet can now be deconstructed, using a wrench. But only if it's open or broken, and the axe is removed. Useful for those who are rebuilding areas where the axe cabinet is.
- Cabinet can now be unlocked/locked using an ID card with Atmospherics access (includes CE & Cap obviously, and the Engineer, strangely enough)
- Old mechanic of "resetting the locking mechanism" has been moved into a separate action: it can still be performed with the multitool, but it takes longer than swiping an ID. Instead of the AI and borg performing the reset action, they now just simply unlock it with no wait time.
- Cabinet has been made marginally stronger to incentivize using an ID or hacking it with the multitool, and the hack time has been increased to incentivize using an ID to open it.
- Fingerprints are added to the metal when deconstructing, to the cabinet when the axe is removed, and to the cabinet when it's hacked or broken into.
- Log entry created when someone removes the fireaxe, to help track down those pesky griefers.
- Other minor bugfixes, such as removing the ability to lock/unlock it when it's already open with the multitool.

#### Testing

All of this has been tested fairly extensively. I tried every access permutation, and being a Borg, and an AI, along with trying to deconstruct it in various edge cases. It seems to perform correctly. The only thing I would like to add, possibly, in the future, is the ability for the emag to trigger the lock reset action, maybe throw a few sparks. But I won't be adding that to this Pull, most likely.

Thanks for reading, and happy axing!

#### Changelog

:cl:  
bugfix: Fire Axe Cabinet cannot be locked/unlocked when already open
bugfix: Fire Axe Cabinet use will result in fingerprints
tweak: Fire Axe Cabinet can be deconstructed with a wrench!
tweak: Fire Axe Cabinet made more robust: health increased, hack time increased
tweak: Fire Axe Cabinet can be unlocked/locked with an ID with Atmospherics access
soundadd: Fire Axe Cabinet will make locker open/close sound when opened/closed respectively
/:cl:
