### PR TITLE
Fixes drones causing AI's hijack objective to fail

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -319,6 +319,8 @@
 	for(var/mob/living/player in player_list)
 		if(istype(player, /mob/living/silicon))
 			continue
+		if(isdrone(player))
+			continue
 		if(player.mind)
 			if(player.stat != DEAD)
 				if(get_area(player) == A)


### PR DESCRIPTION
This prevents drones from causing the AI to fail its hijack objective if a drone is on the shuttle. Drones aren't organic, so they should not result in a fail.

Fixes #3113 

:cl:  
bugfix: fixed drones causing AI's hijack objective to fail
/:cl:
