### PR TITLE
Tearing up bedsheets in hands fixed

### DIFF
--- a/code/game/objects/structures/bedsheet_bin.dm
+++ b/code/game/objects/structures/bedsheet_bin.dm
@@ -38,10 +38,11 @@ LINEN BINS
 
 /obj/item/weapon/bedsheet/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/weapon/wirecutters) || I.is_sharp())
-		var/obj/item/stack/sheet/cloth/C = new (loc, 3)
+		var/obj/item/stack/sheet/cloth/C = new (get_turf(src), 3)
 		transfer_fingerprints_to(C)
 		C.add_fingerprint(user)
 		qdel(src)
+		user.put_in_hands(C)
 		to_chat(user, "<span class='notice'>You tear [src] up.</span>")
 	else
 		return ..()


### PR DESCRIPTION
Bedsheets will no longer disappear inside the player upon being torn up, and will automatically switch to their hands upon crafting.

This has been tested successfully in-game.

Fixes issue #2607 

Changelog

:cl:  
bugfix: bedsheets no longer disappear upon being torn up in player's hands
/:cl:
