### PR TITLE
Fix various syntactic problems

### DIFF
--- a/code/datums/wires/radio.dm
+++ b/code/datums/wires/radio.dm
@@ -1,6 +1,5 @@
 /datum/wires/radio
 	holder_type = /obj/item/device/radio
-	code/datums/wires/radio.dm
 
 /datum/wires/radio/New(atom/holder)
 	wires = list(

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -140,7 +140,7 @@ var/list/motion_alert_listeners = list()
 			for(var/obj/machinery/door/firedoor/D in RA)
 				if(!D.welded)
 					if(D.operating)
-						D.nextstate = CLOSED
+						D.nextstate = FD_CLOSED
 					else if(!D.density)
 						spawn(0)
 							D.close()

--- a/code/game/gamemodes/wizard/soulstone.dm
+++ b/code/game/gamemodes/wizard/soulstone.dm
@@ -146,7 +146,7 @@
 ////////////////////////////Proc for moving soul in and out off stone//////////////////////////////////////
 
 
-/obj/item/device/soulstone/proc/transfer_soul(choice as text, target, mob/user).
+/obj/item/device/soulstone/proc/transfer_soul(choice as text, target, mob/user)
 	switch(choice)
 		if("FORCE")
 			if(!iscarbon(target))		//TODO: Add sacrifice stoning for non-organics, just because you have no body doesnt mean you dont have a soul

--- a/code/game/machinery/doors/firedoor.dm
+++ b/code/game/machinery/doors/firedoor.dm
@@ -4,8 +4,8 @@
 #define CONSTRUCTION_GUTTED 3 //Wires are removed, circuit ready to remove
 #define CONSTRUCTION_NOCIRCUIT 4 //Circuit board removed, can safely weld apart
 
-/var/const/OPEN = 1
-/var/const/CLOSED = 2
+/var/const/FD_OPEN = 1
+/var/const/FD_CLOSED = 2
 
 /obj/machinery/door/firedoor
 	name = "firelock"
@@ -131,10 +131,10 @@
 	if(operating || stat & NOPOWER || !nextstate)
 		return
 	switch(nextstate)
-		if(OPEN)
+		if(FD_OPEN)
 			nextstate = null
 			open()
-		if(CLOSED)
+		if(FD_CLOSED)
 			nextstate = null
 			close()
 

--- a/code/game/objects/items/weapons/storage/storage.dm
+++ b/code/game/objects/items/weapons/storage/storage.dm
@@ -368,9 +368,9 @@
 	return 1
 
 
-/obj/item/weapon/storage/empty_object_contents(burn, src.loc)
+/obj/item/weapon/storage/empty_object_contents(burn, new_loc = src.loc)
 	for(var/obj/item/Item in contents)
-		remove_from_storage(Item, src.loc, burn)
+		remove_from_storage(Item, new_loc, burn)
 
 //This proc is called when you want to place an item into the storage item.
 /obj/item/weapon/storage/attackby(obj/item/W, mob/user, params)

--- a/code/modules/cargo/exports/seeds.dm
+++ b/code/modules/cargo/exports/seeds.dm
@@ -25,7 +25,7 @@
 	export_types = list(/obj/item/seeds)
 	needs_discovery = TRUE // Only for already discovered species
 
-/datum/export/seed/potency.get_cost(obj/O)
+/datum/export/seed/potency/get_cost(obj/O)
 	var/obj/item/seeds/S = O
 	var/cost = ..()
 	if(!cost)

--- a/code/modules/lighting/lighting_system.dm
+++ b/code/modules/lighting/lighting_system.dm
@@ -102,7 +102,7 @@
 		SSlighting.changed_lights |= src
 
 //Remove current effect
-/datum/light_source/proc/remove_effect().
+/datum/light_source/proc/remove_effect()
 	for(var/turf/T in effect)
 		T.update_lumcount(-effect[T])
 

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -80,7 +80,7 @@
 	picked = TRUE
 	languages_spoken = RATVAR
 	languages_understood = HUMAN|RATVAR
-	pass_flags = PASSTABLE || PASSMOB
+	pass_flags = PASSTABLE | PASSMOB
 	health = 70
 	maxHealth = 70
 	density = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs.dm
@@ -678,7 +678,7 @@
 	w_class = 3
 	layer = MOB_LAYER
 	origin_tech = "biotech=6"
-	var/list/banned_mobs()
+	var/list/banned_mobs
 
 /obj/item/asteroid/fugu_gland/afterattack(atom/target, mob/user, proximity_flag)
 	if(proximity_flag && istype(target, /mob/living/simple_animal))

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -48,7 +48,6 @@ var/global/list/rad_collectors = list()
 		else
 			to_chat(user, "<span class='warning'>The controls are locked!</span>")
 			return
-..()
 
 
 /obj/machinery/power/rad_collector/attackby(obj/item/W, mob/user, params)

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -199,7 +199,6 @@ Borg Shaker
 		to_chat(usr, "<span class='warning'>It is currently empty! Please allow some time for the synthesizer to produce more.</span>")
 
 /obj/item/weapon/reagent_containers/borghypo/borgshaker/hacked
-	..()
 	name = "cyborg shaker"
 	desc = "Will mix drinks that knock them dead."
 	icon = 'icons/obj/drinks.dmi'


### PR DESCRIPTION
Code cleanup necessary for MapDiffBot to work, see #3124.

Deletes or fixes nonsense code constructs that *just happen* to compile, because of course they do, but that the map renderer's backend doesn't yet understand.

Some other wacky code constructs were fixed on the parser side, so thanks for the stress-test.